### PR TITLE
Fix tests for SMB

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,16 +40,16 @@ docs = "https://copick.github.io/copick/"
 documentation = "https://copick.github.io/copick/"
 
 [project.optional-dependencies]
-smb = ["smbprotocol==1.13.0"]
+smb = ["smbprotocol"]
 ssh = ["sshfs>=2024.6.0"]
-all = ["smbprotocol==1.13.0", "sshfs>=2024.6.0"]
-fledgeling = ["pooch", "smbprotocol==1.13.0", "sshfs>=2024.6.0"]
+all = ["smbprotocol", "sshfs>=2024.6.0"]
+fledgeling = ["pooch", "smbprotocol", "sshfs>=2024.6.0"]
 test = [
     "pytest",
     "pytest-cov",
     "pooch",
     "sshfs>=2024.6.0",
-    "smbprotocol==1.13.0",
+    "smbprotocol",
 ]
 dev = [
     "black",
@@ -137,7 +137,7 @@ test = "pytest {args:tests}"
 
 [tool.hatch.envs.test_extended]
 dependencies = [
-  "pytest", "pooch", "sshfs>=2024.6.0", "smbprotocol==1.13.0"
+  "pytest", "pooch", "sshfs>=2024.6.0", "smbprotocol"
 ]
 
 [tool.hatch.envs.test_extended.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,16 +40,16 @@ docs = "https://copick.github.io/copick/"
 documentation = "https://copick.github.io/copick/"
 
 [project.optional-dependencies]
-smb = ["smbprotocol"]
+smb = ["smbprotocol==1.13.0"]
 ssh = ["sshfs>=2024.6.0"]
-all = ["smbprotocol", "sshfs>=2024.6.0"]
-fledgeling = ["pooch", "smbprotocol", "sshfs>=2024.6.0"]
+all = ["smbprotocol==1.13.0", "sshfs>=2024.6.0"]
+fledgeling = ["pooch", "smbprotocol==1.13.0", "sshfs>=2024.6.0"]
 test = [
     "pytest",
     "pytest-cov",
     "pooch",
     "sshfs>=2024.6.0",
-    "smbprotocol",
+    "smbprotocol==1.13.0",
 ]
 dev = [
     "black",
@@ -137,7 +137,7 @@ test = "pytest {args:tests}"
 
 [tool.hatch.envs.test_extended]
 dependencies = [
-  "pytest", "pooch", "sshfs>=2024.6.0", "smbprotocol"
+  "pytest", "pooch", "sshfs>=2024.6.0", "smbprotocol==1.13.0"
 ]
 
 [tool.hatch.envs.test_extended.scripts]

--- a/tests/seed_smb.sh
+++ b/tests/seed_smb.sh
@@ -8,4 +8,4 @@ cp -R $1 tests/bin/smb/$2
 chmod -R 775 tests/bin/smb/$2
 # Need to grant ownership to smbuser:smb for some tests to work (permission issues), otherwise owned by root if copied
 # from host
-docker-compose -f ./tests/docker-compose.yml --profile smb exec -T smb-server sh -c "chown -R smbuser:smb /share/data/$2"
+docker compose -f ./tests/docker-compose.yml --profile smb exec -T smb-server sh -c "chown -R smbuser:smb /share/data/$2"


### PR DESCRIPTION
Switches the set up command for SMB tests from `docker-compose` (deprecated API) to `docker compose`.