### PR TITLE
Remove check for voxel_spacing's existance when creating segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ provided through an object-oriented API that abstracts away the underlying stora
 
 ## Documentation
 
-For more information, see the [documentation](https://uermel.github.io/copick/).
+For more information, see the [documentation](https://copick.github.io/copick/).
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,7 @@ provided through an object-oriented API that abstracts away the underlying stora
 
     Copick is released under the open source MIT license.
 
-    [:octicons-arrow-right-24: License](https://github.com/uermel/copick/blob/main/LICENSE)
+    [:octicons-arrow-right-24: License](https://github.com/copick/copick/blob/main/LICENSE)
 
 </div>
 

--- a/docs/snippets/cookiecutter.py
+++ b/docs/snippets/cookiecutter.py
@@ -17,7 +17,7 @@ dependencies:
   - trimesh
   - pip:
     - album
-    - "copick[all] @ git+https://github.com/uermel/copick.git@f78e7a6"
+    - "copick[all]>=0.5.2"
 """
 
 args = [

--- a/docs/snippets/solution_random_points.py
+++ b/docs/snippets/solution_random_points.py
@@ -17,7 +17,7 @@ dependencies:
   - trimesh
   - pip:
     - album
-    - "copick[all] @ git+https://github.com/uermel/copick.git@f78e7a6"
+    - "copick[all]>=0.5.2"
 """
 
 args = [

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -17,7 +17,7 @@ curation. The plugin is available in the ChimeraX Toolshed and can be installed 
 
 <div class="grid cards" markdown>
 
-- :fontawesome-solid-code: [__Repository__](https://github.com/uermel/chimerax-copick)
+- :fontawesome-solid-code: [__Repository__](https://github.com/copick/chimerax-copick)
 - :fontawesome-solid-circle-info: [__Tutorial__](examples/tutorials/chimerax.md)
 - :fontawesome-solid-globe: __Website__
 - :fontawesome-solid-question: __Docs__
@@ -98,7 +98,7 @@ points, manipulate meshes and more.
 
 <div class="grid cards" markdown>
 
-- :fontawesome-solid-code: [__Repository__](https://github.com/uermel/copick-catalog)
+- :fontawesome-solid-code: [__Repository__](https://github.com/copick/copick-catalog)
 - :fontawesome-solid-circle-info: __Tutorial__
 - :fontawesome-solid-globe: __Website__
 - :fontawesome-solid-question: __Docs__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 #dynamic = ["version"]
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
     "fsspec>=2024.6.0",
     "pydantic",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,10 @@ license = {file = "LICENSE"}
 keywords = ["cryoet", "cryo-et", "tomography", "annotation", "segmentation", "collaborative", "copick"]
 
 [project.urls]
-Repository = "https://github.com/uermel/copick.git"
-Issues = "https://github.com/uermel/copick/issues"
+Repository = "https://github.com/copick/copick.git"
+Issues = "https://github.com/copick/copick/issues"
+docs = "https://copick.github.io/copick/"
+documentation = "https://copick.github.io/copick/"
 
 [project.optional-dependencies]
 smb = ["smbprotocol"]

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -914,9 +914,6 @@ class CopickRun:
         if not is_multilabel and name not in [o.name for o in self.root.config.pickable_objects]:
             raise ValueError(f"Object name {name} not found in pickable objects.")
 
-        if voxel_size not in [vs.voxel_size for vs in self.voxel_spacings]:
-            raise ValueError(f"VoxelSpacing {voxel_size} not found in voxel spacings for run {self.name}.")
-
         uid = self.root.config.user_id
 
         if user_id is not None:

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -594,16 +594,6 @@ def test_run_new_segmentations(test_payload: Dict[str, Any]):
             is_multilabel=False,
         )
 
-    # Add segmentation with voxel_spacing that does not exist
-    with pytest.raises(ValueError):
-        copick_run.new_segmentation(
-            voxel_size=30.000,
-            user_id="cellcanvas",
-            session_id="0",
-            name="prediction",
-            is_multilabel=True,
-        )
-
     # Adding the first segmentation inits the _segmentations attribute as list of segmentations
     # For object stores we actually need to write to the zarr to create the "directory"
     seg4 = copick_run.new_segmentation(


### PR DESCRIPTION
Since the segmentations are no longer tied to a specific tomogram, checking if the voxel spacing exists is not necessary and prevents importing segmentations created on binned tomograms. 