### PR TITLE
fix: Reading annotations with shape type "Point" from portal and portal project autogen.

### DIFF
--- a/src/copick/__init__.py
+++ b/src/copick/__init__.py
@@ -1,9 +1,10 @@
 __version__ = "0.8.0"
 
-from copick.ops.open import from_czcdp_datasets, from_file
+from copick.ops.open import from_czcdp_datasets, from_file, from_string
 
 __all__ = [
     "from_file",
     "from_czcdp_datasets",
+    "from_string",
     "__version__",
 ]

--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -132,7 +132,8 @@ class CopickPicksFileCDP(CopickPicksFile):
                 data = json.loads(line)
                 x, y, z = data["location"]["x"] * vs, data["location"]["y"] * vs, data["location"]["z"] * vs
                 mat = np.eye(4, 4)
-                mat[:3, :3] = np.array(data["xyz_rotation_matrix"])
+                if shape_type == "OrientedPoint":
+                    mat[:3, :3] = np.array(data["xyz_rotation_matrix"])
                 if shape_type == "OrientedPoint":
                     point = CopickPoint(
                         location=CopickLocation(x=x, y=y, z=z),
@@ -692,8 +693,6 @@ class CopickRunCDP(CopickRunOverlay):
 
         if portal_author_query is None:
             portal_author_query = []
-
-        print(picks)
 
         # Compare the metadata
         picks = [p for p in picks if p.meta.portal_metadata.compare(portal_meta_query, portal_author_query)]

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Literal, MutableMapping, Optional, Tuple, Type, U
 import numpy as np
 import trimesh
 import zarr
-from pydantic import BaseModel, Field, field_validator
+from pydantic import AliasChoices, BaseModel, Field, field_validator
 from trimesh.parent import Geometry
 
 from copick.util.ome import fits_in_memory, segmentation_pyramid, volume_pyramid, write_ome_zarr_3d
@@ -31,7 +31,7 @@ class PickableObject(BaseModel):
     color: Optional[Tuple[int, int, int, int]] = (100, 100, 100, 255)
     emdb_id: Optional[str] = None
     pdb_id: Optional[str] = None
-    identifier: Optional[str] = Field(None, alias="go_id")
+    identifier: Optional[str] = Field(None, alias=AliasChoices("go_id", "identifier"))
     map_threshold: Optional[float] = None
     radius: Optional[float] = None
 


### PR DESCRIPTION
Annotations with shape_type "Point" do not have orientation information on the portal, so we shouldn't attempt to read it. 

Also fixes autogeneration of portal projects from dataset ids (was still relying on `go_id` field instead of `identifier`).

