### PR TITLE
Adds convenience methods for storing numpy arrays as zarr. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,17 @@ classifiers = [
 #dynamic = ["version"]
 version = "0.5.4"
 dependencies = [
+    "click",
+    "cryoet-data-portal==3.0.3",
     "fsspec>=2024.6.0",
-    "pydantic>=2",
     "numpy",
+    "ome-zarr",
+    "psutil",
+    "pydantic>=2",
+    "s3fs",
+    "scikit-image",
     "trimesh",
     "zarr",
-    "cryoet-data-portal==3.0.3",
-    "s3fs",
-    "click",
 ]
 authors = [
   {name = "Utz H. Ermel", email = "utz.ermel@czii.org"},

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -1472,9 +1472,6 @@ class CopickFeatures:
             slices: Tuple of slices for the axes.
         """
         loc = self.zarr()
-        if loc.mode != "w":
-            raise ValueError("Zarr store is not writable.")
-
         zarr.open(loc)[zarr_group][slices] = data
 
 

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -7,6 +7,8 @@ import zarr
 from pydantic import BaseModel, field_validator
 from trimesh.parent import Geometry
 
+from copick.util.ome import fits_in_memory, segmentation_pyramid, volume_pyramid, write_ome_zarr_3d
+
 
 class PickableObject(BaseModel):
     """Metadata for a pickable objects.
@@ -262,7 +264,51 @@ class CopickObject:
         if loc is None:
             return None
 
-        return np.array(zarr.open(loc)[zarr_group][z, y, x])
+        group = zarr.open(loc)[zarr_group]
+
+        fits, req, avail = fits_in_memory(group, (x, y, z))
+        if not fits:
+            raise ValueError(f"Requested region does not fit in memory. Requested: {req}, Available: {avail}.")
+
+        return group[z, y, x]
+
+    def from_numpy(
+        self,
+        data: np.ndarray,
+        voxel_size: float,
+        dtype: Optional[np.dtype] = np.float32,
+    ) -> None:
+        """Set the object from a numpy array.
+
+        Args:
+            data: The segmentation as a numpy array.
+            voxel_size: Voxel size of the object.
+            dtype: Data type of the segmentation. Default is `np.float32`.
+        """
+        loc = self.zarr()
+
+        pyramid = volume_pyramid(data, voxel_size, 1, dtype=dtype)
+        write_ome_zarr_3d(loc, pyramid)
+
+    def set_region(
+        self,
+        data: np.ndarray,
+        zarr_group: str = "0",
+        x: slice = slice(None, None),
+        y: slice = slice(None, None),
+        z: slice = slice(None, None),
+    ) -> None:
+        """Set a region of the object from a numpy array.
+
+        Args:
+            data: The object's subregion as a numpy array.
+            zarr_group: Zarr group to access.
+            x: Slice for the x-axis.
+            y: Slice for the y-axis.
+            z: Slice for the z-axis.
+        """
+        loc = self.zarr()
+        zarr.open(loc)[zarr_group][z, y, x] = data
 
 
 class CopickRoot:
@@ -1287,7 +1333,51 @@ class CopickTomogram:
         """
 
         loc = self.zarr()
+        group = zarr.open(loc)[zarr_group]
+
+        fits, req, avail = fits_in_memory(group, (x, y, z))
+        if not fits:
+            raise ValueError(f"Requested region does not fit in memory. Requested: {req}, Available: {avail}.")
+
         return np.array(zarr.open(loc)[zarr_group][z, y, x])
+
+    def from_numpy(
+        self,
+        data: np.ndarray,
+        levels: int = 3,
+        dtype: Optional[np.dtype] = np.float32,
+    ) -> None:
+        """Set the tomogram from a numpy array and compute multiscale pyramid. By default, three levels of the pyramid
+        are computed.
+
+        Args:
+            data: The segmentation as a numpy array.
+            levels: Number of levels in the multiscale pyramid.
+            dtype: Data type of the segmentation. Default is `np.float32`.
+        """
+        loc = self.zarr()
+        pyramid = volume_pyramid(data, self.voxel_spacing.voxel_size, levels, dtype=dtype)
+        write_ome_zarr_3d(loc, pyramid)
+
+    def set_region(
+        self,
+        data: np.ndarray,
+        zarr_group: str = "0",
+        x: slice = slice(None, None),
+        y: slice = slice(None, None),
+        z: slice = slice(None, None),
+    ) -> None:
+        """Set a region of the tomogram from a numpy array.
+
+        Args:
+            data: The tomogram's subregion as a numpy array.
+            zarr_group: Zarr group to access.
+            x: Slice for the x-axis.
+            y: Slice for the y-axis.
+            z: Slice for the z-axis.
+        """
+        loc = self.zarr()
+        zarr.open(loc)[zarr_group][z, y, x] = data
 
 
 class CopickFeaturesMeta(BaseModel):
@@ -1356,11 +1446,36 @@ class CopickFeatures:
 
         loc = self.zarr()
         group = zarr.open(loc)[zarr_group]
+        ndim = len(group.shape)
 
         if slices is None:
-            return np.array(group)
-        else:
-            return np.array(group[slices])
+            slices = tuple(slice(None, None) for _ in range(ndim))
+
+        fits, req, avail = fits_in_memory(group, slices)
+        if not fits:
+            raise ValueError(f"Requested region does not fit in memory. Requested: {req}, Available: {avail}.")
+
+        return np.array(group[slices])
+
+    def set_region(
+        self,
+        data: np.ndarray,
+        zarr_group: str = "0",
+        slices: Tuple[slice, ...] = None,
+    ) -> None:
+        """Set the content of the Zarr-File for this feature map from a numpy array. Multiscale group and slices are
+        supported.
+
+        Args:
+            data: The data to set.
+            zarr_group: Zarr group to access.
+            slices: Tuple of slices for the axes.
+        """
+        loc = self.zarr()
+        if loc.mode != "w":
+            raise ValueError("Zarr store is not writable.")
+
+        zarr.open(loc)[zarr_group][slices] = data
 
 
 class CopickPicksFile(BaseModel):
@@ -1774,4 +1889,48 @@ class CopickSegmentation:
         """
 
         loc = self.zarr()
+        group = zarr.open(loc)[zarr_group]
+
+        fits, req, avail = fits_in_memory(group, (x, y, z))
+        if not fits:
+            raise ValueError(f"Requested region does not fit in memory. Requested: {req}, Available: {avail}.")
+
         return np.array(zarr.open(loc)[zarr_group][z, y, x])
+
+    def from_numpy(
+        self,
+        data: np.ndarray,
+        levels: int = 1,
+        dtype: Optional[np.dtype] = np.uint8,
+    ) -> None:
+        """Set the segmentation from a numpy array and compute multiscale pyramid. By default, no pyramid is computed
+        for segmentations.
+
+        Args:
+            data: The segmentation as a numpy array.
+            levels: Number of levels in the multiscale pyramid.
+            dtype: Data type of the segmentation. Default is `np.uint8`.
+        """
+        loc = self.zarr()
+        pyramid = segmentation_pyramid(data, self.voxel_size, levels, dtype=dtype)
+        write_ome_zarr_3d(loc, pyramid)
+
+    def set_region(
+        self,
+        data: np.ndarray,
+        zarr_group: str = "0",
+        x: slice = slice(None, None),
+        y: slice = slice(None, None),
+        z: slice = slice(None, None),
+    ) -> None:
+        """Set a region of the segmentation from a numpy array.
+
+        Args:
+            data: The segmentation's subregion as a numpy array.
+            zarr_group: Zarr group to access.
+            x: Slice for the x-axis.
+            y: Slice for the y-axis.
+            z: Slice for the z-axis.
+        """
+        loc = self.zarr()
+        zarr.open(loc)[zarr_group][z, y, x] = data

--- a/src/copick/util/ome.py
+++ b/src/copick/util/ome.py
@@ -27,8 +27,8 @@ def _ome_zarr_axes() -> List[Dict[str, str]]:
     ]
 
 
-def _ome_zarr_transforms(voxel_size: float) -> Dict[str, Any]:
-    return {"scale": [voxel_size, voxel_size, voxel_size], "type": "scale"}
+def _ome_zarr_transforms(voxel_size: float) -> List[Dict[str, Any]]:
+    return [{"scale": [voxel_size, voxel_size, voxel_size], "type": "scale"}]
 
 
 def volume_pyramid(
@@ -144,7 +144,7 @@ def fits_in_memory(array: zarr.Group, slices: Tuple[slice, ...]) -> Tuple[bool, 
 
     num_elem = []
     for dim, sl in zip(array.shape, slices):
-        num_elem.append(range(*sl.indices(dim)))
+        num_elem.append(len(range(*sl.indices(dim))))
 
     requested = np.prod(np.array(num_elem)) * array.itemsize
     available = psutil.virtual_memory().available

--- a/src/copick/util/ome.py
+++ b/src/copick/util/ome.py
@@ -37,6 +37,17 @@ def volume_pyramid(
     levels: int,
     dtype: np.dtype = np.float32,
 ) -> Dict[float, np.ndarray]:
+    """Create a volume pyramid by downscaling with interpolation, maintaining the local mean.
+
+    Args:
+        volume: The volume to downsample.
+        voxel_size: The voxel size of the input volume.
+        levels: The number of levels in the pyramid.
+        dtype: The data type of the output arrays.
+
+    Returns:
+        A dictionary containing the pyramid with the voxel size as the key.
+    """
     pyramid = {voxel_size: volume.astype(dtype)}
     vs = voxel_size
 
@@ -54,6 +65,17 @@ def segmentation_pyramid(
     levels: int,
     dtype: np.dtype = np.int8,
 ) -> Dict[float, np.ndarray]:
+    """Create an image pyramid by downsampling without interpolation.
+
+    Args:
+        segmentation: The segmentation to downsample.
+        voxel_size: The voxel size of the input segmentation.
+        levels: The number of levels in the pyramid.
+        dtype: The data type of the output arrays.
+
+    Returns:
+        A dictionary containing the pyramid with the voxel size as the key.
+    """
     pyramid = {voxel_size: segmentation.astype(dtype)}
     vs = voxel_size
 

--- a/src/copick/util/ome.py
+++ b/src/copick/util/ome.py
@@ -1,0 +1,131 @@
+from typing import Any, Dict, List, MutableMapping, Tuple
+
+import numpy as np
+import psutil
+import zarr
+from ome_zarr.writer import write_multiscale
+from skimage.transform import downscale_local_mean, rescale
+
+
+def _ome_zarr_axes() -> List[Dict[str, str]]:
+    return [
+        {
+            "name": "z",
+            "type": "space",
+            "unit": "angstrom",
+        },
+        {
+            "name": "y",
+            "type": "space",
+            "unit": "angstrom",
+        },
+        {
+            "name": "x",
+            "type": "space",
+            "unit": "angstrom",
+        },
+    ]
+
+
+def _ome_zarr_transforms(voxel_size: float) -> Dict[str, Any]:
+    return {"scale": [voxel_size, voxel_size, voxel_size], "type": "scale"}
+
+
+def volume_pyramid(
+    volume: np.ndarray,
+    voxel_size: float,
+    levels: int,
+    dtype: np.dtype = np.float32,
+) -> Dict[float, np.ndarray]:
+    pyramid = {voxel_size: volume.astype(dtype)}
+    vs = voxel_size
+
+    for _ in range(1, levels):
+        array = pyramid[vs]
+        vs *= 2
+        pyramid[vs] = downscale_local_mean(array, (2, 2, 2)).astype(dtype)
+
+    return pyramid
+
+
+def segmentation_pyramid(
+    segmentation: np.ndarray,
+    voxel_size: float,
+    levels: int,
+    dtype: np.dtype = np.int8,
+) -> Dict[float, np.ndarray]:
+    pyramid = {voxel_size: segmentation.astype(dtype)}
+    vs = voxel_size
+
+    for _ in range(1, levels):
+        array = pyramid[vs]
+        vs *= 2
+        pyramid[vs] = (
+            rescale(
+                array,
+                (1.0 / 2.0, 1.0 / 2.0, 1.0 / 2.0),
+                anti_aliasing=False,
+                preserve_range=True,
+                order=0,
+            ).astype(dtype),
+        )
+
+    return pyramid
+
+
+def ome_metadata(pyramid: Dict[float, np.ndarray]) -> Dict[str, Any]:
+    return {
+        "axes": _ome_zarr_axes(),
+        "transforms": [_ome_zarr_transforms(voxel_size) for voxel_size in pyramid],
+    }
+
+
+def write_ome_zarr_3d(
+    store: MutableMapping,
+    pyramid: Dict[float, np.ndarray],
+    chunk_size: Tuple[int, ...] = (256, 256, 256),
+) -> None:
+    """Write a 3D pyramid to an OME-Zarr store.
+
+    Args:
+        store: The store to write to.
+        pyramid: The pyramid to write.
+        chunk_size: The chunk size to use for the Zarr store. Default is (256, 256, 256).
+    """
+    ome_meta = ome_metadata(pyramid)
+    root_group = zarr.group(store=store, overwrite=True)
+
+    write_multiscale(
+        list(pyramid.values()),
+        group=root_group,
+        axes=ome_meta["axes"],
+        coordinate_transformations=ome_meta["transforms"],
+        storage_options=dict(chunks=chunk_size, overwrite=True),
+        compute=True,
+        metadata={},
+    )
+
+
+def fits_in_memory(array: zarr.Group, slices: Tuple[slice, ...]) -> Tuple[bool, int, int]:
+    """Check if the array fits in memory after slicing.
+
+    Args:
+        array: The Zarr array to check.
+        slices: The slices to apply to the array.
+
+    Returns:
+        A tuple containing:
+            - A boolean indicating if the array fits in memory.
+            - The number of bytes requested.
+            - The number of bytes available.
+    """
+
+    num_elem = []
+    for dim, sl in zip(array.shape, slices):
+        num_elem.append(range(*sl.indices(dim)))
+
+    requested = np.prod(np.array(num_elem)) * array.itemsize
+    available = psutil.virtual_memory().available
+    fits = requested < available
+
+    return fits, requested, available


### PR DESCRIPTION
Adds additional reqs: 
- scikit-image
- psutil

This adds two methods for tomograms, objects, and segmentations: 
- `from_numpy` - overwrites the entire volume and computes multiscale on demand
- `set_region` - sets specfic subregions of the zarr from a numpy array

Also adds one method for features
- `set_region` - sets specfic subregions of the zarr from a numpy array

because the shape of feature maps is less defined no method is provided that would store multiscale information (@kephale I guess we could add one that at least creates proper OME-metadata for arbitrary arrays at one scale)

Also implements memory-size checks for all `numpy()`-methods implemented by #43.

closes #36 