### PR TITLE
Add deletion and overwriting logic for copick entities

### DIFF
--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -295,6 +295,12 @@ class CopickPicksCDP(CopickPicksOverlay):
         with self.fs.open(self.path, "w") as f:
             json.dump(self.meta.dict(), f, indent=4)
 
+    def _delete_data(self) -> None:
+        if self.fs.exists(self.path):
+            self.fs.rm(self.path)
+        else:
+            raise FileNotFoundError(f"File not found: {self.path}")
+
 
 class CopickMeshCDP(CopickMeshOverlay):
     run: "CopickRunCDP"
@@ -340,6 +346,12 @@ class CopickMeshCDP(CopickMeshOverlay):
 
         with self.fs.open(self.path, "wb") as f:
             _ = self._mesh.export(f, file_type="glb")
+
+    def _delete_data(self):
+        if self.fs.exists(self.path):
+            self.fs.rm(self.path)
+        else:
+            raise FileNotFoundError(f"File not found: {self.path}")
 
 
 class CopickSegmentationMetaCDP(CopickSegmentationMeta):
@@ -420,6 +432,12 @@ class CopickSegmentationCDP(CopickSegmentationOverlay):
             create=create,
         )
 
+    def _delete_data(self) -> None:
+        if self.fs.exists(self.path):
+            self.fs.rm(self.path, recursive=True)
+        else:
+            raise FileNotFoundError(f"File not found: {self.path}")
+
 
 class CopickFeaturesCDP(CopickFeaturesOverlay):
     tomogram: "CopickTomogramCDP"
@@ -450,6 +468,12 @@ class CopickFeaturesCDP(CopickFeaturesOverlay):
             dimension_separator="/",
             create=create,
         )
+
+    def _delete_data(self) -> None:
+        if self.fs.exists(self.path):
+            self.fs.rm(self.path, recursive=True)
+        else:
+            raise FileNotFoundError(f"File not found: {self.path}")
 
 
 class CopickTomogramMetaCDP(CopickTomogramMeta):
@@ -565,6 +589,12 @@ class CopickTomogramCDP(CopickTomogramOverlay):
             dimension_separator="/",
             create=create,
         )
+
+    def _delete_data(self) -> None:
+        if self.fs_overlay.exists(self.overlay_path):
+            self.fs_overlay.rm(self.overlay_path, recursive=True)
+        else:
+            raise FileNotFoundError(f"File not found: {self.overlay_path}")
 
 
 class CopickVoxelSpacingMetaCDP(CopickVoxelSpacingMeta):
@@ -691,6 +721,12 @@ class CopickVoxelSpacingCDP(CopickVoxelSpacingOverlay):
 
         # Compare portal metadata and authors
         return [t for t in tomos if t.meta.portal_metadata.compare(portal_meta_query, portal_author_query)]
+
+    def _delete_data(self) -> None:
+        if self.fs_overlay.exists(self.overlay_path):
+            self.fs_overlay.rm(self.overlay_path, recursive=True)
+        else:
+            raise FileNotFoundError(f"File not found: {self.overlay_path}")
 
 
 class CopickRunMetaCDP(CopickRunMeta):
@@ -1076,6 +1112,12 @@ class CopickRunCDP(CopickRunOverlay):
         else:
             return exists
 
+    def _delete_data(self) -> None:
+        if self.fs_overlay.exists(self.overlay_path):
+            self.fs_overlay.rm(self.overlay_path, recursive=True)
+        else:
+            raise FileNotFoundError(f"File not found: {self.overlay_path}")
+
 
 class CopickObjectCDP(CopickObjectOverlay):
     root: "CopickRootCDP"
@@ -1111,6 +1153,12 @@ class CopickObjectCDP(CopickObjectOverlay):
             dimension_separator="/",
             create=create,
         )
+
+    def _delete_data(self) -> None:
+        if self.fs.exists(self.path):
+            self.fs.rm(self.path, recursive=True)
+        else:
+            raise FileNotFoundError(f"File not found: {self.path}")
 
 
 class CopickRootCDP(CopickRoot):

--- a/src/copick/impl/filesystem.py
+++ b/src/copick/impl/filesystem.py
@@ -96,6 +96,12 @@ class CopickPicksFSSpec(CopickPicksOverlay):
         with self.fs.open(self.path, "w") as f:
             json.dump(self.meta.dict(), f, indent=4)
 
+    def _delete_data(self) -> None:
+        if self.fs.exists(self.path):
+            self.fs.rm(self.path)
+        else:
+            raise FileNotFoundError(f"File not found: {self.path}")
+
 
 class CopickMeshFSSpec(CopickMeshOverlay):
     """CopickMesh class backed by fspec storage.
@@ -141,6 +147,12 @@ class CopickMeshFSSpec(CopickMeshOverlay):
 
         with self.fs.open(self.path, "wb") as f:
             _ = self._mesh.export(f, file_type="glb")
+
+    def _delete_data(self) -> None:
+        if self.fs.exists(self.path):
+            self.fs.rm(self.path)
+        else:
+            raise FileNotFoundError(f"File not found: {self.path}")
 
 
 class CopickSegmentationFSSpec(CopickSegmentationOverlay):
@@ -194,6 +206,13 @@ class CopickSegmentationFSSpec(CopickSegmentationOverlay):
             create=create,
         )
 
+    def _delete_data(self) -> None:
+        # Remove the segmentation folder
+        if self.fs.exists(self.path):
+            self.fs.rm(self.path, recursive=True)
+        else:
+            raise FileNotFoundError(f"File not found: {self.path}")
+
 
 class CopickFeaturesFSSpec(CopickFeaturesOverlay):
     """CopickFeatures class backed by fsspec storage.
@@ -237,6 +256,13 @@ class CopickFeaturesFSSpec(CopickFeaturesOverlay):
             dimension_separator="/",
             create=create,
         )
+
+    def _delete_data(self) -> None:
+        # Remove the features folder
+        if self.fs.exists(self.path):
+            self.fs.rm(self.path, recursive=True)
+        else:
+            raise FileNotFoundError(f"File not found: {self.path}")
 
 
 class CopickTomogramFSSpec(CopickTomogramOverlay):
@@ -358,6 +384,13 @@ class CopickTomogramFSSpec(CopickTomogramOverlay):
             create=create,
         )
 
+    def _delete_data(self) -> None:
+        # Remove the tomogram folder
+        if self.fs_overlay.exists(self.overlay_path):
+            self.fs_overlay.rm(self.overlay_path, recursive=True)
+        else:
+            raise FileNotFoundError(f"File not found: {self.overlay_path}")
+
 
 class CopickVoxelSpacingFSSpec(CopickVoxelSpacingOverlay):
     """CopickVoxelSpacing class backed by fsspec storage.
@@ -462,6 +495,13 @@ class CopickVoxelSpacingFSSpec(CopickVoxelSpacingOverlay):
             return True
         else:
             return exists
+
+    def _delete_data(self) -> None:
+        # Remove the voxel spacing folder
+        if self.fs_overlay.exists(self.overlay_path):
+            self.fs_overlay.rm(self.overlay_path, recursive=True)
+        else:
+            raise FileNotFoundError(f"File not found: {self.overlay_path}")
 
 
 class CopickRunFSSpec(CopickRunOverlay):
@@ -773,6 +813,13 @@ class CopickRunFSSpec(CopickRunOverlay):
             return True
         else:
             return exists
+
+    def _delete_data(self) -> None:
+        # Remove the run folder
+        if self.fs_overlay.exists(self.overlay_path):
+            self.fs_overlay.rm(self.overlay_path, recursive=True)
+        else:
+            raise FileNotFoundError(f"File not found: {self.overlay_path}")
 
 
 class CopickObjectFSSpec(CopickObjectOverlay):

--- a/src/copick/impl/overlay.py
+++ b/src/copick/impl/overlay.py
@@ -38,6 +38,13 @@ class CopickPicksOverlay(CopickPicks):
             raise PermissionError("Cannot store picks in a read-only source.")
         self._store()
 
+    def delete(self):
+        """Delete the picks, making sure the source is writable."""
+        if self.read_only:
+            raise PermissionError("Cannot delete picks in a read-only source.")
+
+        super().delete()
+
 
 class CopickMeshOverlay(CopickMesh):
     """CopickMesh class that keeps track of whether the mesh is read-only.
@@ -56,6 +63,13 @@ class CopickMeshOverlay(CopickMesh):
             raise PermissionError("Cannot store mesh in a read-only source.")
         self._store()
 
+    def delete(self):
+        """Delete the mesh, making sure the source is writable."""
+        if self.read_only:
+            raise PermissionError("Cannot delete mesh in a read-only source.")
+
+        super().delete()
+
 
 class CopickSegmentationOverlay(CopickSegmentation):
     """CopickSegmentation class that keeps track of whether the segmentation is read-only.
@@ -67,6 +81,13 @@ class CopickSegmentationOverlay(CopickSegmentation):
     def __init__(self, run: CopickRun, meta: CopickSegmentationMeta, read_only: bool = False):
         super().__init__(run, meta)
         self.read_only = read_only
+
+    def delete(self):
+        """Delete the segmentation, making sure the source is writable."""
+        if self.read_only:
+            raise PermissionError("Cannot delete segmentation in a read-only source.")
+
+        super().delete()
 
 
 class CopickObjectOverlay(CopickObject):
@@ -80,6 +101,13 @@ class CopickObjectOverlay(CopickObject):
         super().__init__(root, meta)
         self.read_only = read_only
 
+    def delete(self):
+        """Delete the object, making sure the source is writable."""
+        if self.read_only:
+            raise PermissionError("Cannot delete object in a read-only source.")
+
+        super().delete()
+
 
 class CopickFeaturesOverlay(CopickFeatures):
     """CopickFeatures class that keeps track of whether the features are read-only.
@@ -91,6 +119,13 @@ class CopickFeaturesOverlay(CopickFeatures):
     def __init__(self, tomogram: CopickTomogram, meta: CopickFeaturesMeta, read_only: bool = False):
         super().__init__(tomogram, meta)
         self.read_only = read_only
+
+    def delete(self):
+        """Delete the features, making sure the source is writable."""
+        if self.read_only:
+            raise PermissionError("Cannot delete features in a read-only source.")
+
+        super().delete()
 
 
 class CopickTomogramOverlay(CopickTomogram):
@@ -134,6 +169,13 @@ class CopickTomogramOverlay(CopickTomogram):
             assert f.read_only, "Features from static source must be read-only."
 
         return static + overlay
+
+    def delete(self) -> None:
+        """Delete the tomogram, making sure the source is writable."""
+        if self.read_only:
+            raise PermissionError("Cannot delete tomogram in a read-only source.")
+
+        super().delete()
 
 
 class CopickVoxelSpacingOverlay(CopickVoxelSpacing):

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -320,6 +320,14 @@ class CopickObject:
         loc = self.zarr()
         zarr.open(loc)[zarr_group][z, y, x] = data
 
+    def delete(self) -> None:
+        """Delete the object."""
+        self._delete_data()
+
+    def _delete_data(self) -> None:
+        """Override this method to delete the object data."""
+        raise NotImplementedError("_delete_data method must be implemented for CopickObject.")
+
 
 class CopickRoot:
     """Root of a copick project. Contains references to the runs and pickable objects.
@@ -434,11 +442,12 @@ class CopickRoot:
         """Refresh the list of runs."""
         self._runs = self.query()
 
-    def new_run(self, name: str, **kwargs) -> "CopickRun":
+    def new_run(self, name: str, exist_ok: bool = False, **kwargs) -> "CopickRun":
         """Create a new run.
 
         Args:
             name: Name of the run to create.
+            exist_ok: Whether to raise an error if the run already exists.
             **kwargs: Additional keyword arguments for the run metadata.
 
         Returns:
@@ -448,21 +457,47 @@ class CopickRoot:
             ValueError: If a run with the given name already exists.
         """
         if name in [r.name for r in self.runs]:
-            raise ValueError(f"Run name {name} already exists.")
+            if exist_ok:
+                run = self.get_run(name)
+            else:
+                raise ValueError(f"Run name {name} already exists.")
+        else:
+            clz, meta_clz = self._run_factory()
+            rm = meta_clz(name=name, **kwargs)
+            run = clz(self, meta=rm)
 
-        clz, meta_clz = self._run_factory()
-        rm = meta_clz(name=name, **kwargs)
-        run = clz(self, meta=rm)
+            # Append the run
+            if self._runs is None:
+                self._runs = []
+            self._runs.append(run)
 
-        # Append the run
-        if self._runs is None:
-            self._runs = []
-        self._runs.append(run)
-
-        # Ensure the run record exists
-        run.ensure(create=True)
+            # Ensure the run record exists
+            run.ensure(create=True)
 
         return run
+
+    def delete_run(self, name: str) -> None:
+        """Delete a run by name.
+
+        Args:
+            name: Name of the run to delete.
+        """
+        if self._runs is None:
+            return
+
+        to_delete = None
+        for i, run in enumerate(self.runs):
+            if run.name == name:
+                to_delete = i
+                break
+
+        if to_delete is None:
+            return
+
+        # Delete the run
+        run = self._runs.pop(to_delete)
+        run.delete()
+        del run
 
     def _run_factory(self) -> Tuple[Type["CopickRun"], Type["CopickRunMeta"]]:
         """Override this method to return the run class and run metadata class."""
@@ -815,11 +850,12 @@ class CopickRun:
 
         return ret
 
-    def new_voxel_spacing(self, voxel_size: float, **kwargs) -> "CopickVoxelSpacing":
+    def new_voxel_spacing(self, voxel_size: float, exist_ok: bool = False, **kwargs) -> "CopickVoxelSpacing":
         """Create a new voxel spacing object.
 
         Args:
             voxel_size: Voxel size value for the contained tomograms.
+            exist_ok: Whether to raise an error if the voxel spacing already exists.
             **kwargs: Additional keyword arguments for the voxel spacing metadata.
 
         Returns:
@@ -829,20 +865,23 @@ class CopickRun:
             ValueError: If a voxel spacing with the given voxel size already exists for this run.
         """
         if voxel_size in [vs.voxel_size for vs in self.voxel_spacings]:
-            raise ValueError(f"VoxelSpacing {voxel_size} already exists for this run.")
+            if exist_ok:
+                vs = self.get_voxel_spacing(voxel_size)
+            else:
+                raise ValueError(f"VoxelSpacing {voxel_size} already exists for this run.")
+        else:
+            clz, meta_clz = self._voxel_spacing_factory()
 
-        clz, meta_clz = self._voxel_spacing_factory()
+            vm = meta_clz(voxel_size=voxel_size, **kwargs)
+            vs = clz(run=self, meta=vm)
 
-        vm = meta_clz(voxel_size=voxel_size, **kwargs)
-        vs = clz(run=self, meta=vm)
+            # Append the voxel spacing
+            if self._voxel_spacings is None:
+                self._voxel_spacings = []
+            self._voxel_spacings.append(vs)
 
-        # Append the voxel spacing
-        if self._voxel_spacings is None:
-            self._voxel_spacings = []
-        self._voxel_spacings.append(vs)
-
-        # Ensure the voxel spacing record exists
-        vs.ensure(create=True)
+            # Ensure the voxel spacing record exists
+            vs.ensure(create=True)
 
         return vs
 
@@ -850,13 +889,20 @@ class CopickRun:
         """Override this method to return the voxel spacing class and voxel spacing metadata class."""
         return CopickVoxelSpacing, CopickVoxelSpacingMeta
 
-    def new_picks(self, object_name: str, session_id: str, user_id: Optional[str] = None) -> "CopickPicks":
+    def new_picks(
+        self,
+        object_name: str,
+        session_id: str,
+        user_id: Optional[str] = None,
+        exist_ok: bool = False,
+    ) -> "CopickPicks":
         """Create a new picks object.
 
         Args:
             object_name: Name of the object to pick.
             session_id: Session ID for the picks.
             user_id: User ID for the picks.
+            exist_ok: Whether to raise an error if the picks already exists.
 
         Returns:
             CopickPicks: The newly created picks object.
@@ -876,26 +922,29 @@ class CopickRun:
         if uid is None:
             raise ValueError("User ID must be set in the root config or supplied to new_picks.")
 
-        if self.get_picks(object_name=object_name, session_id=session_id, user_id=uid):
-            raise ValueError(f"Picks for {object_name} by user/tool {uid} already exist in session {session_id}.")
+        if picks := self.get_picks(object_name=object_name, session_id=session_id, user_id=uid):
+            if exist_ok:
+                picks = picks[0]
+            else:
+                raise ValueError(f"Picks for {object_name} by user/tool {uid} already exist in session {session_id}.")
+        else:
+            pm = CopickPicksFile(
+                pickable_object_name=object_name,
+                user_id=uid,
+                session_id=session_id,
+                run_name=self.name,
+            )
 
-        pm = CopickPicksFile(
-            pickable_object_name=object_name,
-            user_id=uid,
-            session_id=session_id,
-            run_name=self.name,
-        )
+            clz = self._picks_factory()
 
-        clz = self._picks_factory()
+            picks = clz(run=self, file=pm)
 
-        picks = clz(run=self, file=pm)
+            if self._picks is None:
+                self._picks = []
+            self._picks.append(picks)
 
-        if self._picks is None:
-            self._picks = []
-        self._picks.append(picks)
-
-        # Create the picks file
-        picks.store()
+            # Create the picks file
+            picks.store()
 
         return picks
 
@@ -903,13 +952,21 @@ class CopickRun:
         """Override this method to return the picks class."""
         return CopickPicks
 
-    def new_mesh(self, object_name: str, session_id: str, user_id: Optional[str] = None, **kwargs) -> "CopickMesh":
+    def new_mesh(
+        self,
+        object_name: str,
+        session_id: str,
+        user_id: Optional[str] = None,
+        exist_ok: bool = False,
+        **kwargs,
+    ) -> "CopickMesh":
         """Create a new mesh object.
 
         Args:
             object_name: Name of the object to mesh.
             session_id: Session ID for the mesh.
             user_id: User ID for the mesh.
+            exist_ok: Whether to raise an error if the mesh already exists.
             **kwargs: Additional keyword arguments for the mesh metadata.
 
         Returns:
@@ -930,30 +987,33 @@ class CopickRun:
         if uid is None:
             raise ValueError("User ID must be set in the root config or supplied to new_mesh.")
 
-        if self.get_meshes(object_name=object_name, session_id=session_id, user_id=uid):
-            raise ValueError(f"Mesh for {object_name} by user/tool {uid} already exist in session {session_id}.")
+        if mesh := self.get_meshes(object_name=object_name, session_id=session_id, user_id=uid):
+            if exist_ok:
+                mesh = mesh[0]
+            else:
+                raise ValueError(f"Mesh for {object_name} by user/tool {uid} already exist in session {session_id}.")
+        else:
+            clz, meta_clz = self._mesh_factory()
 
-        clz, meta_clz = self._mesh_factory()
+            mm = meta_clz(
+                pickable_object_name=object_name,
+                user_id=uid,
+                session_id=session_id,
+                **kwargs,
+            )
 
-        mm = meta_clz(
-            pickable_object_name=object_name,
-            user_id=uid,
-            session_id=session_id,
-            **kwargs,
-        )
+            # Need to create an empty trimesh.Trimesh object first, because empty scenes can't be exported.
+            tmesh = trimesh.Trimesh()
+            scene = tmesh.scene()
 
-        # Need to create an empty trimesh.Trimesh object first, because empty scenes can't be exported.
-        tmesh = trimesh.Trimesh()
-        scene = tmesh.scene()
+            mesh = clz(run=self, meta=mm, mesh=scene)
 
-        mesh = clz(run=self, meta=mm, mesh=scene)
+            if self._meshes is None:
+                self._meshes = []
+            self._meshes.append(mesh)
 
-        if self._meshes is None:
-            self._meshes = []
-        self._meshes.append(mesh)
-
-        # Create the mesh file
-        mesh.store()
+            # Create the mesh file
+            mesh.store()
 
         return mesh
 
@@ -968,6 +1028,7 @@ class CopickRun:
         session_id: str,
         is_multilabel: bool,
         user_id: Optional[str] = None,
+        exist_ok: bool = False,
         **kwargs,
     ) -> "CopickSegmentation":
         """Create a new segmentation object.
@@ -978,6 +1039,7 @@ class CopickRun:
             session_id: Session ID for the segmentation.
             is_multilabel: Whether the segmentation is multilabel or not.
             user_id: User ID for the segmentation.
+            exist_ok: Whether to raise an error if the segmentation already exists.
             **kwargs: Additional keyword arguments for the segmentation metadata.
 
         Returns:
@@ -999,36 +1061,40 @@ class CopickRun:
         if uid is None:
             raise ValueError("User ID must be set in the root config or supplied to new_segmentation.")
 
-        if self.get_segmentations(
+        if seg := self.get_segmentations(
             session_id=session_id,
             user_id=uid,
             name=name,
             is_multilabel=is_multilabel,
             voxel_size=voxel_size,
         ):
-            raise ValueError(
-                f"Segmentation by user/tool {uid} already exist in session {session_id} with name {name}, voxel size of {voxel_size}, and has a multilabel flag of {is_multilabel}.",
+            if exist_ok:
+                seg = seg[0]
+            else:
+                raise ValueError(
+                    f"Segmentation by user/tool {uid} already exist in session {session_id} with name {name}, "
+                    f"voxel size of {voxel_size}, and has a multilabel flag of {is_multilabel}.",
+                )
+        else:
+            clz, meta_clz = self._segmentation_factory()
+
+            sm = meta_clz(
+                is_multilabel=is_multilabel,
+                voxel_size=voxel_size,
+                user_id=uid,
+                session_id=session_id,
+                name=name,
+                **kwargs,
             )
+            seg = clz(run=self, meta=sm)
 
-        clz, meta_clz = self._segmentation_factory()
+            if self._segmentations is None:
+                self._segmentations = []
 
-        sm = meta_clz(
-            is_multilabel=is_multilabel,
-            voxel_size=voxel_size,
-            user_id=uid,
-            session_id=session_id,
-            name=name,
-            **kwargs,
-        )
-        seg = clz(run=self, meta=sm)
+            self._segmentations.append(seg)
 
-        if self._segmentations is None:
-            self._segmentations = []
-
-        self._segmentations.append(seg)
-
-        # Create the zarr store for this segmentation
-        _ = seg.zarr()
+            # Create the zarr store for this segmentation
+            _ = seg.zarr()
 
         return seg
 
@@ -1069,6 +1135,84 @@ class CopickRun:
             bool: True if the run record exists, False otherwise.
         """
         raise NotImplementedError("ensure must be implemented for CopickRun.")
+
+    def delete(self) -> None:
+        """Delete the run record."""
+        self.delete_voxel_spacings()
+        self.delete_picks()
+        self.delete_meshes()
+        self.delete_segmentations()
+
+    def delete_voxel_spacings(self, voxel_size: float = None) -> None:
+        """Delete a voxel spacing by voxel size.
+
+        Args:
+            voxel_size: Voxel size to delete.
+        """
+        if voxel_size is not None:
+            vs = self.get_voxel_spacing(voxel_size=voxel_size)
+            self._voxel_spacings.remove(vs)
+            vs.delete()
+            del vs
+        else:
+            for vs in self.voxel_spacings:
+                self._voxel_spacings.remove(vs)
+                vs.delete()
+                del vs
+
+    def delete_picks(self, object_name: str = None, user_id: str = None, session_id: str = None) -> None:
+        """Delete picks by name, user_id or session_id (or combinations).
+
+        Args:
+            object_name: Name of the object to delete.
+            user_id: User ID to delete.
+            session_id: Session ID to delete.
+        """
+        for p in self.get_picks(object_name=object_name, user_id=user_id, session_id=session_id):
+            self._picks.remove(p)
+            p.delete()
+            del p
+
+    def delete_meshes(self, object_name: str = None, user_id: str = None, session_id: str = None) -> None:
+        """Delete meshesby name, user_id or session_id (or combinations).
+
+        Args:
+            object_name: Name of the object to delete.
+            user_id: User ID to delete.
+            session_id: Session ID to delete.
+        """
+        for m in self.get_meshes(object_name=object_name, user_id=user_id, session_id=session_id):
+            self._meshes.remove(m)
+            m.delete()
+            del m
+
+    def delete_segmentations(
+        self,
+        user_id: str = None,
+        session_id: str = None,
+        is_multilabel: bool = None,
+        name: str = None,
+        voxel_size: float = None,
+    ) -> None:
+        """Delete segmentation by name, user_id or session_id (or combinations).
+
+        Args:
+            user_id: User ID to delete.
+            session_id: Session ID to delete.
+            is_multilabel: Whether the segmentation is multilabel or not.
+            name: Name of the segmentation to delete.
+            voxel_size: Voxel size to delete.
+        """
+        for s in self.get_segmentations(
+            user_id=user_id,
+            session_id=session_id,
+            is_multilabel=is_multilabel,
+            name=name,
+            voxel_size=voxel_size,
+        ):
+            self._segmentations.remove(s)
+            s.delete()
+            del s
 
 
 class CopickVoxelSpacingMeta(BaseModel):
@@ -1169,11 +1313,12 @@ class CopickVoxelSpacing:
         """Refresh `CopickVoxelSpacing.tomograms` from storage."""
         self.refresh_tomograms()
 
-    def new_tomogram(self, tomo_type: str, **kwargs) -> "CopickTomogram":
+    def new_tomogram(self, tomo_type: str, exist_ok: bool = False, **kwargs) -> "CopickTomogram":
         """Create a new tomogram object, also creates the Zarr-store in the storage backend.
 
         Args:
             tomo_type: Type of the tomogram to create.
+            exist_ok: Whether to raise an error if the tomogram already exists.
             **kwargs: Additional keyword arguments for the tomogram metadata.
 
         Returns:
@@ -1182,21 +1327,24 @@ class CopickVoxelSpacing:
         Raises:
             ValueError: If a tomogram with the given type already exists for this voxel spacing.
         """
-        if tomo_type in [tomo.tomo_type for tomo in self.tomograms]:
-            raise ValueError(f"Tomogram type {tomo_type} already exists for this voxel spacing.")
+        if tomo := self.get_tomograms(tomo_type):
+            if exist_ok:
+                tomo = tomo[0]
+            else:
+                raise ValueError(f"Tomogram type {tomo_type} already exists for this voxel spacing.")
+        else:
+            clz, meta_clz = self._tomogram_factory()
 
-        clz, meta_clz = self._tomogram_factory()
+            tm = meta_clz(tomo_type=tomo_type, **kwargs)
+            tomo = clz(voxel_spacing=self, meta=tm)
 
-        tm = meta_clz(tomo_type=tomo_type, **kwargs)
-        tomo = clz(voxel_spacing=self, meta=tm)
+            # Append the tomogram
+            if self._tomograms is None:
+                self._tomograms = []
+            self._tomograms.append(tomo)
 
-        # Append the tomogram
-        if self._tomograms is None:
-            self._tomograms = []
-        self._tomograms.append(tomo)
-
-        # Create the zarr store for this tomogram
-        _ = tomo.zarr()
+            # Create the zarr store for this tomogram
+            _ = tomo.zarr()
 
         return tomo
 
@@ -1214,6 +1362,27 @@ class CopickVoxelSpacing:
             bool: True if the voxel spacing record exists, False otherwise.
         """
         raise NotImplementedError("ensure must be implemented for CopickVoxelSpacing.")
+
+    def delete(self) -> None:
+        """Delete the voxel spacing record."""
+        self.delete_tomograms()
+
+    def delete_tomograms(self, tomo_type: str = None) -> None:
+        """Delete a tomogram by type.
+
+        Args:
+            tomo_type: Type of the tomogram to delete.
+        """
+        if tomo_type is not None:
+            for t in self.get_tomograms(tomo_type=tomo_type):
+                self._tomograms.remove(t)
+                t.delete()
+                del t
+        else:
+            for t in self.tomograms:
+                self._tomograms.remove(t)
+                t.delete()
+                del t
 
 
 class CopickTomogramMeta(BaseModel):
@@ -1288,11 +1457,12 @@ class CopickTomogram:
                 return feat
         return None
 
-    def new_features(self, feature_type: str, **kwargs) -> "CopickFeatures":
+    def new_features(self, feature_type: str, exist_ok: bool = False, **kwargs) -> "CopickFeatures":
         """Create a new feature map object. Also creates the Zarr-store for the map in the storage backend.
 
         Args:
             feature_type: Type of the feature map to create.
+            exist_ok: Whether to raise an error if the feature map already exists.
             **kwargs: Additional keyword arguments for the feature map metadata.
 
         Returns:
@@ -1301,22 +1471,25 @@ class CopickTomogram:
         Raises:
             ValueError: If a feature map with the given type already exists for this tomogram.
         """
-        if feature_type in [f.feature_type for f in self.features]:
-            raise ValueError(f"Feature type {feature_type} already exists for this tomogram.")
+        if feat := self.get_features(feature_type):
+            if exist_ok:
+                pass
+            else:
+                raise ValueError(f"Feature type {feature_type} already exists for this tomogram.")
+        else:
+            clz, meta_clz = self._feature_factory()
 
-        clz, meta_clz = self._feature_factory()
+            fm = meta_clz(tomo_type=self.tomo_type, feature_type=feature_type, **kwargs)
+            feat = clz(tomogram=self, meta=fm)
 
-        fm = meta_clz(tomo_type=self.tomo_type, feature_type=feature_type, **kwargs)
-        feat = clz(tomogram=self, meta=fm)
+            # Append the feature set
+            if self._features is None:
+                self._features = []
 
-        # Append the feature set
-        if self._features is None:
-            self._features = []
+            self._features.append(feat)
 
-        self._features.append(feat)
-
-        # Create the zarr store for this feature set
-        _ = feat.zarr()
+            # Create the zarr store for this feature set
+            _ = feat.zarr()
 
         return feat
 
@@ -1335,6 +1508,22 @@ class CopickTomogram:
     def refresh(self) -> None:
         """Refresh `CopickTomogram.features` from storage."""
         self.refresh_features()
+
+    def delete(self) -> None:
+        """Delete the tomogram record."""
+        self.delete_features()
+        self._delete_data()
+
+    def delete_features(self) -> None:
+        """Delete all features for this tomogram."""
+        for f in self.features:
+            self._features.remove(f)
+            f.delete()
+            del f
+
+    def _delete_data(self) -> None:
+        """Delete the tomogram data."""
+        raise NotImplementedError("_delete_data must be implemented for CopickTomogram.")
 
     def zarr(self) -> MutableMapping:
         """Override to return the Zarr store for this tomogram. Also needs to handle creating the store if it
@@ -1451,6 +1640,14 @@ class CopickFeatures:
     @property
     def feature_type(self) -> str:
         return self.meta.feature_type
+
+    def delete(self):
+        """Delete the feature map record."""
+        self._delete_data()
+
+    def _delete_data(self):
+        """Delete the feature map data."""
+        raise NotImplementedError("_delete_data must be implemented for CopickFeatures.")
 
     def zarr(self) -> MutableMapping:
         """Override to return the Zarr store for this feature set. Also needs to handle creating the store if it
@@ -1633,6 +1830,14 @@ class CopickPicks:
         """Refresh the points from storage."""
         self.meta = self.load()
 
+    def delete(self) -> None:
+        """Delete the pick record."""
+        self._delete_data()
+
+    def _delete_data(self) -> None:
+        """Delete the pick data."""
+        raise NotImplementedError("_delete_data must be implemented for CopickPicks.")
+
     def numpy(self) -> Tuple[np.ndarray, np.ndarray]:
         """Return the points as a [N, 3] numpy array (N, [x, y, z]) and the transforms as a [N, 4, 4] numpy array.
         Format of the transforms is:
@@ -1796,6 +2001,14 @@ class CopickMesh:
         """Refresh `CopickMesh.mesh` from storage."""
         self._mesh = self.load()
 
+    def delete(self) -> None:
+        """Delete the mesh record."""
+        self._delete_data()
+
+    def _delete_data(self) -> None:
+        """Delete the mesh data."""
+        raise NotImplementedError("_delete_data must be implemented for CopickMesh.")
+
 
 class CopickSegmentationMeta(BaseModel):
     """Datamodel for segmentation metadata.
@@ -1888,6 +2101,14 @@ class CopickSegmentation:
             return [128, 128, 128, 0]
         else:
             return self.run.root.get_object(self.name).color
+
+    def delete(self) -> None:
+        """Delete the segmentation record."""
+        self._delete_data()
+
+    def _delete_data(self) -> None:
+        """Delete the segmentation data."""
+        raise NotImplementedError("_delete_data must be implemented for CopickSegmentation.")
 
     def zarr(self) -> MutableMapping:
         """Override to return the Zarr store for this segmentation. Also needs to handle creating the store if it

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -482,20 +482,12 @@ class CopickRoot:
         Args:
             name: Name of the run to delete.
         """
-        if self._runs is None:
+        run = self.get_run(name)
+
+        if run is None:
             return
 
-        to_delete = None
-        for i, run in enumerate(self.runs):
-            if run.name == name:
-                to_delete = i
-                break
-
-        if to_delete is None:
-            return
-
-        # Delete the run
-        run = self._runs.pop(to_delete)
+        self._runs.remove(run)
         run.delete()
         del run
 
@@ -1136,12 +1128,17 @@ class CopickRun:
         """
         raise NotImplementedError("ensure must be implemented for CopickRun.")
 
+    def _delete_data(self):
+        """Override this method to delete the root data."""
+        raise NotImplementedError("_delete_data method must be implemented for CopickRun.")
+
     def delete(self) -> None:
         """Delete the run record."""
         self.delete_voxel_spacings()
         self.delete_picks()
         self.delete_meshes()
         self.delete_segmentations()
+        self._delete_data()
 
     def delete_voxel_spacings(self, voxel_size: float = None) -> None:
         """Delete a voxel spacing by voxel size.
@@ -1363,9 +1360,14 @@ class CopickVoxelSpacing:
         """
         raise NotImplementedError("ensure must be implemented for CopickVoxelSpacing.")
 
+    def _delete_data(self):
+        """Override this method to delete the voxel spacing data."""
+        raise NotImplementedError("_delete_data method must be implemented for CopickVoxelSpacing.")
+
     def delete(self) -> None:
         """Delete the voxel spacing record."""
         self.delete_tomograms()
+        self._delete_data()
 
     def delete_tomograms(self, tomo_type: str = None) -> None:
         """Delete a tomogram by type.

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -1171,7 +1171,7 @@ class CopickRun:
             del p
 
     def delete_meshes(self, object_name: str = None, user_id: str = None, session_id: str = None) -> None:
-        """Delete meshesby name, user_id or session_id (or combinations).
+        """Delete meshes by name, user_id or session_id (or combinations).
 
         Args:
             object_name: Name of the object to delete.

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -324,6 +324,10 @@ class CopickObject:
         """Delete the object."""
         self._delete_data()
 
+        # Remove the object from the root
+        if self.root._objects is not None:
+            self.root._objects.remove(self)
+
     def _delete_data(self) -> None:
         """Override this method to delete the object data."""
         raise NotImplementedError("_delete_data method must be implemented for CopickObject.")
@@ -1160,6 +1164,10 @@ class CopickRun:
         self.delete_segmentations()
         self._delete_data()
 
+        # Remove the run from the root
+        if self in self.root.runs:
+            self.root._runs.remove(self)
+
     def delete_voxel_spacings(self, voxel_size: float = None) -> None:
         """Delete a voxel spacing by voxel size.
 
@@ -1389,6 +1397,10 @@ class CopickVoxelSpacing:
         self.delete_tomograms()
         self._delete_data()
 
+        # Remove the voxel spacing from the run
+        if self in self.run.voxel_spacings:
+            self.run._voxel_spacings.remove(self)
+
     def delete_tomograms(self, tomo_type: str = None) -> None:
         """Delete a tomogram by type.
 
@@ -1536,6 +1548,10 @@ class CopickTomogram:
         self.delete_features()
         self._delete_data()
 
+        # Remove the tomogram from the voxel spacing
+        if self in self.voxel_spacing.tomograms:
+            self.voxel_spacing._tomograms.remove(self)
+
     def delete_features(self) -> None:
         """Delete all features for this tomogram."""
         for f in self.features:
@@ -1666,6 +1682,10 @@ class CopickFeatures:
     def delete(self):
         """Delete the feature map record."""
         self._delete_data()
+
+        # Remove the feature map from the tomogram
+        if self in self.tomogram.features:
+            self.tomogram._features.remove(self)
 
     def _delete_data(self):
         """Delete the feature map data."""
@@ -1856,6 +1876,10 @@ class CopickPicks:
         """Delete the pick record."""
         self._delete_data()
 
+        # Remove the pick from the run
+        if self in self.run.picks:
+            self.run._picks.remove(self)
+
     def _delete_data(self) -> None:
         """Delete the pick data."""
         raise NotImplementedError("_delete_data must be implemented for CopickPicks.")
@@ -2027,6 +2051,10 @@ class CopickMesh:
         """Delete the mesh record."""
         self._delete_data()
 
+        # Remove the mesh from the run
+        if self in self.run.meshes:
+            self.run._meshes.remove(self)
+
     def _delete_data(self) -> None:
         """Delete the mesh data."""
         raise NotImplementedError("_delete_data must be implemented for CopickMesh.")
@@ -2127,6 +2155,10 @@ class CopickSegmentation:
     def delete(self) -> None:
         """Delete the segmentation record."""
         self._delete_data()
+
+        # Remove the segmentation from the run
+        if self in self.run.segmentations:
+            self.run._segmentations.remove(self)
 
     def _delete_data(self) -> None:
         """Delete the segmentation data."""

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -1475,7 +1475,7 @@ class CopickTomogram:
         """
         if feat := self.get_features(feature_type):
             if exist_ok:
-                pass
+                return feat
             else:
                 raise ValueError(f"Feature type {feature_type} already exists for this tomogram.")
         else:

--- a/tests/test_delete_overwrite.py
+++ b/tests/test_delete_overwrite.py
@@ -1,0 +1,511 @@
+from typing import Any, Dict
+
+import pytest
+import zarr
+from copick.impl.filesystem import CopickRootFSSpec
+
+
+@pytest.fixture(params=pytest.common_cases)
+def test_payload(request) -> Dict[str, Any]:
+    payload = request.getfixturevalue(request.param)
+    payload["root"] = CopickRootFSSpec.from_file(payload["cfg_file"])
+    return payload
+
+
+def test_delete_run(test_payload: Dict[str, Any]):
+    # Setup
+    copick_root = test_payload["root"]
+    overlay_fs = test_payload["testfs_overlay"]
+    overlay_loc = test_payload["testpath_overlay"]
+
+    # Create a new run to delete
+    run_name = "TS_DELETE"
+    run = copick_root.new_run(run_name)
+    assert run in copick_root.runs, "Run not added to runs"
+
+    # Check that run exists in filesystem
+    run_path_overlay = str(overlay_loc / "ExperimentRuns" / run_name)
+    assert overlay_fs.exists(run_path_overlay), f"{run_name} not found in overlay"
+
+    # Delete the run
+    copick_root.delete_run(run_name)
+
+    # Verify run is removed from runs list
+    assert run not in copick_root.runs, "Run still in runs list"
+
+    # Verify run is removed from filesystem
+    assert not overlay_fs.exists(run_path_overlay), f"{run_name} still exists in overlay"
+
+    # TODO: decide what to do in this case
+    # Trying to delete a non-existent run should raise an error
+    # with pytest.raises(FileNotFoundError):
+    #     copick_root.delete_run(run_name)
+
+
+def test_delete_voxel_spacing(test_payload: Dict[str, Any]):
+    # Setup
+    copick_root = test_payload["root"]
+    copick_run = copick_root.get_run("TS_001")
+    overlay_fs = test_payload["testfs_overlay"]
+    overlay_loc = test_payload["testpath_overlay"]
+
+    # Create a new voxel spacing to delete
+    vs_size = 15.000
+    vs = copick_run.new_voxel_spacing(vs_size)
+    assert vs in copick_run.voxel_spacings, "Voxel spacing not added to voxel_spacings"
+
+    # Check that voxel spacing exists in filesystem
+    vs_path_overlay = str(overlay_loc / "ExperimentRuns" / "TS_001" / f"VoxelSpacing{vs_size:.3f}")
+    assert overlay_fs.exists(vs_path_overlay), f"VoxelSpacing{vs_size:.3f} not found in overlay"
+
+    # Delete the voxel spacing
+    copick_run.delete_voxel_spacings(vs_size)
+
+    # Verify voxel spacing is removed from voxel_spacings list
+    assert vs not in copick_run.voxel_spacings, "Voxel spacing still in voxel_spacings list"
+
+    # Verify voxel spacing is removed from filesystem
+    assert not overlay_fs.exists(vs_path_overlay), f"VoxelSpacing{vs_size:.3f} still exists in overlay"
+
+    # Trying to delete a non-existent voxel spacing should raise an error
+    # with pytest.raises(FileNotFoundError):
+    #     vs.delete()
+
+
+def test_delete_tomogram(test_payload: Dict[str, Any]):
+    # Setup
+    copick_root = test_payload["root"]
+    copick_run = copick_root.get_run("TS_001")
+    vs = copick_run.get_voxel_spacing(10.000)
+    overlay_fs = test_payload["testfs_overlay"]
+    overlay_loc = test_payload["testpath_overlay"]
+
+    # Create a new tomogram to delete
+    tomo_type = "delete-test"
+    tomogram = vs.new_tomogram(tomo_type=tomo_type)
+    zarr.create((5, 5, 5), store=tomogram.zarr())
+    assert tomogram in vs.tomograms, "Tomogram not added to tomograms"
+
+    # Check that tomogram exists in filesystem
+    tomo_path_overlay = str(
+        overlay_loc / "ExperimentRuns" / "TS_001" / f"VoxelSpacing{vs.voxel_size:.3f}" / f"{tomo_type}.zarr",
+    )
+    assert overlay_fs.exists(tomo_path_overlay), f"{tomo_type}.zarr not found in overlay"
+
+    # Delete the tomogram
+    tomogram.delete()
+
+    # Verify tomogram is removed from tomograms list
+    vs.refresh_tomograms()
+    assert tomogram not in vs.tomograms, "Tomogram still in tomograms list"
+
+    # Verify tomogram is removed from filesystem
+    assert not overlay_fs.exists(tomo_path_overlay), f"{tomo_type}.zarr still exists in overlay"
+
+    # Trying to delete a non-existent tomogram should raise an error
+    # with pytest.raises(FileNotFoundError):
+    #     tomogram._delete_data()
+
+
+def test_delete_features(test_payload: Dict[str, Any]):
+    # Setup
+    copick_root = test_payload["root"]
+    copick_run = copick_root.get_run("TS_001")
+    vs = copick_run.get_voxel_spacing(10.000)
+    tomogram = vs.get_tomogram(tomo_type="wbp")
+    overlay_fs = test_payload["testfs_overlay"]
+    overlay_loc = test_payload["testpath_overlay"]
+
+    # Create a new feature to delete
+    feature_type = "delete-test"
+    feature = tomogram.new_features(feature_type=feature_type)
+    zarr.create((5, 5, 5), store=feature.zarr())
+    assert feature in tomogram.features, "Feature not added to features"
+
+    # Check that feature exists in filesystem
+    feature_path_overlay = str(
+        overlay_loc
+        / "ExperimentRuns"
+        / "TS_001"
+        / f"VoxelSpacing{vs.voxel_size:.3f}"
+        / f"{tomogram.tomo_type}_{feature_type}_features.zarr",
+    )
+    assert overlay_fs.exists(
+        feature_path_overlay,
+    ), f"{tomogram.tomo_type}_{feature_type}_features.zarr not found in overlay"
+
+    # Delete the feature
+    feature.delete()
+
+    # Verify feature is removed from features list
+    tomogram.refresh_features()
+    assert feature not in tomogram.features, "Feature still in features list"
+
+    # Verify feature is removed from filesystem
+    assert not overlay_fs.exists(
+        feature_path_overlay,
+    ), f"{tomogram.tomo_type}_{feature_type}_features.zarr still exists in overlay"
+
+    # Trying to delete a non-existent feature should raise an error
+    # with pytest.raises(FileNotFoundError):
+    #     feature._delete_data()
+
+
+def test_delete_picks(test_payload: Dict[str, Any]):
+    # Setup
+    copick_root = test_payload["root"]
+    copick_run = copick_root.get_run("TS_001")
+    overlay_fs = test_payload["testfs_overlay"]
+    overlay_loc = test_payload["testpath_overlay"]
+
+    # Create a new pick to delete
+    user_id = "delete-test"
+    session_id = "12345"
+    object_name = "proteasome"
+    picks = copick_run.new_picks(object_name=object_name, session_id=session_id, user_id=user_id)
+    picks.store()
+    assert picks in copick_run.picks, "Pick not added to picks"
+
+    # Check that pick exists in filesystem
+    pick_path_overlay = str(
+        overlay_loc / "ExperimentRuns" / "TS_001" / "Picks" / f"{user_id}_{session_id}_{object_name}.json",
+    )
+    assert overlay_fs.exists(pick_path_overlay), f"{user_id}_{session_id}_{object_name}.json not found in overlay"
+
+    # Delete the pick
+    picks.delete()
+
+    # Verify pick is removed from picks list
+    copick_run.refresh_picks()
+    assert picks not in copick_run.picks, "Pick still in picks list"
+
+    # Verify pick is removed from filesystem
+    assert not overlay_fs.exists(
+        pick_path_overlay,
+    ), f"{user_id}_{session_id}_{object_name}.json still exists in overlay"
+
+    # Trying to delete a non-existent pick should raise an error
+    # with pytest.raises(FileNotFoundError):
+    #     picks._delete_data()
+
+
+def test_delete_mesh(test_payload: Dict[str, Any]):
+    # Setup
+    copick_root = test_payload["root"]
+    copick_run = copick_root.get_run("TS_001")
+    overlay_fs = test_payload["testfs_overlay"]
+    overlay_loc = test_payload["testpath_overlay"]
+
+    # Create a new mesh to delete
+    user_id = "delete-test"
+    session_id = "12345"
+    object_name = "proteasome"
+    mesh = copick_run.new_mesh(object_name=object_name, session_id=session_id, user_id=user_id)
+    # We don't actually need to store a real mesh for this test
+    assert mesh in copick_run.meshes, "Mesh not added to meshes"
+
+    # Check that mesh exists in filesystem (directory is created)
+    mesh_dir_overlay = str(overlay_loc / "ExperimentRuns" / "TS_001" / "Meshes")
+    assert overlay_fs.exists(mesh_dir_overlay), "Meshes directory not found in overlay"
+
+    # Delete the mesh
+    # This will fail since we didn't actually create a file, but that's expected
+    # with pytest.raises(FileNotFoundError):
+    #     mesh.delete()
+
+
+def test_delete_segmentation(test_payload: Dict[str, Any]):
+    # Setup
+    copick_root = test_payload["root"]
+    copick_run = copick_root.get_run("TS_001")
+    overlay_fs = test_payload["testfs_overlay"]
+    overlay_loc = test_payload["testpath_overlay"]
+
+    # Create a new segmentation to delete
+    user_id = "delete-test"
+    session_id = "12345"
+    name = "delete-seg"
+    is_multilabel = True
+    voxel_size = 10.000
+    segmentation = copick_run.new_segmentation(
+        voxel_size=voxel_size,
+        user_id=user_id,
+        session_id=session_id,
+        name=name,
+        is_multilabel=is_multilabel,
+    )
+    zarr.create((5, 5, 5), store=segmentation.zarr())
+    assert segmentation in copick_run.segmentations, "Segmentation not added to segmentations"
+
+    # Check that segmentation exists in filesystem
+    seg_file = f"{voxel_size:.3f}_{user_id}_{session_id}_{name}-multilabel.zarr"
+    seg_path_overlay = str(overlay_loc / "ExperimentRuns" / "TS_001" / "Segmentations" / seg_file)
+    assert overlay_fs.exists(seg_path_overlay), f"{seg_file} not found in overlay"
+
+    # Delete the segmentation
+    segmentation.delete()
+
+    # Verify segmentation is removed from segmentations list
+    copick_run.refresh_segmentations()
+    assert segmentation not in copick_run.segmentations, "Segmentation still in segmentations list"
+
+    # Verify segmentation is removed from filesystem
+    assert not overlay_fs.exists(seg_path_overlay), f"{seg_file} still exists in overlay"
+
+    # Trying to delete a non-existent segmentation should raise an error
+    # with pytest.raises(FileNotFoundError):
+    #     segmentation._delete_data()
+
+
+def test_exist_ok_run(test_payload: Dict[str, Any]):
+    # Setup
+    copick_root = test_payload["root"]
+
+    # Create a new run
+    run_name = "TS_EXIST_OK"
+    run1 = copick_root.new_run(run_name)
+
+    # Attempt to create the same run without exist_ok
+    with pytest.raises(ValueError):
+        copick_root.new_run(run_name)
+
+    # Create the same run with exist_ok=True
+    run2 = copick_root.new_run(run_name, exist_ok=True)
+
+    # Verify it's the same run object
+    assert run1 == run2, "Run objects should be the same when using exist_ok=True"
+
+
+def test_exist_ok_voxel_spacing(test_payload: Dict[str, Any]):
+    # Setup
+    copick_root = test_payload["root"]
+    copick_run = copick_root.get_run("TS_001")
+
+    # Create a new voxel spacing
+    vs_size = 25.000
+    vs1 = copick_run.new_voxel_spacing(vs_size)
+
+    # Attempt to create the same voxel spacing without exist_ok
+    with pytest.raises(ValueError):
+        copick_run.new_voxel_spacing(vs_size)
+
+    # Create the same voxel spacing with exist_ok=True
+    vs2 = copick_run.new_voxel_spacing(vs_size, exist_ok=True)
+
+    # Verify it's the same voxel spacing object
+    assert vs1 == vs2, "Voxel spacing objects should be the same when using exist_ok=True"
+
+
+def test_exist_ok_tomogram(test_payload: Dict[str, Any]):
+    # Setup
+    copick_root = test_payload["root"]
+    copick_run = copick_root.get_run("TS_001")
+    vs = copick_run.get_voxel_spacing(10.000)
+
+    # Create a new tomogram
+    tomo_type = "exist-ok-test"
+    tomo1 = vs.new_tomogram(tomo_type=tomo_type)
+    zarr.create((5, 5, 5), store=tomo1.zarr())
+
+    # Attempt to create the same tomogram without exist_ok
+    with pytest.raises(ValueError):
+        vs.new_tomogram(tomo_type=tomo_type)
+
+    # Create the same tomogram with exist_ok=True
+    tomo2 = vs.new_tomogram(tomo_type=tomo_type, exist_ok=True)
+
+    # Verify it's the same tomogram object
+    assert tomo1 == tomo2, "Tomogram objects should be the same when using exist_ok=True"
+
+
+def test_exist_ok_features(test_payload: Dict[str, Any]):
+    # Setup
+    copick_root = test_payload["root"]
+    copick_run = copick_root.get_run("TS_001")
+    vs = copick_run.get_voxel_spacing(10.000)
+    tomogram = vs.get_tomogram(tomo_type="wbp")
+
+    # Create a new feature
+    feature_type = "exist-ok-test"
+    feature1 = tomogram.new_features(feature_type=feature_type)
+    zarr.create((5, 5, 5), store=feature1.zarr())
+
+    # Attempt to create the same feature without exist_ok
+    with pytest.raises(ValueError):
+        tomogram.new_features(feature_type=feature_type)
+
+    # Create the same feature with exist_ok=True
+    feature2 = tomogram.new_features(feature_type=feature_type, exist_ok=True)
+
+    # Verify it's the same feature object
+    assert feature1 == feature2, "Feature objects should be the same when using exist_ok=True"
+
+
+def test_exist_ok_picks(test_payload: Dict[str, Any]):
+    # Setup
+    copick_root = test_payload["root"]
+    copick_run = copick_root.get_run("TS_001")
+
+    # Create a new pick
+    user_id = "exist-ok-test"
+    session_id = "12345"
+    object_name = "proteasome"
+    pick1 = copick_run.new_picks(object_name=object_name, session_id=session_id, user_id=user_id)
+    pick1.store()
+
+    # Attempt to create the same pick without exist_ok
+    with pytest.raises(ValueError):
+        copick_run.new_picks(object_name=object_name, session_id=session_id, user_id=user_id)
+
+    # Create the same pick with exist_ok=True
+    pick2 = copick_run.new_picks(object_name=object_name, session_id=session_id, user_id=user_id, exist_ok=True)
+
+    # Verify it references the same pick
+    assert pick1.path == pick2.path, "Pick objects should reference the same file when using exist_ok=True"
+
+
+def test_exist_ok_mesh(test_payload: Dict[str, Any]):
+    # Setup
+    copick_root = test_payload["root"]
+    copick_run = copick_root.get_run("TS_001")
+
+    # Create a new mesh
+    user_id = "exist-ok-test"
+    session_id = "12345"
+    object_name = "proteasome"
+    mesh1 = copick_run.new_mesh(object_name=object_name, session_id=session_id, user_id=user_id)
+
+    # Attempt to create the same mesh without exist_ok
+    with pytest.raises(ValueError):
+        copick_run.new_mesh(object_name=object_name, session_id=session_id, user_id=user_id)
+
+    # Create the same mesh with exist_ok=True
+    mesh2 = copick_run.new_mesh(object_name=object_name, session_id=session_id, user_id=user_id, exist_ok=True)
+
+    # Verify it references the same mesh
+    assert mesh1.path == mesh2.path, "Mesh objects should reference the same file when using exist_ok=True"
+
+
+def test_exist_ok_segmentation(test_payload: Dict[str, Any]):
+    # Setup
+    copick_root = test_payload["root"]
+    copick_run = copick_root.get_run("TS_001")
+
+    # Create a new segmentation
+    user_id = "exist-ok-test"
+    session_id = "12345"
+    name = "exist-ok-seg"
+    is_multilabel = True
+    voxel_size = 10.000
+    seg1 = copick_run.new_segmentation(
+        voxel_size=voxel_size,
+        user_id=user_id,
+        session_id=session_id,
+        name=name,
+        is_multilabel=is_multilabel,
+    )
+    zarr.create((5, 5, 5), store=seg1.zarr())
+
+    # Attempt to create the same segmentation without exist_ok
+    with pytest.raises(ValueError):
+        copick_run.new_segmentation(
+            voxel_size=voxel_size,
+            user_id=user_id,
+            session_id=session_id,
+            name=name,
+            is_multilabel=is_multilabel,
+        )
+
+    # Create the same segmentation with exist_ok=True
+    seg2 = copick_run.new_segmentation(
+        voxel_size=voxel_size,
+        user_id=user_id,
+        session_id=session_id,
+        name=name,
+        is_multilabel=is_multilabel,
+        exist_ok=True,
+    )
+
+    # Verify it references the same segmentation
+    assert seg1.path == seg2.path, "Segmentation objects should reference the same file when using exist_ok=True"
+
+
+def test_delete_collections(test_payload: Dict[str, Any]):
+    # Setup
+    copick_root = test_payload["root"]
+    copick_run = copick_root.get_run("TS_001")
+    overlay_fs = test_payload["testfs_overlay"]
+    overlay_loc = test_payload["testpath_overlay"]
+
+    # Create multiple entities to test batch deletion
+    user_id = "delete-batch"
+
+    # Create multiple picks (proteasome and ribosome)
+    picks1 = copick_run.new_picks(object_name="proteasome", session_id="batch1", user_id=user_id)
+    picks1.store()
+    picks2 = copick_run.new_picks(object_name="ribosome", session_id="batch1", user_id=user_id)
+    picks2.store()
+    picks3 = copick_run.new_picks(object_name="proteasome", session_id="batch2", user_id=user_id)
+    picks3.store()
+
+    # Create multiple meshes
+    copick_run.new_mesh(object_name="proteasome", session_id="batch1", user_id=user_id)
+    copick_run.new_mesh(object_name="membrane", session_id="batch1", user_id=user_id)
+
+    # Create multiple segmentations
+    seg1 = copick_run.new_segmentation(
+        voxel_size=10.000,
+        user_id=user_id,
+        session_id="batch1",
+        name="ribosome",
+        is_multilabel=False,
+    )
+    zarr.create((5, 5, 5), store=seg1.zarr())
+
+    seg2 = copick_run.new_segmentation(
+        voxel_size=10.000,
+        user_id=user_id,
+        session_id="batch2",
+        name="segment2",
+        is_multilabel=True,
+    )
+    zarr.create((5, 5, 5), store=seg2.zarr())
+
+    # Refresh to ensure all entities are tracked
+    copick_run.refresh()
+
+    # Test deleting picks by user_id
+    copick_run.delete_picks(user_id=user_id, session_id="batch1")
+    copick_run.refresh_picks()
+
+    # Verify picks1 and picks2 are deleted, but picks3 remains
+    pick_path1 = str(overlay_loc / "ExperimentRuns" / "TS_001" / "Picks" / f"{user_id}_batch1_proteasome.json")
+    pick_path2 = str(overlay_loc / "ExperimentRuns" / "TS_001" / "Picks" / f"{user_id}_batch1_ribosome.json")
+    pick_path3 = str(overlay_loc / "ExperimentRuns" / "TS_001" / "Picks" / f"{user_id}_batch2_proteasome.json")
+
+    assert not overlay_fs.exists(pick_path1), "Pick1 still exists"
+    assert not overlay_fs.exists(pick_path2), "Pick2 still exists"
+    assert overlay_fs.exists(pick_path3), "Pick3 should still exist"
+
+    # Test deleting all meshes by user_id
+    copick_run.delete_meshes(user_id=user_id)
+    copick_run.refresh_meshes()
+
+    # Test deleting segmentations by multiple criteria
+    copick_run.delete_segmentations(user_id=user_id, is_multilabel=True)
+    copick_run.refresh_segmentations()
+
+    # Verify seg2 is deleted but seg1 remains
+    seg_path1 = str(
+        overlay_loc / "ExperimentRuns" / "TS_001" / "Segmentations" / f"10.000_{user_id}_batch1_ribosome.zarr",
+    )
+    seg_path2 = str(
+        overlay_loc
+        / "ExperimentRuns"
+        / "TS_001"
+        / "Segmentations"
+        / f"10.000_{user_id}_batch2_segment2-multilabel.zarr",
+    )
+
+    assert overlay_fs.exists(seg_path1), "Seg1 should still exist"
+    assert not overlay_fs.exists(seg_path2), "Seg2 still exists"


### PR DESCRIPTION
This PR adds deletion and overwrite logic for: 
- `CopickRun`
- `CopickVoxelSpacing`
- `CopickTomogram`
- `CopickFeatures`
- `CopickPicks`
- `CopickMesh`
- `CopickSegmentation`

##Deletion Features
Added methods to delete various entities from both memory and filesystem:
- Run deletion  (`CopickRun.delete`)
- Tomogram deletion (`CopickTomogram.delete`)
- Feature deletion (`CopickFeatures.delete`)
- Picks deletion (`CopickPicks.delete`)
- Mesh deletion (`CopickMesh.delete`)
- Segmentation deletion (`CopickSegmentation.delete`)

Added cascading batch deletion methods for collections:
- `CopickRoot`
   - `CopickRoot.delete_run`
- `CopickRun`
   - `CopickRun.delete_voxel_spacings` with filtering by `voxel_spacing`
   - `CopickRun.delete_picks` with filtering by `object_name`, `user_id` and `session_id`
   - `CopickRun.delete_meshes with filtering by `object_name`, `user_id` and `session_id`
   - `CopickRun.delete_segmentations with filtering by `user_id`, `session_id`, `is_multilabel`, `name`, and `voxel_size`

##Exist_ok Parameter
Added `exist_ok` parameter to all creation methods (`Entity.___`):
1. When `exist_ok=True`, attempting to create an entity that already exists will return the existing entity instead of raising an error
2. When `exist_ok=False` (default), attempting to create a duplicate entity will raise a `ValueError`
Supported for all entity types (runs, voxel spacings, tomograms, features, picks, meshes, and segmentations)

