### PR TITLE
Support querying against data portal annotation metadata to select picks/segmentation 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 #dynamic = ["version"]
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
     "fsspec>=2024.6.0",
-    "pydantic",
+    "pydantic>=2",
     "numpy",
     "trimesh",
     "zarr",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 #dynamic = ["version"]
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
     "fsspec>=2024.6.0",
     "pydantic>=2",

--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -662,6 +662,21 @@ class CopickRunCDP(CopickRunOverlay):
         portal_meta_query: Dict[str, Any] = None,
         portal_author_query: List[str] = None,
     ) -> List["CopickPicksCDP"]:
+        """Get picks by name, user_id or session_id (or combinations). Portal metadata are compared for equality. Portal
+        authors are checked for inclusion in the full author list.
+
+        Args:
+            object_name: Name of the object to search for.
+            user_id: User ID to search for.
+            session_id: Session ID to search for.
+            portal_meta_query: Dictionary of values to compare against portal metadata of this annotation. Allowed keys
+                are the scalar fields of [cryoet_data_portal.Annotation](https://chanzuckerberg.github.io/cryoet-data-portal/python-api.html#annotation)
+            portal_author_query: List of author names. Segmentations are included if this author is in the portal
+                annotation's author list.
+
+        Returns:
+            List[CopickPicks]: List of picks that match the search criteria.
+        """
         picks = super().get_picks(object_name, user_id, session_id)
 
         # Just return the regular output if no additional conditions
@@ -795,6 +810,24 @@ class CopickRunCDP(CopickRunOverlay):
         portal_meta_query: Dict[str, Any] = None,
         portal_author_query: List[str] = None,
     ) -> List["CopickSegmentationCDP"]:
+        """Get segmentations by user_id, session_id, name, type or voxel_size (or combinations) and portal metadata and
+        authors. Portal metadata are compared for equality. Portal authors are checked for inclusion in the full author
+        list.
+
+        Args:
+            user_id: User ID to search for.
+            session_id: Session ID to search for.
+            is_multilabel: Whether the segmentation is multilabel or not.
+            name: Name of the segmentation to search for.
+            voxel_size: Voxel size to search for.
+            portal_meta_query: Dictionary of values to compare against portal metadata of this annotation. Allowed keys
+                are the scalar fields of [cryoet_data_portal.Annotation](https://chanzuckerberg.github.io/cryoet-data-portal/python-api.html#annotation)
+            portal_author_query: List of author names. Segmentations are included if this author is in the portal
+                annotation's author list.
+
+        Returns:
+            List[CopickSegmentation]: List of segmentations that match the search criteria.
+        """
         segmentations = super().get_segmentations(user_id, session_id, is_multilabel, name, voxel_size)
 
         # Just return the regular output if no additional conditions

--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -53,7 +53,7 @@ def _portal_to_model(clz: _portal_types, name: str) -> Type[BaseModel]:
     return create_model(name, **scalars)
 
 
-_PortalAnnotation = _portal_to_model(cdp.Annotation, "PortalAnnotation")
+_PortalAnnotation = _portal_to_model(cdp.Annotation, "_PortalAnnotation")
 
 
 class PortalAnnotationMeta(BaseModel):

--- a/src/copick/impl/filesystem.py
+++ b/src/copick/impl/filesystem.py
@@ -45,7 +45,7 @@ class CopickConfigFSSpec(CopickConfig):
 
     config_type: str = "filesystem"
     overlay_root: str
-    static_root: Optional[str]
+    static_root: Optional[str] = None
 
     overlay_fs_args: Optional[Dict[str, Any]] = {}
     static_fs_args: Optional[Dict[str, Any]] = {}

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -4,16 +4,16 @@ from typing import Dict, List, Literal, MutableMapping, Optional, Tuple, Type, U
 import numpy as np
 
 # Should work with pydantic 1 and 2
-import pydantic
+# import pydantic
 import trimesh
 
-if pydantic.VERSION.startswith("1"):
-    from pydantic import BaseModel, validator
-elif pydantic.VERSION.startswith("2"):
-    from pydantic.v1 import BaseModel, validator
-else:
-    raise ImportError(f"Unsupported pydantic version {pydantic.VERSION}.")
-
+# if pydantic.VERSION.startswith("1"):
+#     from pydantic import BaseModel, validator
+# elif pydantic.VERSION.startswith("2"):
+#     from pydantic.v1 import BaseModel, validator
+# else:
+#     raise ImportError(f"Unsupported pydantic version {pydantic.VERSION}.")
+from pydantic import BaseModel, field_validator
 from trimesh.parent import Geometry
 
 
@@ -41,13 +41,13 @@ class PickableObject(BaseModel):
     map_threshold: Optional[float] = None
     radius: Optional[float] = None
 
-    @validator("label")
+    @field_validator("label")
     def validate_label(cls, v) -> int:
         """Validate the label."""
         assert v != 0, "Label 0 is reserved for background."
         return v
 
-    @validator("color")
+    @field_validator("color")
     def validate_color(cls, v) -> Tuple[int, int, int, int]:
         """Validate the color."""
         assert len(v) == 4, "Color must be a 4-tuple (RGBA)."
@@ -130,10 +130,11 @@ class CopickPoint(BaseModel):
     instance_id: Optional[int] = 0
     score: Optional[float] = 1.0
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = {
+        "arbitrary_types_allowed": True,
+    }
 
-    @validator("transformation_")
+    @field_validator("transformation_")
     def validate_transformation(cls, v) -> List[List[float]]:
         """Validate the transformation matrix."""
         arr = np.array(v)
@@ -1314,8 +1315,8 @@ class CopickPicksFile(BaseModel):
     pickable_object_name: str
     user_id: str
     session_id: Union[str, Literal["0"]]
-    run_name: Optional[str]
-    voxel_spacing: Optional[float]
+    run_name: Optional[str] = None
+    voxel_spacing: Optional[float] = None
     unit: str = "angstrom"
     points: Optional[List[CopickPoint]] = None
     trust_orientation: Optional[bool] = True

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -32,12 +32,14 @@ class PickableObject(BaseModel):
     radius: Optional[float] = None
 
     @field_validator("label")
+    @classmethod
     def validate_label(cls, v) -> int:
         """Validate the label."""
         assert v != 0, "Label 0 is reserved for background."
         return v
 
     @field_validator("color")
+    @classmethod
     def validate_color(cls, v) -> Tuple[int, int, int, int]:
         """Validate the color."""
         assert len(v) == 4, "Color must be a 4-tuple (RGBA)."
@@ -125,6 +127,7 @@ class CopickPoint(BaseModel):
     }
 
     @field_validator("transformation_")
+    @classmethod
     def validate_transformation(cls, v) -> List[List[float]]:
         """Validate the transformation matrix."""
         arr = np.array(v)

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -33,8 +33,8 @@ class PickableObject(BaseModel):
 
     name: str
     is_particle: bool
-    label: Optional[int]
-    color: Optional[Tuple[int, int, int, int]]
+    label: Optional[int] = 1
+    color: Optional[Tuple[int, int, int, int]] = (100, 100, 100, 255)
     emdb_id: Optional[str] = None
     pdb_id: Optional[str] = None
     go_id: Optional[str] = None

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -2,17 +2,7 @@ import json
 from typing import Dict, List, Literal, MutableMapping, Optional, Tuple, Type, Union
 
 import numpy as np
-
-# Should work with pydantic 1 and 2
-# import pydantic
 import trimesh
-
-# if pydantic.VERSION.startswith("1"):
-#     from pydantic import BaseModel, validator
-# elif pydantic.VERSION.startswith("2"):
-#     from pydantic.v1 import BaseModel, validator
-# else:
-#     raise ImportError(f"Unsupported pydantic version {pydantic.VERSION}.")
 from pydantic import BaseModel, field_validator
 from trimesh.parent import Geometry
 


### PR DESCRIPTION
Overrides `root.get_picks` and `root.get_segmentations` in order to allow querying against any scalar field of [cryoet_data_portal.Annotation](https://chanzuckerberg.github.io/cryoet-data-portal/python-api.html#annotation) and the list of author namees. 

The signature of `root.get_picks` changes to: 

```python 
    def get_picks(
        self,
        object_name: str = None,
        user_id: str = None,
        session_id: str = None,
        portal_meta_query: Dict[str, Any] = None,
        portal_author_query: List[str] = None,
    ) -> List["CopickPicksCDP"]:
        """Get picks by name, user_id or session_id (or combinations). Portal metadata are compared for equality. Portal
        authors are checked for inclusion in the full author list.

        Args:
            object_name: Name of the object to search for.
            user_id: User ID to search for.
            session_id: Session ID to search for.
            portal_meta_query: Dictionary of values to compare against portal metadata of this annotation. Allowed keys
                are the scalar fields of [cryoet_data_portal.Annotation](https://chanzuckerberg.github.io/cryoet-data-portal/python-api.html#annotation)
            portal_author_query: List of author names. Segmentations are included if this author is in the portal
                annotation's author list.

        Returns:
            List[CopickPicks]: List of picks that match the search criteria.
        """
```

The signature of `root.get_segmentations` changes to:

```python
    def get_segmentations(
        self,
        user_id: str = None,
        session_id: str = None,
        is_multilabel: bool = None,
        name: str = None,
        voxel_size: float = None,
        portal_meta_query: Dict[str, Any] = None,
        portal_author_query: List[str] = None,
    ) -> List["CopickSegmentationCDP"]:
        """Get segmentations by user_id, session_id, name, type or voxel_size (or combinations) and portal metadata and
        authors. Portal metadata are compared for equality. Portal authors are checked for inclusion in the full author
        list.

        Args:
            user_id: User ID to search for.
            session_id: Session ID to search for.
            is_multilabel: Whether the segmentation is multilabel or not.
            name: Name of the segmentation to search for.
            voxel_size: Voxel size to search for.
            portal_meta_query: Dictionary of values to compare against portal metadata of this annotation. Allowed keys
                are the scalar fields of [cryoet_data_portal.Annotation](https://chanzuckerberg.github.io/cryoet-data-portal/python-api.html#annotation)
            portal_author_query: List of author names. Segmentations are included if this author is in the portal
                annotation's author list.

        Returns:
            List[CopickSegmentation]: List of segmentations that match the search criteria.
        """
```