### PR TITLE
Fix finding symlinked runs when using SSHFS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 #dynamic = ["version"]
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
     "fsspec>=2024.6.0",
     "pydantic>=2",

--- a/src/copick/impl/filesystem.py
+++ b/src/copick/impl/filesystem.py
@@ -887,6 +887,7 @@ class CopickRootFSSpec(CopickRoot):
             for p, details in paths.items()
             if (details.get("type", "") == "directory")
             or (details.get("type", "") == "other" and details.get("islink", False))
+            or (details.get("type", "") == "link")
         ]
 
         # Remove any hidden files


### PR DESCRIPTION
sshfs uses 

```
{'size': 74,
  'type': 'link',
  'gid': 25018,
  'uid': 5502,
  'time': datetime.datetime(2024, 5, 28, 18, 34, 45),
  'mtime': datetime.datetime(2024, 5, 28, 18, 34, 45),
  'permissions': 41471,
  'name': '...'
},
```

for links, which differs from localFS

```
{'size': 74,
  'type': 'other',
  'islink': True,
  'gid': 25018,
  'uid': 5502,
  'time': datetime.datetime(2024, 5, 28, 18, 34, 45),
  'mtime': datetime.datetime(2024, 5, 28, 18, 34, 45),
  'permissions': 41471,
  'name': '...'
},
```

This PR adds an additional test for that. 