### PR TITLE
fix: remove requirement for providing objects when generating a local config project

### DIFF
--- a/src/copick/cli/config.py
+++ b/src/copick/cli/config.py
@@ -107,7 +107,7 @@ def dataportal(
     type=str,
     multiple=True,
     callback=parse_object,
-    required=True,
+    required=False,
     help="List of desired objects in the format: name,is_particle,[radius],[pdb_id]. Repeat this option for multiple objects.",
 )
 @click.option(


### PR DESCRIPTION
Previous implementation required for pickable objects to be provided, which shouldn't be necessary in all instances.  