### PR TITLE
Remove reference to cryoET data portal client object to make copick root picklable.

### DIFF
--- a/src/copick/__init__.py
+++ b/src/copick/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.2"
+__version__ = "1.1.0"
 
 from copick.ops.open import from_czcdp_datasets, from_file, from_string
 

--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -1,5 +1,6 @@
 import json
 import re
+import warnings
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import cryoet_data_portal as cdp
@@ -1121,12 +1122,24 @@ class CopickRootCDP(CopickRoot):
         self.fs_overlay: AbstractFileSystem = fsspec.core.url_to_fs(config.overlay_root, **config.overlay_fs_args)[0]
         self.root_overlay: str = self.fs_overlay._strip_protocol(config.overlay_root)  # noqa
 
-        client = cdp.Client()
-        self.datasets = [cdp.Dataset.get_by_id(client, did) for did in config.dataset_ids]
-
     @property
     def go_map(self) -> Dict[str, str]:
         return {po.identifier: po.name for po in self.pickable_objects if po.identifier is not None}
+
+    @property
+    def datasets(self) -> List[cdp.Dataset]:
+        warnings.warn(
+            "CopickRootCDP.datasets will be deprecated in the next release. Use CopickRootCDP.dataset_ids instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        client = cdp.Client()
+        datasets = cdp.Dataset.find(client, [cdp.Dataset.id._in(self.dataset_ids)])
+        return datasets
+
+    @property
+    def dataset_ids(self) -> List[int]:
+        return self.config.dataset_ids
 
     @classmethod
     def from_file(cls, path: str) -> "CopickRootCDP":
@@ -1143,7 +1156,7 @@ class CopickRootCDP(CopickRoot):
 
     def query(self) -> List[CopickRunCDP]:
         client = cdp.Client()
-        portal_runs = cdp.Run.find(client, [cdp.Run.dataset_id._in([d.id for d in self.datasets])])  # noqa
+        portal_runs = cdp.Run.find(client, [cdp.Run.dataset_id._in([self.dataset_ids])])  # noqa
 
         runs = []
         for pr in portal_runs:


### PR DESCRIPTION
When using python's multiprocessing, state is communicated via pickled objects. The GraphQL client that is the basis of the portal's API client results in unpicklable objects. By accident, the CopickRootCDP object had references to actual dataset objects.

This PR removes those references, and instead creates a property that computes them on the fly. This property will be removed in an upcoming major version in favor of just returning the dataset IDs. 