### PR TITLE
Add from_string to based module import

### DIFF
--- a/src/copick/__init__.py
+++ b/src/copick/__init__.py
@@ -1,9 +1,10 @@
 __version__ = "0.7.0"
 
-from copick.ops.open import from_czcdp_datasets, from_file
+from copick.ops.open import from_czcdp_datasets, from_file, from_string
 
 __all__ = [
     "from_file",
+    "from_string",
     "from_czcdp_datasets",
     "__version__",
 ]


### PR DESCRIPTION
Ensure `copick.from_string` is available with base module import