### PR TITLE
fix: Make cryoET data portal implementation compatible with python 3.9

### DIFF
--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -641,6 +641,9 @@ class CopickRunCDP(CopickRunOverlay):
         sessions = [n.split("_")[1] for n in names]
         objects = [n.split("_")[2] for n in names]
 
+        # TODO: zip(strict=True) (replace once python 3.9 is EOL)
+        assert len(users) == len(sessions) == len(objects)
+
         return [
             CopickPicksCDP(
                 run=self,
@@ -651,7 +654,7 @@ class CopickRunCDP(CopickRunOverlay):
                 ),
                 read_only=False,
             )
-            for u, s, o in zip(users, sessions, objects, strict=True)
+            for u, s, o in zip(users, sessions, objects)
         ]
 
     def get_picks(
@@ -723,7 +726,7 @@ class CopickRunCDP(CopickRunOverlay):
                 ),
                 read_only=False,
             )
-            for u, s, o in zip(users, sessions, objects, strict=True)
+            for u, s, o in zip(users, sessions, objects)  # , strict=True)
         ]
 
     def _query_static_segmentations(self) -> List[CopickSegmentationCDP]:

--- a/src/copick/impl/filesystem.py
+++ b/src/copick/impl/filesystem.py
@@ -554,7 +554,7 @@ class CopickRunFSSpec(CopickRunOverlay):
         sessions = [n.split("_")[1] for n in names]
         objects = [n.split("_")[2] for n in names]
 
-        # zip(strict=True) (replace once python 3.9 is EOL)
+        # TODO: zip(strict=True) (replace once python 3.9 is EOL)
         assert len(users) == len(sessions) == len(objects)
 
         return [
@@ -581,7 +581,7 @@ class CopickRunFSSpec(CopickRunOverlay):
         sessions = [n.split("_")[1] for n in names]
         objects = [n.split("_")[2] for n in names]
 
-        # zip(strict=True) (replace once python 3.9 is EOL)
+        # TODO: zip(strict=True) (replace once python 3.9 is EOL)
         assert len(users) == len(sessions) == len(objects)
 
         return [
@@ -611,7 +611,7 @@ class CopickRunFSSpec(CopickRunOverlay):
         sessions = [n.split("_")[1] for n in names]
         objects = [n.split("_")[2] for n in names]
 
-        # zip(strict=True) (replace once python 3.9 is EOL)
+        # TODO: zip(strict=True) (replace once python 3.9 is EOL)
         assert len(users) == len(sessions) == len(objects)
 
         return [
@@ -638,7 +638,7 @@ class CopickRunFSSpec(CopickRunOverlay):
         sessions = [n.split("_")[1] for n in names]
         objects = [n.split("_")[2] for n in names]
 
-        # zip(strict=True) (replace once python 3.9 is EOL)
+        # TODO: zip(strict=True) (replace once python 3.9 is EOL)
         assert len(users) == len(sessions) == len(objects)
 
         return [


### PR DESCRIPTION
Replace use of `zip(..., strict=True)` with explicit assertion.