### PR TITLE
Pin copick below zarr v3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "s3fs",
     "scikit-image",
     "trimesh",
-    "zarr",
+    "zarr<3",
     "distinctipy",
 ]
 authors = [

--- a/src/copick/__init__.py
+++ b/src/copick/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 from copick.ops.open import from_czcdp_datasets, from_file, from_string
 


### PR DESCRIPTION
We need to pin below zarr 3 for now, or update zarr usage. Currently a fresh install of copick breaks with:

`ImportError: cannot import name 'FSStore' from 'zarr.storage'`
