### PR TITLE
Remove "factory" methods, use class attributes instead

### DIFF
--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -39,14 +39,14 @@ from copick.models import (
 )
 
 if TYPE_CHECKING:
-    RunTypes = Tuple[Type["CopickRunCDP"], Type["CopickRunMetaCDP"]]
-    ObjectTypes = Tuple[Type["CopickObjectCDP"], Type[PickableObject]]
-    VoxelSpacingTypes = Tuple[Type["CopickVoxelSpacingCDP"], Type["CopickVoxelSpacingMetaCDP"]]
-    PicksTypes = Tuple[Type["CopickPicksCDP"], Type["CopickPicksFileCDP"]]
-    MeshTypes = Tuple[Type["CopickMeshCDP"], Type[CopickMeshMeta]]
-    SegmentationTypes = Tuple[Type["CopickSegmentationCDP"], Type["CopickSegmentationMetaCDP"]]
-    TomogramTypes = Tuple[Type["CopickTomogramCDP"], Type["CopickTomogramMetaCDP"]]
-    FeaturesTypes = Tuple[Type["CopickFeaturesCDP"], Type[CopickFeaturesMeta]]
+    RunClz = Tuple[Type["CopickRunCDP"], Type["CopickRunMetaCDP"]]
+    ObjectClz = Tuple[Type["CopickObjectCDP"], Type[PickableObject]]
+    VoxelSpacingClz = Tuple[Type["CopickVoxelSpacingCDP"], Type["CopickVoxelSpacingMetaCDP"]]
+    PicksClz = Tuple[Type["CopickPicksCDP"], Type["CopickPicksFileCDP"]]
+    MeshClz = Tuple[Type["CopickMeshCDP"], Type[CopickMeshMeta]]
+    SegmenationClz = Tuple[Type["CopickSegmentationCDP"], Type["CopickSegmentationMetaCDP"]]
+    TomogramClz = Tuple[Type["CopickTomogramCDP"], Type["CopickTomogramMetaCDP"]]
+    FeaturesClz = Tuple[Type["CopickFeaturesCDP"], Type[CopickFeaturesMeta]]
 
 
 def camel(s: str) -> str:
@@ -375,18 +375,18 @@ class CopickTomogramMetaCDP(CopickTomogramMeta):
 
 
 class CopickTomogramCDP(CopickTomogramOverlay):
-    features_types: "FeaturesTypes" = ("CopickFeaturesCDP", "CopickFeaturesMeta")
+    features_clz: "FeaturesClz" = ("CopickFeaturesCDP", "CopickFeaturesMeta")
 
     voxel_spacing: "CopickVoxelSpacingCDP"
     meta: CopickTomogramMetaCDP
 
     def _feature_factory(self) -> Tuple[Type[CopickFeaturesCDP], Type["CopickFeaturesMeta"]]:
         warnings.warn(
-            "_feature_factory is deprecated, use CopickTomogramCDP.features_types class attribute instead.",
+            "_feature_factory is deprecated, use CopickTomogramCDP.features_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.features_types
+        return self.features_clz
 
     @property
     def static_path(self) -> str:
@@ -421,7 +421,7 @@ class CopickTomogramCDP(CopickTomogramOverlay):
         feature_types = [ft for ft in feature_types if not ft.startswith(".")]
 
         feature_types = list(set(feature_types))
-        clz, meta_clz = self.features_types
+        clz, meta_clz = self.features_clz
 
         return [
             clz(
@@ -466,18 +466,18 @@ class CopickVoxelSpacingMetaCDP(CopickVoxelSpacingMeta):
 
 
 class CopickVoxelSpacingCDP(CopickVoxelSpacingOverlay):
-    tomogram_types: "TomogramTypes" = ("CopickTomogramCDP", "CopickTomogramMetaCDP")
+    tomogram_clz: "TomogramClz" = ("CopickTomogramCDP", "CopickTomogramMetaCDP")
 
     run: "CopickRunCDP"
     meta: CopickVoxelSpacingMetaCDP
 
     def _tomogram_factory(self) -> Tuple[Type[CopickTomogramCDP], Type[CopickTomogramMetaCDP]]:
         warnings.warn(
-            "_tomogram_factory is deprecated, use CopickVoxelSpacingCDP.tomogram_types class attribute instead.",
+            "_tomogram_factory is deprecated, use CopickVoxelSpacingCDP.tomogram_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.tomogram_types
+        return self.tomogram_clz
 
     @property
     def overlay_path(self):
@@ -497,7 +497,7 @@ class CopickVoxelSpacingCDP(CopickVoxelSpacingOverlay):
 
         client = cdp.Client()
         portal_tomos = cdp.Tomogram.find(client, [cdp.Tomogram.tomogram_voxel_spacing_id == self.portal_vs_id])  # noqa
-        clz, meta_clz = self.tomogram_types
+        clz, meta_clz = self.tomogram_clz
         tomos = []
 
         for t in portal_tomos:
@@ -517,7 +517,7 @@ class CopickVoxelSpacingCDP(CopickVoxelSpacingOverlay):
         tomo_types = [tt for tt in tomo_types if not tt.startswith(".")]
 
         tomo_types = list(set(tomo_types))
-        clz, meta_clz = self.tomogram_types
+        clz, meta_clz = self.tomogram_clz
 
         return [
             clz(
@@ -570,45 +570,45 @@ class CopickRunMetaCDP(CopickRunMeta):
 
 
 class CopickRunCDP(CopickRunOverlay):
-    voxel_spacing_types: "VoxelSpacingTypes" = ("CopickVoxelSpacingCDP", "CopickVoxelSpacingMetaCDP")
-    picks_types: "PicksTypes" = ("CopickPicksCDP", "CopickPicksFileCDP")
-    mesh_types: "MeshTypes" = ("CopickMeshCDP", CopickMeshMeta)
-    segmentation_types: "SegmentationTypes" = ("CopickSegmentationCDP", "CopickSegmentationMetaCDP")
+    voxel_spacing_clz: "VoxelSpacingClz" = ("CopickVoxelSpacingCDP", "CopickVoxelSpacingMetaCDP")
+    picks_clz: "PicksClz" = ("CopickPicksCDP", "CopickPicksFileCDP")
+    mesh_clz: "MeshClz" = ("CopickMeshCDP", CopickMeshMeta)
+    segmentation_clz: "SegmenationClz" = ("CopickSegmentationCDP", "CopickSegmentationMetaCDP")
 
     root: "CopickRootCDP"
     meta: CopickRunMetaCDP
 
     def _voxel_spacing_factory(self) -> Tuple[Type[CopickVoxelSpacingCDP], Type[CopickVoxelSpacingMetaCDP]]:
         warnings.warn(
-            "_voxel_spacing_factory is deprecated, use CopickRunCDP.voxel_spacing_types class attribute instead.",
+            "_voxel_spacing_factory is deprecated, use CopickRunCDP.voxel_spacing_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.voxel_spacing_types
+        return self.voxel_spacing_clz
 
     def _picks_factory(self) -> Type[CopickPicksCDP]:
         warnings.warn(
-            "_picks_factory is deprecated, use CopickRunCDP.picks_types class attribute instead.",
+            "_picks_factory is deprecated, use CopickRunCDP.picks_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.picks_types[0]
+        return self.picks_clz[0]
 
     def _mesh_factory(self) -> Tuple[Type[CopickMeshCDP], Type[CopickMeshMeta]]:
         warnings.warn(
-            "_mesh_factory is deprecated, use CopickRunCDP.mesh_types class attribute instead.",
+            "_mesh_factory is deprecated, use CopickRunCDP.mesh_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.mesh_types
+        return self.mesh_clz
 
     def _segmentation_factory(self) -> Tuple[Type[CopickSegmentationCDP], Type[CopickSegmentationMetaCDP]]:
         warnings.warn(
-            "_segmentation_factory is deprecated, use CopickRunCDP.segmentation_types class attribute instead.",
+            "_segmentation_factory is deprecated, use CopickRunCDP.segmentation_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.segmentation_types
+        return self.segmentation_clz
 
     @property
     def overlay_path(self) -> str:
@@ -634,7 +634,7 @@ class CopickRunCDP(CopickRunOverlay):
         )
 
         # portal_vs = self.portal_run.tomogram_voxel_spacings
-        clz, meta_clz = self.voxel_spacing_types
+        clz, meta_clz = self.voxel_spacing_clz
 
         return [clz(meta=meta_clz.from_portal(vs), run=self) for vs in portal_vs]
 
@@ -644,7 +644,7 @@ class CopickRunCDP(CopickRunOverlay):
         opaths = [p.rstrip("/") for p in opaths]
         spacings = [float(p.replace(f"{overlay_vs_loc}", "")) for p in opaths]
 
-        clz, meta_clz = self.voxel_spacing_types
+        clz, meta_clz = self.voxel_spacing_clz
 
         return [
             clz(
@@ -761,7 +761,7 @@ class CopickRunCDP(CopickRunOverlay):
         sessions = [n.split("_")[1] for n in names]
         objects = [n.split("_")[2] for n in names]
 
-        clz, meta_clz = self.mesh_types
+        clz, meta_clz = self.mesh_clz
 
         return [
             clz(
@@ -794,7 +794,7 @@ class CopickRunCDP(CopickRunOverlay):
         )
 
         segmentations = []
-        clz, meta_clz = self.segmentation_types
+        clz, meta_clz = self.segmentation_clz
 
         for af in seg_annos:
             seg_meta = meta_clz.from_portal(af, name=go_map[af.annotation.object_id])
@@ -816,7 +816,7 @@ class CopickRunCDP(CopickRunOverlay):
 
         # multilabel vs single label
         metas = []
-        clz, meta_clz = self.segmentation_types
+        clz, meta_clz = self.segmentation_clz
         for n in names:
             if "multilabel" in n:
                 parts = n.split("_")
@@ -971,8 +971,8 @@ class CopickObjectCDP(CopickObjectOverlay):
 
 
 class CopickRootCDP(CopickRoot):
-    run_types: "RunTypes" = ("CopickRunCDP", "CopickRunMetaCDP")
-    object_types: "ObjectTypes" = ("CopickObjectCDP", PickableObject)
+    run_clz: "RunClz" = ("CopickRunCDP", "CopickRunMetaCDP")
+    object_clz: "ObjectClz" = ("CopickObjectCDP", PickableObject)
 
     config: CopickConfigCDP
 
@@ -998,19 +998,19 @@ class CopickRootCDP(CopickRoot):
 
     def _run_factory(self) -> Tuple[Type[CopickRunCDP], Type[CopickRunMetaCDP]]:
         warnings.warn(
-            "_run_factory is deprecated, use CopickRootCDP.run_types class attribute instead.",
+            "_run_factory is deprecated, use CopickRootCDP.run_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.run_types
+        return self.run_clz
 
     def _object_factory(self) -> Tuple[Type[CopickObjectCDP], Type[PickableObject]]:
         warnings.warn(
-            "_object_factory is deprecated, use CopickRootCDP.object_types class attribute instead.",
+            "_object_factory is deprecated, use CopickRootCDP.object_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.object_types
+        return self.object_clz
 
     def query(self) -> List[CopickRunCDP]:
         client = cdp.Client()

--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -1,6 +1,7 @@
 import json
 import re
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+import warnings
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 import cryoet_data_portal as cdp
 import fsspec
@@ -36,6 +37,16 @@ from copick.models import (
     CopickVoxelSpacingMeta,
     PickableObject,
 )
+
+if TYPE_CHECKING:
+    RunTypes = Tuple[Type["CopickRunCDP"], Type["CopickRunMetaCDP"]]
+    ObjectTypes = Tuple[Type["CopickObjectCDP"], Type[PickableObject]]
+    VoxelSpacingTypes = Tuple[Type["CopickVoxelSpacingCDP"], Type["CopickVoxelSpacingMetaCDP"]]
+    PicksTypes = Tuple[Type["CopickPicksCDP"], Type["CopickPicksFileCDP"]]
+    MeshTypes = Tuple[Type["CopickMeshCDP"], Type[CopickMeshMeta]]
+    SegmentationTypes = Tuple[Type["CopickSegmentationCDP"], Type["CopickSegmentationMetaCDP"]]
+    TomogramTypes = Tuple[Type["CopickTomogramCDP"], Type["CopickTomogramMetaCDP"]]
+    FeaturesTypes = Tuple[Type["CopickFeaturesCDP"], Type[CopickFeaturesMeta]]
 
 
 def camel(s: str) -> str:
@@ -364,11 +375,18 @@ class CopickTomogramMetaCDP(CopickTomogramMeta):
 
 
 class CopickTomogramCDP(CopickTomogramOverlay):
+    features_types: FeaturesTypes = ("CopickFeaturesCDP", "CopickFeaturesMeta")
+
     voxel_spacing: "CopickVoxelSpacingCDP"
     meta: CopickTomogramMetaCDP
 
     def _feature_factory(self) -> Tuple[Type[CopickFeaturesCDP], Type["CopickFeaturesMeta"]]:
-        return CopickFeaturesCDP, CopickFeaturesMeta
+        warnings.warn(
+            "_feature_factory is deprecated, use CopickTomogramCDP.features_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.features_types
 
     @property
     def static_path(self) -> str:
@@ -403,7 +421,7 @@ class CopickTomogramCDP(CopickTomogramOverlay):
         feature_types = [ft for ft in feature_types if not ft.startswith(".")]
 
         feature_types = list(set(feature_types))
-        clz, meta_clz = self._feature_factory()
+        clz, meta_clz = self.features_types
 
         return [
             clz(
@@ -448,11 +466,18 @@ class CopickVoxelSpacingMetaCDP(CopickVoxelSpacingMeta):
 
 
 class CopickVoxelSpacingCDP(CopickVoxelSpacingOverlay):
+    tomogram_types: TomogramTypes = ("CopickTomogramCDP", "CopickTomogramMetaCDP")
+
     run: "CopickRunCDP"
     meta: CopickVoxelSpacingMetaCDP
 
     def _tomogram_factory(self) -> Tuple[Type[CopickTomogramCDP], Type[CopickTomogramMetaCDP]]:
-        return CopickTomogramCDP, CopickTomogramMetaCDP
+        warnings.warn(
+            "_tomogram_factory is deprecated, use CopickVoxelSpacingCDP.tomogram_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.tomogram_types
 
     @property
     def overlay_path(self):
@@ -472,7 +497,7 @@ class CopickVoxelSpacingCDP(CopickVoxelSpacingOverlay):
 
         client = cdp.Client()
         portal_tomos = cdp.Tomogram.find(client, [cdp.Tomogram.tomogram_voxel_spacing_id == self.portal_vs_id])  # noqa
-        clz, meta_clz = self._tomogram_factory()
+        clz, meta_clz = self.tomogram_types
         tomos = []
 
         for t in portal_tomos:
@@ -492,7 +517,7 @@ class CopickVoxelSpacingCDP(CopickVoxelSpacingOverlay):
         tomo_types = [tt for tt in tomo_types if not tt.startswith(".")]
 
         tomo_types = list(set(tomo_types))
-        clz, meta_clz = self._tomogram_factory()
+        clz, meta_clz = self.tomogram_types
 
         return [
             clz(
@@ -545,20 +570,45 @@ class CopickRunMetaCDP(CopickRunMeta):
 
 
 class CopickRunCDP(CopickRunOverlay):
+    voxel_spacing_types: VoxelSpacingTypes = ("CopickVoxelSpacingCDP", "CopickVoxelSpacingMetaCDP")
+    picks_types: PicksTypes = ("CopickPicksCDP", "CopickPicksFileCDP")
+    mesh_types: MeshTypes = ("CopickMeshCDP", CopickMeshMeta)
+    segmentation_types: SegmentationTypes = ("CopickSegmentationCDP", "CopickSegmentationMetaCDP")
+
     root: "CopickRootCDP"
     meta: CopickRunMetaCDP
 
     def _voxel_spacing_factory(self) -> Tuple[Type[CopickVoxelSpacingCDP], Type[CopickVoxelSpacingMetaCDP]]:
-        return CopickVoxelSpacingCDP, CopickVoxelSpacingMetaCDP
+        warnings.warn(
+            "_voxel_spacing_factory is deprecated, use CopickRunCDP.voxel_spacing_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.voxel_spacing_types
 
     def _picks_factory(self) -> Type[CopickPicksCDP]:
-        return CopickPicksCDP
+        warnings.warn(
+            "_picks_factory is deprecated, use CopickRunCDP.picks_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.picks_types[0]
 
     def _mesh_factory(self) -> Tuple[Type[CopickMeshCDP], Type[CopickMeshMeta]]:
-        return CopickMeshCDP, CopickMeshMeta
+        warnings.warn(
+            "_mesh_factory is deprecated, use CopickRunCDP.mesh_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.mesh_types
 
     def _segmentation_factory(self) -> Tuple[Type[CopickSegmentationCDP], Type[CopickSegmentationMetaCDP]]:
-        return CopickSegmentationCDP, CopickSegmentationMetaCDP
+        warnings.warn(
+            "_segmentation_factory is deprecated, use CopickRunCDP.segmentation_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.segmentation_types
 
     @property
     def overlay_path(self) -> str:
@@ -584,7 +634,7 @@ class CopickRunCDP(CopickRunOverlay):
         )
 
         # portal_vs = self.portal_run.tomogram_voxel_spacings
-        clz, meta_clz = self._voxel_spacing_factory()
+        clz, meta_clz = self.voxel_spacing_types
 
         return [clz(meta=meta_clz.from_portal(vs), run=self) for vs in portal_vs]
 
@@ -594,7 +644,7 @@ class CopickRunCDP(CopickRunOverlay):
         opaths = [p.rstrip("/") for p in opaths]
         spacings = [float(p.replace(f"{overlay_vs_loc}", "")) for p in opaths]
 
-        clz, meta_clz = self._voxel_spacing_factory()
+        clz, meta_clz = self.voxel_spacing_types
 
         return [
             clz(
@@ -711,7 +761,7 @@ class CopickRunCDP(CopickRunOverlay):
         sessions = [n.split("_")[1] for n in names]
         objects = [n.split("_")[2] for n in names]
 
-        clz, meta_clz = self._mesh_factory()
+        clz, meta_clz = self.mesh_types
 
         return [
             clz(
@@ -744,7 +794,7 @@ class CopickRunCDP(CopickRunOverlay):
         )
 
         segmentations = []
-        clz, meta_clz = self._segmentation_factory()
+        clz, meta_clz = self.segmentation_types
 
         for af in seg_annos:
             seg_meta = meta_clz.from_portal(af, name=go_map[af.annotation.object_id])
@@ -766,7 +816,7 @@ class CopickRunCDP(CopickRunOverlay):
 
         # multilabel vs single label
         metas = []
-        clz, meta_clz = self._segmentation_factory()
+        clz, meta_clz = self.segmentation_types
         for n in names:
             if "multilabel" in n:
                 parts = n.split("_")
@@ -921,6 +971,9 @@ class CopickObjectCDP(CopickObjectOverlay):
 
 
 class CopickRootCDP(CopickRoot):
+    run_types: RunTypes = ("CopickRunCDP", "CopickRunMetaCDP")
+    object_types: ObjectTypes = ("CopickObjectCDP", PickableObject)
+
     config: CopickConfigCDP
 
     def __init__(self, config: CopickConfigCDP):
@@ -944,10 +997,20 @@ class CopickRootCDP(CopickRoot):
         return cls(CopickConfigCDP(**data))
 
     def _run_factory(self) -> Tuple[Type[CopickRunCDP], Type[CopickRunMetaCDP]]:
-        return CopickRunCDP, CopickRunMetaCDP
+        warnings.warn(
+            "_run_factory is deprecated, use CopickRootCDP.run_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.run_types
 
     def _object_factory(self) -> Tuple[Type[CopickObjectCDP], Type[PickableObject]]:
-        return CopickObjectCDP, PickableObject
+        warnings.warn(
+            "_object_factory is deprecated, use CopickRootCDP.object_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.object_types
 
     def query(self) -> List[CopickRunCDP]:
         client = cdp.Client()

--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -375,7 +375,7 @@ class CopickTomogramMetaCDP(CopickTomogramMeta):
 
 
 class CopickTomogramCDP(CopickTomogramOverlay):
-    features_types: FeaturesTypes = ("CopickFeaturesCDP", "CopickFeaturesMeta")
+    features_types: "FeaturesTypes" = ("CopickFeaturesCDP", "CopickFeaturesMeta")
 
     voxel_spacing: "CopickVoxelSpacingCDP"
     meta: CopickTomogramMetaCDP
@@ -466,7 +466,7 @@ class CopickVoxelSpacingMetaCDP(CopickVoxelSpacingMeta):
 
 
 class CopickVoxelSpacingCDP(CopickVoxelSpacingOverlay):
-    tomogram_types: TomogramTypes = ("CopickTomogramCDP", "CopickTomogramMetaCDP")
+    tomogram_types: "TomogramTypes" = ("CopickTomogramCDP", "CopickTomogramMetaCDP")
 
     run: "CopickRunCDP"
     meta: CopickVoxelSpacingMetaCDP
@@ -570,10 +570,10 @@ class CopickRunMetaCDP(CopickRunMeta):
 
 
 class CopickRunCDP(CopickRunOverlay):
-    voxel_spacing_types: VoxelSpacingTypes = ("CopickVoxelSpacingCDP", "CopickVoxelSpacingMetaCDP")
-    picks_types: PicksTypes = ("CopickPicksCDP", "CopickPicksFileCDP")
-    mesh_types: MeshTypes = ("CopickMeshCDP", CopickMeshMeta)
-    segmentation_types: SegmentationTypes = ("CopickSegmentationCDP", "CopickSegmentationMetaCDP")
+    voxel_spacing_types: "VoxelSpacingTypes" = ("CopickVoxelSpacingCDP", "CopickVoxelSpacingMetaCDP")
+    picks_types: "PicksTypes" = ("CopickPicksCDP", "CopickPicksFileCDP")
+    mesh_types: "MeshTypes" = ("CopickMeshCDP", CopickMeshMeta)
+    segmentation_types: "SegmentationTypes" = ("CopickSegmentationCDP", "CopickSegmentationMetaCDP")
 
     root: "CopickRootCDP"
     meta: CopickRunMetaCDP
@@ -971,8 +971,8 @@ class CopickObjectCDP(CopickObjectOverlay):
 
 
 class CopickRootCDP(CopickRoot):
-    run_types: RunTypes = ("CopickRunCDP", "CopickRunMetaCDP")
-    object_types: ObjectTypes = ("CopickObjectCDP", PickableObject)
+    run_types: "RunTypes" = ("CopickRunCDP", "CopickRunMetaCDP")
+    object_types: "ObjectTypes" = ("CopickObjectCDP", PickableObject)
 
     config: CopickConfigCDP
 

--- a/src/copick/impl/filesystem.py
+++ b/src/copick/impl/filesystem.py
@@ -1,6 +1,6 @@
 import concurrent.futures
 import json
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 import fsspec
 import trimesh
@@ -31,6 +31,17 @@ from copick.models import (
     CopickVoxelSpacingMeta,
     PickableObject,
 )
+
+# Type aliases using forward references
+if TYPE_CHECKING:
+    RunTypes = Tuple[Type["CopickRunFSSpec"], Type[CopickRunMeta]]
+    ObjectTypes = Tuple[Type["CopickObjectFSSpec"], Type[PickableObject]]
+    VoxelSpacingTypes = Tuple[Type["CopickVoxelSpacingFSSpec"], Type[CopickVoxelSpacingMeta]]
+    PicksTypes = Tuple[Type["CopickPicksFSSpec"], Type[CopickPicksFile]]
+    MeshTypes = Tuple[Type["CopickMeshFSSpec"], Type[CopickMeshMeta]]
+    SegmentationTypes = Tuple[Type["CopickSegmentationFSSpec"], Type[CopickSegmentationMeta]]
+    TomogramTypes = Tuple[Type["CopickTomogramFSSpec"], Type[CopickTomogramMeta]]
+    FeaturesTypes = Tuple[Type["CopickFeaturesFSSpec"], Type[CopickFeaturesMeta]]
 
 
 class CopickConfigFSSpec(CopickConfig):
@@ -252,9 +263,10 @@ class CopickTomogramFSSpec(CopickTomogramOverlay):
         static_is_overlay (bool): Whether the static and overlay sources are the same.
     """
 
+    features_types: "FeaturesTypes" = ("CopickFeaturesFSSpec", "CopickFeaturesMeta")
     voxel_spacing: "CopickVoxelSpacingFSSpec"
 
-    def _feature_factory(self) -> Tuple[Type[CopickFeatures], Type["CopickFeaturesMeta"]]:
+    def _feature_factory(self) -> Tuple[Type[CopickFeatures], Type[CopickFeaturesMeta]]:
         return CopickFeaturesFSSpec, CopickFeaturesMeta
 
     @property

--- a/src/copick/impl/filesystem.py
+++ b/src/copick/impl/filesystem.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import json
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 import fsspec
@@ -20,7 +21,6 @@ from copick.impl.overlay import (
 )
 from copick.models import (
     CopickConfig,
-    CopickFeatures,
     CopickFeaturesMeta,
     CopickMeshMeta,
     CopickPicksFile,
@@ -266,8 +266,13 @@ class CopickTomogramFSSpec(CopickTomogramOverlay):
     features_types: "FeaturesTypes" = ("CopickFeaturesFSSpec", "CopickFeaturesMeta")
     voxel_spacing: "CopickVoxelSpacingFSSpec"
 
-    def _feature_factory(self) -> Tuple[Type[CopickFeatures], Type[CopickFeaturesMeta]]:
-        return CopickFeaturesFSSpec, CopickFeaturesMeta
+    def _feature_factory(self) -> Tuple[Type[CopickFeaturesFSSpec], Type[CopickFeaturesMeta]]:
+        warnings.warn(
+            "_feature_factory is deprecated, use CopickTomogramFSSpec.features_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.features_types
 
     @property
     def static_path(self) -> str:
@@ -383,10 +388,16 @@ class CopickVoxelSpacingFSSpec(CopickVoxelSpacingOverlay):
 
     """
 
+    tomogram_types: "TomogramTypes" = ("CopickTomogramFSSpec", "CopickTomogramMeta")
     run: "CopickRunFSSpec"
 
     def _tomogram_factory(self) -> Tuple[Type[CopickTomogramFSSpec], Type[CopickTomogramMeta]]:
-        return CopickTomogramFSSpec, CopickTomogramMeta
+        warnings.warn(
+            "_tomogram_factory is deprecated, use CopickVoxelSpacingFSSpec.tomogram_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.tomogram_types
 
     @property
     def static_path(self) -> str:
@@ -487,19 +498,44 @@ class CopickRunFSSpec(CopickRunOverlay):
         static_is_overlay (bool): Whether the static and overlay sources are the same.
     """
 
+    voxel_spacing_types: "VoxelSpacingTypes" = ("CopickVoxelSpacingFSSpec", "CopickVoxelSpacingMeta")
+    picks_types: "PicksTypes" = ("CopickPicksFSSpec", "CopickPicksFile")
+    mesh_types: "MeshTypes" = ("CopickMeshFSSpec", "CopickMeshMeta")
+    segmentation_types: "SegmentationTypes" = ("CopickSegmentationFSSpec", "CopickSegmentationMeta")
+
     root: "CopickRootFSSpec"
 
     def _voxel_spacing_factory(self) -> Tuple[Type[CopickVoxelSpacingFSSpec], Type["CopickVoxelSpacingMeta"]]:
-        return CopickVoxelSpacingFSSpec, CopickVoxelSpacingMeta
+        warnings.warn(
+            "_voxel_spacing_factory is deprecated, use CopickRunFSSpec.voxel_spacing_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.voxel_spacing_types
 
     def _picks_factory(self) -> Type[CopickPicksFSSpec]:
-        return CopickPicksFSSpec
+        warnings.warn(
+            "_picks_factory is deprecated, use CopickRunFSSpec.picks_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.picks_types[0]
 
     def _mesh_factory(self) -> Tuple[Type[CopickMeshFSSpec], Type[CopickMeshMeta]]:
-        return CopickMeshFSSpec, CopickMeshMeta
+        warnings.warn(
+            "_mesh_factory is deprecated, use CopickRunFSSpec.mesh_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.mesh_types
 
     def _segmentation_factory(self) -> Tuple[Type[CopickSegmentationFSSpec], Type[CopickSegmentationMeta]]:
-        return CopickSegmentationFSSpec, CopickSegmentationMeta
+        warnings.warn(
+            "_segmentation_factory is deprecated, use CopickRunFSSpec.segmentation_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.segmentation_types
 
     @property
     def static_path(self) -> str:
@@ -844,6 +880,9 @@ class CopickRootFSSpec(CopickRoot):
         root_static (Optional[str]): The root path for the static storage.
     """
 
+    run_types: RunTypes = ("CopickRunFSSpec", "CopickRunMeta")
+    object_types: ObjectTypes = ("CopickObjectFSSpec", "PickableObject")
+
     def __init__(self, config: CopickConfigFSSpec):
         """
         Args:
@@ -884,10 +923,20 @@ class CopickRootFSSpec(CopickRoot):
         return cls(CopickConfigFSSpec(**data))
 
     def _run_factory(self) -> Tuple[Type[CopickRunFSSpec], Type["CopickRunMeta"]]:
-        return CopickRunFSSpec, CopickRunMeta
+        warnings.warn(
+            "_run_factory is deprecated, use CopickRootFSSpec.run_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.run_types
 
     def _object_factory(self) -> Tuple[Type[CopickObjectFSSpec], Type[PickableObject]]:
-        return CopickObjectFSSpec, PickableObject
+        warnings.warn(
+            "_object_factory is deprecated, use CopickRootFSSpec.object_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.object_types
 
     @staticmethod
     def _query_names(fs, root) -> List[str]:
@@ -937,3 +986,14 @@ class CopickRootFSSpec(CopickRoot):
             runs.append(CopickRunFSSpec(root=self, meta=rm))
 
         return runs
+
+
+# Resolve forward references
+CopickRootFSSpec.run_types = (CopickRunFSSpec, CopickRunMeta)
+CopickRootFSSpec.object_types = (CopickObjectFSSpec, PickableObject)
+CopickRunFSSpec.voxel_spacing_types = (CopickVoxelSpacingFSSpec, CopickVoxelSpacingMeta)
+CopickRunFSSpec.picks_types = (CopickPicksFSSpec, CopickPicksFile)
+CopickRunFSSpec.mesh_types = (CopickMeshFSSpec, CopickMeshMeta)
+CopickRunFSSpec.segmentation_types = (CopickSegmentationFSSpec, CopickSegmentationMeta)
+CopickVoxelSpacingFSSpec.tomogram_types = (CopickTomogramFSSpec, CopickTomogramMeta)
+CopickTomogramFSSpec.features_types = (CopickFeaturesFSSpec, CopickFeaturesMeta)

--- a/src/copick/impl/filesystem.py
+++ b/src/copick/impl/filesystem.py
@@ -880,8 +880,8 @@ class CopickRootFSSpec(CopickRoot):
         root_static (Optional[str]): The root path for the static storage.
     """
 
-    run_types: RunTypes = ("CopickRunFSSpec", "CopickRunMeta")
-    object_types: ObjectTypes = ("CopickObjectFSSpec", "PickableObject")
+    run_types: "RunTypes" = ("CopickRunFSSpec", "CopickRunMeta")
+    object_types: "ObjectTypes" = ("CopickObjectFSSpec", "PickableObject")
 
     def __init__(self, config: CopickConfigFSSpec):
         """

--- a/src/copick/impl/filesystem.py
+++ b/src/copick/impl/filesystem.py
@@ -34,14 +34,14 @@ from copick.models import (
 
 # Type aliases using forward references
 if TYPE_CHECKING:
-    RunTypes = Tuple[Type["CopickRunFSSpec"], Type[CopickRunMeta]]
-    ObjectTypes = Tuple[Type["CopickObjectFSSpec"], Type[PickableObject]]
-    VoxelSpacingTypes = Tuple[Type["CopickVoxelSpacingFSSpec"], Type[CopickVoxelSpacingMeta]]
-    PicksTypes = Tuple[Type["CopickPicksFSSpec"], Type[CopickPicksFile]]
-    MeshTypes = Tuple[Type["CopickMeshFSSpec"], Type[CopickMeshMeta]]
-    SegmentationTypes = Tuple[Type["CopickSegmentationFSSpec"], Type[CopickSegmentationMeta]]
-    TomogramTypes = Tuple[Type["CopickTomogramFSSpec"], Type[CopickTomogramMeta]]
-    FeaturesTypes = Tuple[Type["CopickFeaturesFSSpec"], Type[CopickFeaturesMeta]]
+    RunClz = Tuple[Type["CopickRunFSSpec"], Type[CopickRunMeta]]
+    ObjectClz = Tuple[Type["CopickObjectFSSpec"], Type[PickableObject]]
+    VoxelSpacingClz = Tuple[Type["CopickVoxelSpacingFSSpec"], Type[CopickVoxelSpacingMeta]]
+    PicksClz = Tuple[Type["CopickPicksFSSpec"], Type[CopickPicksFile]]
+    MeshClz = Tuple[Type["CopickMeshFSSpec"], Type[CopickMeshMeta]]
+    SegmenationClz = Tuple[Type["CopickSegmentationFSSpec"], Type[CopickSegmentationMeta]]
+    TomogramClz = Tuple[Type["CopickTomogramFSSpec"], Type[CopickTomogramMeta]]
+    FeaturesClz = Tuple[Type["CopickFeaturesFSSpec"], Type[CopickFeaturesMeta]]
 
 
 class CopickConfigFSSpec(CopickConfig):
@@ -263,16 +263,16 @@ class CopickTomogramFSSpec(CopickTomogramOverlay):
         static_is_overlay (bool): Whether the static and overlay sources are the same.
     """
 
-    features_types: "FeaturesTypes" = ("CopickFeaturesFSSpec", "CopickFeaturesMeta")
+    features_clz: "FeaturesClz" = ("CopickFeaturesFSSpec", "CopickFeaturesMeta")
     voxel_spacing: "CopickVoxelSpacingFSSpec"
 
     def _feature_factory(self) -> Tuple[Type[CopickFeaturesFSSpec], Type[CopickFeaturesMeta]]:
         warnings.warn(
-            "_feature_factory is deprecated, use CopickTomogramFSSpec.features_types class attribute instead.",
+            "_feature_factory is deprecated, use CopickTomogramFSSpec.features_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.features_types
+        return self.features_clz
 
     @property
     def static_path(self) -> str:
@@ -388,16 +388,16 @@ class CopickVoxelSpacingFSSpec(CopickVoxelSpacingOverlay):
 
     """
 
-    tomogram_types: "TomogramTypes" = ("CopickTomogramFSSpec", "CopickTomogramMeta")
+    tomogram_clz: "TomogramClz" = ("CopickTomogramFSSpec", "CopickTomogramMeta")
     run: "CopickRunFSSpec"
 
     def _tomogram_factory(self) -> Tuple[Type[CopickTomogramFSSpec], Type[CopickTomogramMeta]]:
         warnings.warn(
-            "_tomogram_factory is deprecated, use CopickVoxelSpacingFSSpec.tomogram_types class attribute instead.",
+            "_tomogram_factory is deprecated, use CopickVoxelSpacingFSSpec.tomogram_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.tomogram_types
+        return self.tomogram_clz
 
     @property
     def static_path(self) -> str:
@@ -498,44 +498,44 @@ class CopickRunFSSpec(CopickRunOverlay):
         static_is_overlay (bool): Whether the static and overlay sources are the same.
     """
 
-    voxel_spacing_types: "VoxelSpacingTypes" = ("CopickVoxelSpacingFSSpec", "CopickVoxelSpacingMeta")
-    picks_types: "PicksTypes" = ("CopickPicksFSSpec", "CopickPicksFile")
-    mesh_types: "MeshTypes" = ("CopickMeshFSSpec", "CopickMeshMeta")
-    segmentation_types: "SegmentationTypes" = ("CopickSegmentationFSSpec", "CopickSegmentationMeta")
+    voxel_spacing_clz: "VoxelSpacingClz" = ("CopickVoxelSpacingFSSpec", "CopickVoxelSpacingMeta")
+    picks_clz: "PicksClz" = ("CopickPicksFSSpec", "CopickPicksFile")
+    mesh_clz: "MeshClz" = ("CopickMeshFSSpec", "CopickMeshMeta")
+    segmentation_clz: "SegmenationClz" = ("CopickSegmentationFSSpec", "CopickSegmentationMeta")
 
     root: "CopickRootFSSpec"
 
     def _voxel_spacing_factory(self) -> Tuple[Type[CopickVoxelSpacingFSSpec], Type["CopickVoxelSpacingMeta"]]:
         warnings.warn(
-            "_voxel_spacing_factory is deprecated, use CopickRunFSSpec.voxel_spacing_types class attribute instead.",
+            "_voxel_spacing_factory is deprecated, use CopickRunFSSpec.voxel_spacing_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.voxel_spacing_types
+        return self.voxel_spacing_clz
 
     def _picks_factory(self) -> Type[CopickPicksFSSpec]:
         warnings.warn(
-            "_picks_factory is deprecated, use CopickRunFSSpec.picks_types class attribute instead.",
+            "_picks_factory is deprecated, use CopickRunFSSpec.picks_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.picks_types[0]
+        return self.picks_clz[0]
 
     def _mesh_factory(self) -> Tuple[Type[CopickMeshFSSpec], Type[CopickMeshMeta]]:
         warnings.warn(
-            "_mesh_factory is deprecated, use CopickRunFSSpec.mesh_types class attribute instead.",
+            "_mesh_factory is deprecated, use CopickRunFSSpec.mesh_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.mesh_types
+        return self.mesh_clz
 
     def _segmentation_factory(self) -> Tuple[Type[CopickSegmentationFSSpec], Type[CopickSegmentationMeta]]:
         warnings.warn(
-            "_segmentation_factory is deprecated, use CopickRunFSSpec.segmentation_types class attribute instead.",
+            "_segmentation_factory is deprecated, use CopickRunFSSpec.segmentation_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.segmentation_types
+        return self.segmentation_clz
 
     @property
     def static_path(self) -> str:
@@ -880,8 +880,8 @@ class CopickRootFSSpec(CopickRoot):
         root_static (Optional[str]): The root path for the static storage.
     """
 
-    run_types: "RunTypes" = ("CopickRunFSSpec", "CopickRunMeta")
-    object_types: "ObjectTypes" = ("CopickObjectFSSpec", "PickableObject")
+    run_clz: "RunClz" = ("CopickRunFSSpec", "CopickRunMeta")
+    object_clz: "ObjectClz" = ("CopickObjectFSSpec", "PickableObject")
 
     def __init__(self, config: CopickConfigFSSpec):
         """
@@ -924,19 +924,19 @@ class CopickRootFSSpec(CopickRoot):
 
     def _run_factory(self) -> Tuple[Type[CopickRunFSSpec], Type["CopickRunMeta"]]:
         warnings.warn(
-            "_run_factory is deprecated, use CopickRootFSSpec.run_types class attribute instead.",
+            "_run_factory is deprecated, use CopickRootFSSpec.run_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.run_types
+        return self.run_clz
 
     def _object_factory(self) -> Tuple[Type[CopickObjectFSSpec], Type[PickableObject]]:
         warnings.warn(
-            "_object_factory is deprecated, use CopickRootFSSpec.object_types class attribute instead.",
+            "_object_factory is deprecated, use CopickRootFSSpec.object_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.object_types
+        return self.object_clz
 
     @staticmethod
     def _query_names(fs, root) -> List[str]:
@@ -989,11 +989,11 @@ class CopickRootFSSpec(CopickRoot):
 
 
 # Resolve forward references
-CopickRootFSSpec.run_types = (CopickRunFSSpec, CopickRunMeta)
-CopickRootFSSpec.object_types = (CopickObjectFSSpec, PickableObject)
-CopickRunFSSpec.voxel_spacing_types = (CopickVoxelSpacingFSSpec, CopickVoxelSpacingMeta)
-CopickRunFSSpec.picks_types = (CopickPicksFSSpec, CopickPicksFile)
-CopickRunFSSpec.mesh_types = (CopickMeshFSSpec, CopickMeshMeta)
-CopickRunFSSpec.segmentation_types = (CopickSegmentationFSSpec, CopickSegmentationMeta)
-CopickVoxelSpacingFSSpec.tomogram_types = (CopickTomogramFSSpec, CopickTomogramMeta)
-CopickTomogramFSSpec.features_types = (CopickFeaturesFSSpec, CopickFeaturesMeta)
+CopickRootFSSpec.run_clz = (CopickRunFSSpec, CopickRunMeta)
+CopickRootFSSpec.object_clz = (CopickObjectFSSpec, PickableObject)
+CopickRunFSSpec.voxel_spacing_clz = (CopickVoxelSpacingFSSpec, CopickVoxelSpacingMeta)
+CopickRunFSSpec.picks_clz = (CopickPicksFSSpec, CopickPicksFile)
+CopickRunFSSpec.mesh_clz = (CopickMeshFSSpec, CopickMeshMeta)
+CopickRunFSSpec.segmentation_clz = (CopickSegmentationFSSpec, CopickSegmentationMeta)
+CopickVoxelSpacingFSSpec.tomogram_clz = (CopickTomogramFSSpec, CopickTomogramMeta)
+CopickTomogramFSSpec.features_clz = (CopickFeaturesFSSpec, CopickFeaturesMeta)

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -12,14 +12,14 @@ from copick.util.ome import fits_in_memory, segmentation_pyramid, volume_pyramid
 
 # Type aliases using forward references
 if TYPE_CHECKING:
-    RunTypes = Tuple[Type["CopickRun"], Type["CopickRunMeta"]]
-    ObjectTypes = Tuple[Type["CopickObject"], Type["PickableObject"]]
-    VoxelSpacingTypes = Tuple[Type["CopickVoxelSpacing"], Type["CopickVoxelSpacingMeta"]]
-    PicksTypes = Tuple[Type["CopickPicks"], Type["CopickPicksFile"]]
-    MeshTypes = Tuple[Type["CopickMesh"], Type["CopickMeshMeta"]]
-    SegmentationTypes = Tuple[Type["CopickSegmentation"], Type["CopickSegmentationMeta"]]
-    TomogramTypes = Tuple[Type["CopickTomogram"], Type["CopickTomogramMeta"]]
-    FeaturesTypes = Tuple[Type["CopickFeatures"], Type["CopickFeaturesMeta"]]
+    RunClz = Tuple[Type["CopickRun"], Type["CopickRunMeta"]]
+    ObjectClz = Tuple[Type["CopickObject"], Type["PickableObject"]]
+    VoxelSpacingClz = Tuple[Type["CopickVoxelSpacing"], Type["CopickVoxelSpacingMeta"]]
+    PicksClz = Tuple[Type["CopickPicks"], Type["CopickPicksFile"]]
+    MeshClz = Tuple[Type["CopickMesh"], Type["CopickMeshMeta"]]
+    SegmenationClz = Tuple[Type["CopickSegmentation"], Type["CopickSegmentationMeta"]]
+    TomogramClz = Tuple[Type["CopickTomogram"], Type["CopickTomogramMeta"]]
+    FeaturesClz = Tuple[Type["CopickFeatures"], Type["CopickFeaturesMeta"]]
 
 
 class CopickLocation(BaseModel):
@@ -431,8 +431,8 @@ class CopickRoot:
 
     """
 
-    run_types: "RunTypes" = ("CopickRun", "CopickRunMeta")
-    object_types: "ObjectTypes" = ("CopickObject", "PickableObject")
+    run_clz: "RunClz" = ("CopickRun", "CopickRunMeta")
+    object_clz: "ObjectClz" = ("CopickObject", "PickableObject")
 
     def __init__(self, config: CopickConfig):
         """
@@ -487,7 +487,7 @@ class CopickRoot:
         """
         # Random access
         if self._runs is None:
-            clz, meta_clz = self.run_types
+            clz, meta_clz = self.run_clz
             rm = meta_clz(name=name, **kwargs)
             run = clz(self, meta=rm)
 
@@ -507,7 +507,7 @@ class CopickRoot:
     @property
     def pickable_objects(self) -> List["CopickObject"]:
         if self._objects is None:
-            clz, meta_clz = self.object_types
+            clz, meta_clz = self.object_clz
             self._objects = [clz(self, meta=obj) for obj in self.config.pickable_objects]
 
         return self._objects
@@ -547,7 +547,7 @@ class CopickRoot:
         if name in [r.name for r in self.runs]:
             raise ValueError(f"Run name {name} already exists.")
 
-        clz, meta_clz = self.run_types
+        clz, meta_clz = self.run_clz
         rm = meta_clz(name=name, **kwargs)
         run = clz(self, meta=rm)
 
@@ -562,28 +562,28 @@ class CopickRoot:
         return run
 
     def _run_factory(self) -> Tuple[Type["CopickRun"], Type["CopickRunMeta"]]:
-        """DEPRECATED, use CopickRoot.run_types class attribute instead.
+        """DEPRECATED, use CopickRoot.run_clz class attribute instead.
 
         Override this method to return the run class and run metadata class.
         """
         warnings.warn(
-            "_run_factory is deprecated, use CopickRoot.run_types class attribute instead.",
+            "_run_factory is deprecated, use CopickRoot.run_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.run_types
+        return self.run_clz
 
     def _object_factory(self) -> Tuple[Type["CopickObject"], Type["PickableObject"]]:
-        """DEPRECATED, use CopickRoot.object_types class attribute instead.
+        """DEPRECATED, use CopickRoot.object_clz class attribute instead.
 
         Override this method to return the object class and object metadata class.
         """
         warnings.warn(
-            "_object_factory is deprecated, use CopickRoot.object_types class attribute instead.",
+            "_object_factory is deprecated, use CopickRoot.object_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.object_types
+        return self.object_clz
 
 
 class CopickRun:
@@ -604,10 +604,10 @@ class CopickRun:
             loaded when CopickRun.segmentations is accessed **for the first time**.
     """
 
-    voxel_spacing_types: "VoxelSpacingTypes" = ("CopickVoxelSpacing", "CopickVoxelSpacingMeta")
-    picks_types: "PicksTypes" = ("CopickPicks", "CopickPicksFile")
-    mesh_types: "MeshTypes" = ("CopickMesh", "CopickMeshMeta")
-    segmentation_types: "SegmentationTypes" = ("CopickSegmentation", "CopickSegmentationMeta")
+    voxel_spacing_clz: "VoxelSpacingClz" = ("CopickVoxelSpacing", "CopickVoxelSpacingMeta")
+    picks_clz: "PicksClz" = ("CopickPicks", "CopickPicksFile")
+    mesh_clz: "MeshClz" = ("CopickMesh", "CopickMeshMeta")
+    segmentation_clz: "SegmenationClz" = ("CopickSegmentation", "CopickSegmentationMeta")
 
     def __init__(self, root: "CopickRoot", meta: CopickRunMeta):
         self.meta = meta
@@ -695,7 +695,7 @@ class CopickRun:
         """
         # Random access
         if self._voxel_spacings is None:
-            clz, meta_clz = self.voxel_spacing_types
+            clz, meta_clz = self.voxel_spacing_clz
             vm = meta_clz(voxel_size=voxel_size, **kwargs)
             vs = clz(self, meta=vm)
 
@@ -893,7 +893,7 @@ class CopickRun:
         if voxel_size in [vs.voxel_size for vs in self.voxel_spacings]:
             raise ValueError(f"VoxelSpacing {voxel_size} already exists for this run.")
 
-        clz, meta_clz = self.voxel_spacing_types
+        clz, meta_clz = self.voxel_spacing_clz
 
         vm = meta_clz(voxel_size=voxel_size, **kwargs)
         vs = clz(run=self, meta=vm)
@@ -909,16 +909,16 @@ class CopickRun:
         return vs
 
     def _voxel_spacing_factory(self) -> Tuple[Type["CopickVoxelSpacing"], Type["CopickVoxelSpacingMeta"]]:
-        """DEPRECATED, use CopickRun.voxel_spacing_types class attribute instead.
+        """DEPRECATED, use CopickRun.voxel_spacing_clz class attribute instead.
 
         Override this method to return the voxel spacing class and voxel spacing metadata class.
         """
         warnings.warn(
-            "_voxel_spacing_factory is deprecated, use CopickRun.voxel_spacing_types class attribute instead.",
+            "_voxel_spacing_factory is deprecated, use CopickRun.voxel_spacing_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.voxel_spacing_types
+        return self.voxel_spacing_clz
 
     def new_picks(self, object_name: str, session_id: str, user_id: Optional[str] = None) -> "CopickPicks":
         """Create a new picks object.
@@ -956,7 +956,7 @@ class CopickRun:
             run_name=self.name,
         )
 
-        clz = self.picks_types[0]
+        clz = self.picks_clz[0]
 
         picks = clz(run=self, file=pm)
 
@@ -970,16 +970,16 @@ class CopickRun:
         return picks
 
     def _picks_factory(self) -> Type["CopickPicks"]:
-        """DEPRECATED, use CopickRun.picks_types class attribute instead.
+        """DEPRECATED, use CopickRun.picks_clz class attribute instead.
 
         Override this method to return the picks class.
         """
         warnings.warn(
-            "_picks_factory is deprecated, use CopickRun.picks_types class attribute instead.",
+            "_picks_factory is deprecated, use CopickRun.picks_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.picks_types[0]
+        return self.picks_clz[0]
 
     def new_mesh(self, object_name: str, session_id: str, user_id: Optional[str] = None, **kwargs) -> "CopickMesh":
         """Create a new mesh object.
@@ -1011,7 +1011,7 @@ class CopickRun:
         if self.get_meshes(object_name=object_name, session_id=session_id, user_id=uid):
             raise ValueError(f"Mesh for {object_name} by user/tool {uid} already exist in session {session_id}.")
 
-        clz, meta_clz = self.mesh_types
+        clz, meta_clz = self.mesh_clz
 
         mm = meta_clz(
             pickable_object_name=object_name,
@@ -1036,16 +1036,16 @@ class CopickRun:
         return mesh
 
     def _mesh_factory(self) -> Tuple[Type["CopickMesh"], Type["CopickMeshMeta"]]:
-        """DEPRECATED, use CopickRun.mesh_types class attribute instead.
+        """DEPRECATED, use CopickRun.mesh_clz class attribute instead.
 
         Override this method to return the mesh class and mesh metadata.
         """
         warnings.warn(
-            "_mesh_factory is deprecated, use CopickRun.mesh_types class attribute instead.",
+            "_mesh_factory is deprecated, use CopickRun.mesh_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.mesh_types
+        return self.mesh_clz
 
     def new_segmentation(
         self,
@@ -1096,7 +1096,7 @@ class CopickRun:
                 f"Segmentation by user/tool {uid} already exist in session {session_id} with name {name}, voxel size of {voxel_size}, and has a multilabel flag of {is_multilabel}.",
             )
 
-        clz, meta_clz = self.segmentation_types
+        clz, meta_clz = self.segmentation_clz
 
         sm = meta_clz(
             is_multilabel=is_multilabel,
@@ -1119,16 +1119,16 @@ class CopickRun:
         return seg
 
     def _segmentation_factory(self) -> Tuple[Type["CopickSegmentation"], Type["CopickSegmentationMeta"]]:
-        """DEPRECATED, use CopickRun.segmentation_types class attribute instead.
+        """DEPRECATED, use CopickRun.segmentation_clz class attribute instead.
 
         Override this method to return the segmentation class and segmentation metadata class.
         """
         warnings.warn(
-            "_segmentation_factory is deprecated, use CopickRun.segmentation_types class attribute instead.",
+            "_segmentation_factory is deprecated, use CopickRun.segmentation_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.segmentation_types
+        return self.segmentation_clz
 
     def refresh_voxel_spacings(self) -> None:
         """Refresh the voxel spacings."""
@@ -1176,7 +1176,7 @@ class CopickVoxelSpacing:
             when CopickVoxelSpacing.tomograms is accessed **for the first time**.
     """
 
-    tomogram_types: "TomogramTypes" = ("CopickTomogram", "CopickTomogramMeta")
+    tomogram_clz: "TomogramClz" = ("CopickTomogram", "CopickTomogramMeta")
 
     def __init__(self, run: CopickRun, meta: CopickVoxelSpacingMeta):
         """
@@ -1248,7 +1248,7 @@ class CopickVoxelSpacing:
         if tomo_type in [tomo.tomo_type for tomo in self.tomograms]:
             raise ValueError(f"Tomogram type {tomo_type} already exists for this voxel spacing.")
 
-        clz, meta_clz = self.tomogram_types
+        clz, meta_clz = self.tomogram_clz
 
         tm = meta_clz(tomo_type=tomo_type, **kwargs)
         tomo = clz(voxel_spacing=self, meta=tm)
@@ -1264,16 +1264,16 @@ class CopickVoxelSpacing:
         return tomo
 
     def _tomogram_factory(self) -> Tuple[Type["CopickTomogram"], Type["CopickTomogramMeta"]]:
-        """DEPRECATED, use CopickVoxelSpacing.tomogram_types class attribute instead.
+        """DEPRECATED, use CopickVoxelSpacing.tomogram_clz class attribute instead.
 
         Override this method to return the tomogram class.
         """
         warnings.warn(
-            "_tomogram_factory is deprecated, use CopickVoxelSpacing.tomogram_types class attribute instead.",
+            "_tomogram_factory is deprecated, use CopickVoxelSpacing.tomogram_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.tomogram_types
+        return self.tomogram_clz
 
     def ensure(self, create: bool = False) -> bool:
         """Override to check if the voxel spacing record exists, optionally create it if it does not.
@@ -1299,7 +1299,7 @@ class CopickTomogram:
         tomo_type (str): Type of the tomogram.
     """
 
-    features_types: "FeaturesTypes" = ("CopickFeatures", "CopickFeaturesMeta")
+    features_clz: "FeaturesClz" = ("CopickFeatures", "CopickFeaturesMeta")
 
     def __init__(self, voxel_spacing: "CopickVoxelSpacing", meta: CopickTomogramMeta):
         self.meta = meta
@@ -1358,7 +1358,7 @@ class CopickTomogram:
         if feature_type in [f.feature_type for f in self.features]:
             raise ValueError(f"Feature type {feature_type} already exists for this tomogram.")
 
-        clz, meta_clz = self.features_types
+        clz, meta_clz = self.features_clz
 
         fm = meta_clz(tomo_type=self.tomo_type, feature_type=feature_type, **kwargs)
         feat = clz(tomogram=self, meta=fm)
@@ -1375,16 +1375,16 @@ class CopickTomogram:
         return feat
 
     def _feature_factory(self) -> Tuple[Type["CopickFeatures"], Type["CopickFeaturesMeta"]]:
-        """DEPRECATED, use CopickTomogram.features_types class attribute instead.
+        """DEPRECATED, use CopickTomogram.features_clz class attribute instead.
 
         Override this method to return the features class and features metadata class.
         """
         warnings.warn(
-            "_feature_factory is deprecated, use CopickTomogram.features_types class attribute instead.",
+            "_feature_factory is deprecated, use CopickTomogram.features_clz class attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.features_types
+        return self.features_clz
 
     def query_features(self) -> List["CopickFeatures"]:
         """Override this method to query for features."""
@@ -1953,11 +1953,11 @@ class CopickSegmentation:
 
 
 # Resolve forward references
-CopickRoot.run_types = (CopickRun, CopickRunMeta)
-CopickRoot.object_types = (CopickObject, PickableObject)
-CopickRun.voxel_spacing_types = (CopickVoxelSpacing, CopickVoxelSpacingMeta)
-CopickRun.picks_types = (CopickPicks, CopickPicksFile)
-CopickRun.mesh_types = (CopickMesh, CopickMeshMeta)
-CopickRun.segmentation_types = (CopickSegmentation, CopickSegmentationMeta)
-CopickVoxelSpacing.tomogram_types = (CopickTomogram, CopickTomogramMeta)
-CopickTomogram.features_types = (CopickFeatures, CopickFeaturesMeta)
+CopickRoot.run_clz = (CopickRun, CopickRunMeta)
+CopickRoot.object_clz = (CopickObject, PickableObject)
+CopickRun.voxel_spacing_clz = (CopickVoxelSpacing, CopickVoxelSpacingMeta)
+CopickRun.picks_clz = (CopickPicks, CopickPicksFile)
+CopickRun.mesh_clz = (CopickMesh, CopickMeshMeta)
+CopickRun.segmentation_clz = (CopickSegmentation, CopickSegmentationMeta)
+CopickVoxelSpacing.tomogram_clz = (CopickTomogram, CopickTomogramMeta)
+CopickTomogram.features_clz = (CopickFeatures, CopickFeaturesMeta)

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from typing import TYPE_CHECKING, List, Literal, MutableMapping, Optional, Tuple, Type, Union
 
 import numpy as np
@@ -486,7 +487,7 @@ class CopickRoot:
         """
         # Random access
         if self._runs is None:
-            clz, meta_clz = self._run_factory()
+            clz, meta_clz = self.run_types
             rm = meta_clz(name=name, **kwargs)
             run = clz(self, meta=rm)
 
@@ -506,7 +507,7 @@ class CopickRoot:
     @property
     def pickable_objects(self) -> List["CopickObject"]:
         if self._objects is None:
-            clz, meta_clz = self._object_factory()
+            clz, meta_clz = self.object_types
             self._objects = [clz(self, meta=obj) for obj in self.config.pickable_objects]
 
         return self._objects
@@ -546,7 +547,7 @@ class CopickRoot:
         if name in [r.name for r in self.runs]:
             raise ValueError(f"Run name {name} already exists.")
 
-        clz, meta_clz = self._run_factory()
+        clz, meta_clz = self.run_types
         rm = meta_clz(name=name, **kwargs)
         run = clz(self, meta=rm)
 
@@ -561,12 +562,28 @@ class CopickRoot:
         return run
 
     def _run_factory(self) -> Tuple[Type["CopickRun"], Type["CopickRunMeta"]]:
-        """Override this method to return the run class and run metadata class."""
-        return CopickRun, CopickRunMeta
+        """DEPRECATED, use CopickRoot.run_types class attribute instead.
+
+        Override this method to return the run class and run metadata class.
+        """
+        warnings.warn(
+            "_run_factory is deprecated, use CopickRoot.run_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.run_types
 
     def _object_factory(self) -> Tuple[Type["CopickObject"], Type["PickableObject"]]:
-        """Override this method to return the object class and object metadata class."""
-        return CopickObject, PickableObject
+        """DEPRECATED, use CopickRoot.object_types class attribute instead.
+
+        Override this method to return the object class and object metadata class.
+        """
+        warnings.warn(
+            "_object_factory is deprecated, use CopickRoot.object_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.object_types
 
 
 class CopickRun:
@@ -678,7 +695,7 @@ class CopickRun:
         """
         # Random access
         if self._voxel_spacings is None:
-            clz, meta_clz = self._voxel_spacing_factory()
+            clz, meta_clz = self.voxel_spacing_types
             vm = meta_clz(voxel_size=voxel_size, **kwargs)
             vs = clz(self, meta=vm)
 
@@ -876,7 +893,7 @@ class CopickRun:
         if voxel_size in [vs.voxel_size for vs in self.voxel_spacings]:
             raise ValueError(f"VoxelSpacing {voxel_size} already exists for this run.")
 
-        clz, meta_clz = self._voxel_spacing_factory()
+        clz, meta_clz = self.voxel_spacing_types
 
         vm = meta_clz(voxel_size=voxel_size, **kwargs)
         vs = clz(run=self, meta=vm)
@@ -892,8 +909,16 @@ class CopickRun:
         return vs
 
     def _voxel_spacing_factory(self) -> Tuple[Type["CopickVoxelSpacing"], Type["CopickVoxelSpacingMeta"]]:
-        """Override this method to return the voxel spacing class and voxel spacing metadata class."""
-        return CopickVoxelSpacing, CopickVoxelSpacingMeta
+        """DEPRECATED, use CopickRun.voxel_spacing_types class attribute instead.
+
+        Override this method to return the voxel spacing class and voxel spacing metadata class.
+        """
+        warnings.warn(
+            "_voxel_spacing_factory is deprecated, use CopickRun.voxel_spacing_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.voxel_spacing_types
 
     def new_picks(self, object_name: str, session_id: str, user_id: Optional[str] = None) -> "CopickPicks":
         """Create a new picks object.
@@ -931,7 +956,7 @@ class CopickRun:
             run_name=self.name,
         )
 
-        clz = self._picks_factory()
+        clz = self.picks_types[0]
 
         picks = clz(run=self, file=pm)
 
@@ -945,8 +970,16 @@ class CopickRun:
         return picks
 
     def _picks_factory(self) -> Type["CopickPicks"]:
-        """Override this method to return the picks class."""
-        return CopickPicks
+        """DEPRECATED, use CopickRun.picks_types class attribute instead.
+
+        Override this method to return the picks class.
+        """
+        warnings.warn(
+            "_picks_factory is deprecated, use CopickRun.picks_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.picks_types[0]
 
     def new_mesh(self, object_name: str, session_id: str, user_id: Optional[str] = None, **kwargs) -> "CopickMesh":
         """Create a new mesh object.
@@ -978,7 +1011,7 @@ class CopickRun:
         if self.get_meshes(object_name=object_name, session_id=session_id, user_id=uid):
             raise ValueError(f"Mesh for {object_name} by user/tool {uid} already exist in session {session_id}.")
 
-        clz, meta_clz = self._mesh_factory()
+        clz, meta_clz = self.mesh_types
 
         mm = meta_clz(
             pickable_object_name=object_name,
@@ -1003,8 +1036,16 @@ class CopickRun:
         return mesh
 
     def _mesh_factory(self) -> Tuple[Type["CopickMesh"], Type["CopickMeshMeta"]]:
-        """Override this method to return the mesh class and mesh metadata."""
-        return CopickMesh, CopickMeshMeta
+        """DEPRECATED, use CopickRun.mesh_types class attribute instead.
+
+        Override this method to return the mesh class and mesh metadata.
+        """
+        warnings.warn(
+            "_mesh_factory is deprecated, use CopickRun.mesh_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.mesh_types
 
     def new_segmentation(
         self,
@@ -1055,7 +1096,7 @@ class CopickRun:
                 f"Segmentation by user/tool {uid} already exist in session {session_id} with name {name}, voxel size of {voxel_size}, and has a multilabel flag of {is_multilabel}.",
             )
 
-        clz, meta_clz = self._segmentation_factory()
+        clz, meta_clz = self.segmentation_types
 
         sm = meta_clz(
             is_multilabel=is_multilabel,
@@ -1078,8 +1119,16 @@ class CopickRun:
         return seg
 
     def _segmentation_factory(self) -> Tuple[Type["CopickSegmentation"], Type["CopickSegmentationMeta"]]:
-        """Override this method to return the segmentation class and segmentation metadata class."""
-        return CopickSegmentation, CopickSegmentationMeta
+        """DEPRECATED, use CopickRun.segmentation_types class attribute instead.
+
+        Override this method to return the segmentation class and segmentation metadata class.
+        """
+        warnings.warn(
+            "_segmentation_factory is deprecated, use CopickRun.segmentation_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.segmentation_types
 
     def refresh_voxel_spacings(self) -> None:
         """Refresh the voxel spacings."""
@@ -1199,7 +1248,7 @@ class CopickVoxelSpacing:
         if tomo_type in [tomo.tomo_type for tomo in self.tomograms]:
             raise ValueError(f"Tomogram type {tomo_type} already exists for this voxel spacing.")
 
-        clz, meta_clz = self._tomogram_factory()
+        clz, meta_clz = self.tomogram_types
 
         tm = meta_clz(tomo_type=tomo_type, **kwargs)
         tomo = clz(voxel_spacing=self, meta=tm)
@@ -1215,8 +1264,16 @@ class CopickVoxelSpacing:
         return tomo
 
     def _tomogram_factory(self) -> Tuple[Type["CopickTomogram"], Type["CopickTomogramMeta"]]:
-        """Override this method to return the tomogram class."""
-        return CopickTomogram, CopickTomogramMeta
+        """DEPRECATED, use CopickVoxelSpacing.tomogram_types class attribute instead.
+
+        Override this method to return the tomogram class.
+        """
+        warnings.warn(
+            "_tomogram_factory is deprecated, use CopickVoxelSpacing.tomogram_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.tomogram_types
 
     def ensure(self, create: bool = False) -> bool:
         """Override to check if the voxel spacing record exists, optionally create it if it does not.
@@ -1301,7 +1358,7 @@ class CopickTomogram:
         if feature_type in [f.feature_type for f in self.features]:
             raise ValueError(f"Feature type {feature_type} already exists for this tomogram.")
 
-        clz, meta_clz = self._feature_factory()
+        clz, meta_clz = self.features_types
 
         fm = meta_clz(tomo_type=self.tomo_type, feature_type=feature_type, **kwargs)
         feat = clz(tomogram=self, meta=fm)
@@ -1318,8 +1375,16 @@ class CopickTomogram:
         return feat
 
     def _feature_factory(self) -> Tuple[Type["CopickFeatures"], Type["CopickFeaturesMeta"]]:
-        """Override this method to return the features class and features metadata class."""
-        return CopickFeatures, CopickFeaturesMeta
+        """DEPRECATED, use CopickTomogram.features_types class attribute instead.
+
+        Override this method to return the features class and features metadata class.
+        """
+        warnings.warn(
+            "_feature_factory is deprecated, use CopickTomogram.features_types class attribute instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.features_types
 
     def query_features(self) -> List["CopickFeatures"]:
         """Override this method to query for features."""


### PR DESCRIPTION
This PR deprecates the `_[entity]_factory` methods and introduces class attributes instead. This should enable better type checking and make it generally easier to read and use the classes. 