### PR TITLE
chore: Migrate docs workflow to uv pip

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -14,14 +14,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.10"
+          version: "0.7.13"
+          python-version: "3.12"
 
-      - name: Install dependencies
-        run: |
-          pip install -e ".[docs]"
+      - name: Install copick
+        run: uv sync --locked --extra docs
 
       # Build the book
       - name: Build the book


### PR DESCRIPTION
The docs workflow was broken because of a known issue in pip 25.1.1. This PR migrates it to use `uv pip`.