### PR TITLE
update docs snippet

### DIFF
--- a/docs/snippets/root_list_objects_runs.py
+++ b/docs/snippets/root_list_objects_runs.py
@@ -6,7 +6,7 @@ import copick
 root = copick.from_file("path/to/config.json")
 
 # List all available objects
-obj_info = [(o.name, o.label) for o in root.objects.values()]
+obj_info = [(o.name, o.label) for o in root.pickable_objects]
 
 print("Pickable objects in this project:")
 for name, label in obj_info:


### PR DESCRIPTION
root.objects.values() returns a syntax error, update the docs sample snippet to use the correct `CopickRoot` property. 