### PR TITLE
Fix typo in CryoET Data Portal tomogram metadata

### DIFF
--- a/src/copick/__init__.py
+++ b/src/copick/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 from copick.ops.open import from_czcdp_datasets, from_file, from_string
 

--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -473,7 +473,7 @@ class CopickTomogramMetaCDP(CopickTomogramMeta):
         portal_meta = PortalTomogramMeta.from_tomogram(source)
 
         return cls(
-            tomo_typxe=name,
+            tomo_type=name,
             portal_tomo_id=source.id,
             portal_tomo_path=source.s3_omezarr_dir,
             portal_metadata=portal_meta,


### PR DESCRIPTION
This PR fixes a typo in the `cryoet_data_portal.py` file where 'tomo_typxe' was incorrectly used instead of 'tomo_type' when creating tomogram metadata from a portal source.

The typo was in `CopickTomogramMetaCDP.from_portal` method, line 476.

Fix: Changed 'tomo_typxe=name' to 'tomo_type=name'.