### PR TITLE
feat: Add ability to add objects.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -149,6 +149,9 @@ Add entities to Copick projects.
 **Subcommands:**
 
 - [`copick add tomogram`](#copick-add-tomogram) - Add a tomogram to the project
+- [`copick add segmentation`](#copick-add-segmentation) - Add a segmentation to the project
+- [`copick add object`](#copick-add-object) - Add a pickable object to the project configuration
+- [`copick add object-volume`](#copick-add-object-volume) - Add volume data to an existing pickable object
 
 #### :material-cube: `copick add tomogram`
 
@@ -210,6 +213,132 @@ copick add tomogram --config config.json --chunk-size "128,128,128" data/tomogra
 
 # Add multiple tomograms with custom settings
 copick add tomogram --config config.json --tomo-type "denoised" --voxel_size 8.0 data/processed_*.mrc
+```
+
+#### :material-layers: `copick add segmentation`
+
+Add one or more segmentations to the project from MRC or Zarr files.
+
+**Usage:**
+```bash
+copick add segmentation [OPTIONS] PATH
+```
+
+**Arguments:**
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `PATH` | Path | Path to segmentation file(s) (MRC or Zarr format) or glob pattern (e.g., `*.mrc`) |
+
+**Options:**
+
+| Option | Type | Description | Default |
+|--------|------|-------------|---------|
+| `-c, --config PATH` | Path | Path to the configuration file | Uses `COPICK_CONFIG` env var |
+| `--run TEXT` | String | The name of the run. If not specified, will use the name of the file (stripping extension), ignored if PATH is glob pattern. | `""` |
+| `--voxel-size FLOAT` | Float | Voxel size in Angstrom (overrides header value) | None |
+| `--name TEXT` | String | Name of the segmentation | None |
+| `--user-id TEXT` | String | User ID of the segmentation | `copick` |
+| `--session-id TEXT` | String | Session ID of the segmentation | `1` |
+| `--overwrite / --no-overwrite` | Boolean | Overwrite the object if it exists | `no-overwrite` |
+| `--create / --no-create` | Boolean | Create the object if it does not exist | `create` |
+| `--debug / --no-debug` | Boolean | Enable debug logging | `no-debug` |
+
+**Examples:**
+
+```bash
+# Add single segmentation with default settings
+copick add segmentation --config config.json --run TS_001 --name membrane data/segmentation.mrc
+
+# Add multiple segmentations using glob pattern
+copick add segmentation --config config.json --name organelles data/segmentations/*.mrc
+
+# Add segmentation with custom user and session
+copick add segmentation --config config.json --run TS_001 --name mitochondria --user-id alice --session-id 2 data/mito_seg.mrc
+
+# Add segmentation with custom voxel size
+copick add segmentation --config config.json --run TS_001 --name membrane --voxel-size 10.0 data/membrane.zarr
+```
+
+#### :material-shape: `copick add object`
+
+Add a pickable object to the project configuration.
+
+**Usage:**
+```bash
+copick add object [OPTIONS]
+```
+
+**Options:**
+
+| Option | Type | Description | Default |
+|--------|------|-------------|---------|
+| `-c, --config PATH` | Path | Path to the configuration file | Uses `COPICK_CONFIG` env var |
+| `--name TEXT` | String | Name of the object to add (required) | None |
+| `--object-type CHOICE` | String | Type of object: 'particle' or 'segmentation' | `particle` |
+| `--label INTEGER` | Integer | Numeric label/id for the object. If not provided, will use the next available label | None |
+| `--color TEXT` | String | RGBA color for the object as comma-separated values (e.g. '255,0,0,255' for red) | None |
+| `--emdb-id TEXT` | String | EMDB ID for the object | None |
+| `--pdb-id TEXT` | String | PDB ID for the object | None |
+| `--identifier TEXT` | String | Identifier for the object (e.g. Gene Ontology ID or UniProtKB accession) | None |
+| `--map-threshold FLOAT` | Float | Threshold to apply to the map when rendering the isosurface | None |
+| `--radius FLOAT` | Float | Radius of the particle, when displaying as a sphere | `50` |
+| `--volume PATH` | Path | Path to volume file to associate with the object | None |
+| `--volume-format CHOICE` | String | Format of the volume file ('mrc' or 'zarr') | Auto-detected |
+| `--voxel-size FLOAT` | Float | Voxel size for the volume data. Required if volume is provided | None |
+| `--exist-ok / --no-exist-ok` | Boolean | Whether existing objects with the same name should be overwritten | `no-exist-ok` |
+| `--debug / --no-debug` | Boolean | Enable debug logging | `no-debug` |
+
+**Examples:**
+
+```bash
+# Add a basic particle object
+copick add object --config config.json --name ribosome --object-type particle --radius 120
+
+# Add a particle with PDB reference and custom color
+copick add object --config config.json --name ribosome --object-type particle --radius 120 --pdb-id 4V9D --color "255,0,0,255"
+
+# Add a segmentation object with custom label
+copick add object --config config.json --name membrane --object-type segmentation --label 1 --color "0,255,0,128"
+
+# Add a particle with associated volume data
+copick add object --config config.json --name proteasome --object-type particle --radius 80 --volume data/proteasome.mrc --voxel-size 10.0
+
+# Add object with EMDB reference and identifier
+copick add object --config config.json --name apoferritin --object-type particle --emdb-id EMD-1234 --identifier "GO:0006826" --radius 60
+```
+
+#### :material-cube-outline: `copick add object-volume`
+
+Add volume data to an existing pickable object.
+
+**Usage:**
+```bash
+copick add object-volume [OPTIONS]
+```
+
+**Options:**
+
+| Option | Type | Description | Default |
+|--------|------|-------------|---------|
+| `-c, --config PATH` | Path | Path to the configuration file | Uses `COPICK_CONFIG` env var |
+| `--object-name TEXT` | String | Name of the existing object (required) | None |
+| `--volume-path PATH` | Path | Path to the volume file (required) | None |
+| `--volume-format CHOICE` | String | Format of the volume file ('mrc' or 'zarr') | Auto-detected |
+| `--voxel-size FLOAT` | Float | Voxel size of the volume data in Angstrom | None |
+| `--debug / --no-debug` | Boolean | Enable debug logging | `no-debug` |
+
+**Examples:**
+
+```bash
+# Add volume data to an existing object
+copick add object-volume --config config.json --object-name ribosome --volume-path data/ribosome_volume.mrc
+
+# Add volume with custom voxel size
+copick add object-volume --config config.json --object-name proteasome --volume-path data/proteasome.zarr --voxel-size 8.0
+
+# Add volume with explicit format specification
+copick add object-volume --config config.json --object-name membrane --volume-path data/membrane_vol --volume-format zarr
 ```
 
 ---
@@ -417,7 +546,7 @@ copick browse
 
 ### Add Data to Project
 
-Add tomograms and create annotation templates:
+Add tomograms, segmentations, and objects to your project:
 
 ```bash
 # Add a single tomogram
@@ -425,6 +554,16 @@ copick add tomogram --run TS_001 data/tomogram.mrc
 
 # Add multiple tomograms using glob pattern
 copick add tomogram data/tomograms/*.mrc
+
+# Add pickable objects to the project configuration
+copick add object --name ribosome --object-type particle --radius 120 --pdb-id 4V9D --color "255,0,0,255"
+copick add object --name membrane --object-type segmentation --label 1 --color "0,255,0,128"
+
+# Add volume data to existing objects
+copick add object-volume --object-name ribosome --volume-path data/ribosome_reference.mrc --voxel-size 10.0
+
+# Add segmentation data
+copick add segmentation --run TS_001 --name membrane --user-id analyst data/membrane_seg.mrc
 
 # Create empty picks for annotation
 copick new picks --particle-name ribosome

--- a/src/copick/cli/add.py
+++ b/src/copick/cli/add.py
@@ -398,7 +398,7 @@ def segmentation(
 )
 @add_debug_option
 @click.pass_context
-def object_definition(
+def object(
     ctx,
     config: str,
     name: str,

--- a/src/copick/cli/add.py
+++ b/src/copick/cli/add.py
@@ -382,6 +382,13 @@ def segmentation(
     show_default=True,
 )
 @click.option(
+    "--exist-ok/--no-exist-ok",
+    is_flag=True,
+    default=False,
+    help="Whether existing objects with the same name should be overwritten.",
+    show_default=True,
+)
+@click.option(
     "--voxel-size",
     type=float,
     default=None,
@@ -404,6 +411,7 @@ def object_definition(
     volume: str,
     volume_format: str,
     voxel_size: float,
+    exist_ok: bool,
     debug: bool,
 ):
     """
@@ -476,7 +484,7 @@ def object_definition(
             radius=radius,
             volume=volume_data,
             voxel_size=voxel_size,
-            exist_ok=False,
+            exist_ok=exist_ok,
             save_config=True,
             config_path=config,
             log=debug,

--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -1231,3 +1231,16 @@ class CopickRootCDP(CopickRoot):
             runs.append(CopickRunCDP(root=self, meta=rm))
 
         return runs
+
+    def _query_objects(self):
+        """Override to create objects from config. For CryoET Data Portal, objects are always writable since they only exist in overlay."""
+        clz, meta_clz = self._object_factory()
+        objects = []
+
+        for obj_meta in self.config.pickable_objects:
+            # For CryoET Data Portal, objects are always writable (read_only=False)
+            # since they only exist in the overlay filesystem
+            obj = clz(self, obj_meta, read_only=False)
+            objects.append(obj)
+
+        self._objects = objects

--- a/src/copick/impl/overlay.py
+++ b/src/copick/impl/overlay.py
@@ -100,7 +100,7 @@ class CopickObjectOverlay(CopickObject):
         read_only (bool): Whether the object is read-only.
     """
 
-    def __init__(self, root: CopickRoot, meta: PickableObject, read_only: bool = True):
+    def __init__(self, root: CopickRoot, meta: PickableObject, read_only: bool = False):
         super().__init__(root, meta)
         self.read_only = read_only
 

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -566,7 +566,7 @@ class CopickRoot:
             identifier: Identifier for the object (e.g. Gene Ontology ID or UniProtKB accession).
             map_threshold: Threshold to apply to the map when rendering the isosurface.
             radius: Radius of the particle, when displaying as a sphere.
-            exist_ok: Whether to raise an error if the object already exists.
+            exist_ok: Whether existing objects with the same name should be overwritten..
 
         Returns:
             CopickObject: The newly created object.

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -448,11 +448,14 @@ class CopickRoot:
 
         return None
 
+    def _query_objects(self):
+        clz, meta_clz = self._object_factory()
+        self._objects = [clz(self, meta=obj) for obj in self.config.pickable_objects]
+
     @property
     def pickable_objects(self) -> List["CopickObject"]:
         if self._objects is None:
-            clz, meta_clz = self._object_factory()
-            self._objects = [clz(self, meta=obj) for obj in self.config.pickable_objects]
+            self._query_objects()
 
         return self._objects
 
@@ -474,6 +477,16 @@ class CopickRoot:
     def refresh(self) -> None:
         """Refresh the list of runs."""
         self._runs = self.query()
+        self._objects = None  # Reset objects to force reloading
+
+    def save_config(self, config_path: str) -> None:
+        """Save the configuration to a JSON file.
+
+        Args:
+            config_path: Path to the configuration file to save.
+        """
+        with open(config_path, "w") as f:
+            json.dump(self.config.model_dump(), f, indent=4)
 
     def new_run(self, name: str, exist_ok: bool = False, **kwargs) -> "CopickRun":
         """Create a new run.
@@ -527,6 +540,106 @@ class CopickRoot:
     def _run_factory(self) -> Tuple[Type["CopickRun"], Type["CopickRunMeta"]]:
         """Override this method to return the run class and run metadata class."""
         return CopickRun, CopickRunMeta
+
+    def new_object(
+        self,
+        name: str,
+        is_particle: bool,
+        label: Optional[int] = None,
+        color: Optional[Tuple[int, int, int, int]] = None,
+        emdb_id: Optional[str] = None,
+        pdb_id: Optional[str] = None,
+        identifier: Optional[str] = None,
+        map_threshold: Optional[float] = None,
+        radius: Optional[float] = None,
+        exist_ok: bool = False,
+    ) -> "CopickObject":
+        """Create a new pickable object and add it to the configuration.
+
+        Args:
+            name: Name of the object.
+            is_particle: Whether this object should be represented by points (True) or segmentation masks (False).
+            label: Numeric label/id for the object. If None, will use the next available label.
+            color: RGBA color for the object. If None, will use a default color.
+            emdb_id: EMDB ID for the object.
+            pdb_id: PDB ID for the object.
+            identifier: Identifier for the object (e.g. Gene Ontology ID or UniProtKB accession).
+            map_threshold: Threshold to apply to the map when rendering the isosurface.
+            radius: Radius of the particle, when displaying as a sphere.
+            exist_ok: Whether to raise an error if the object already exists.
+
+        Returns:
+            CopickObject: The newly created object.
+
+        Raises:
+            ValueError: If an object with the given name already exists and exist_ok is False.
+        """
+        sane_name = sanitize_name(name)
+
+        if name != sane_name:
+            raise ValueError(
+                f"Object name '{name}' contains invalid characters. Use copick.escape.sanitize_name() to clean it.",
+            )
+        name = sane_name
+
+        # Check if the object already exists
+        obj = self.get_object(name)
+        if obj and not exist_ok:
+            raise ValueError(f"Object name {name} already exists.")
+
+        if obj:
+            obj.meta.is_particle = is_particle
+            obj.meta.label = label if label else obj.label
+            obj.meta.color = color if color else obj.color
+            obj.meta.emdb_id = emdb_id if emdb_id else obj.emdb_id
+            obj.meta.pdb_id = pdb_id if pdb_id else obj.pdb_id
+            obj.meta.identifier = identifier if identifier else obj.identifier
+            obj.meta.map_threshold = map_threshold if map_threshold else obj.map_threshold
+            obj.meta.radius = radius if radius else obj.radius
+        else:
+            # Check for duplicate label BEFORE auto-assignment
+            if label is not None:
+                existing_labels = {obj.label for obj in self.config.pickable_objects if obj.label is not None}
+
+                if label in existing_labels:
+                    raise ValueError(f"Object label {label} already exists.")
+
+            # Auto-assign label if not provided
+            if label is None:
+                existing_labels = [obj.label for obj in self.config.pickable_objects if obj.label is not None]
+                label = max(existing_labels) + 1 if existing_labels else 1
+
+            # Use default color if not provided
+            if color is None:
+                color = (100, 100, 100, 255)
+
+            # Create the pickable object metadata
+            pickable_meta = PickableObject(
+                name=name,
+                is_particle=is_particle,
+                label=label,
+                color=color,
+                emdb_id=emdb_id,
+                pdb_id=pdb_id,
+                identifier=identifier,
+                map_threshold=map_threshold,
+                radius=radius,
+            )
+
+            # Add to configuration
+            self.config.pickable_objects.append(pickable_meta)
+
+            # Create the object and add to cache
+            clz, _ = self._object_factory()
+            obj = clz(self, pickable_meta, read_only=False)
+
+            # Ensure the objects cache is initialized before appending
+            if self._objects is None:
+                # This will initialize self._objects
+                _ = self.pickable_objects
+            self._objects.append(obj)
+
+        return obj
 
     def _object_factory(self) -> Tuple[Type["CopickObject"], Type["PickableObject"]]:
         """Override this method to return the object class and object metadata class."""

--- a/src/copick/ops/add.py
+++ b/src/copick/ops/add.py
@@ -447,7 +447,7 @@ def add_object(
         radius: Radius of the particle, when displaying as a sphere.
         volume: Optional volume data to associate with the object.
         voxel_size: Voxel size for the volume data. Required if volume is provided.
-        exist_ok: Whether to raise an error if the object already exists.
+        exist_ok: Whether existing objects with the same name should be overwritten..
         save_config: Whether to save the configuration to disk after adding the object.
         config_path: Path to save the configuration. Required if save_config is True.
         log: Whether to log the operation.

--- a/src/copick/ops/add.py
+++ b/src/copick/ops/add.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import mrcfile
 import numpy as np
@@ -8,6 +8,7 @@ from ome_zarr.writer import write_multiscale
 
 from copick.models import (
     CopickFeatures,
+    CopickObject,
     CopickRoot,
     CopickRun,
     CopickTomogram,
@@ -411,3 +412,139 @@ def add_segmentation(
         logging.log(logging.INFO, f"Added segmentation {name} to run {runobj.name}.")
 
     return segmentation
+
+
+def add_object(
+    root: CopickRoot,
+    name: str,
+    is_particle: bool,
+    label: Optional[int] = None,
+    color: Optional[Tuple[int, int, int, int]] = None,
+    emdb_id: Optional[str] = None,
+    pdb_id: Optional[str] = None,
+    identifier: Optional[str] = None,
+    map_threshold: Optional[float] = None,
+    radius: Optional[float] = None,
+    volume: Optional[np.ndarray] = None,
+    voxel_size: Optional[float] = None,
+    exist_ok: bool = False,
+    save_config: bool = False,
+    config_path: Optional[str] = None,
+    log: bool = False,
+) -> CopickObject:
+    """Add a new pickable object to the copick root configuration.
+
+    Args:
+        root: The copick root object.
+        name: Name of the object.
+        is_particle: Whether this object should be represented by points (True) or segmentation masks (False).
+        label: Numeric label/id for the object. If None, will use the next available label.
+        color: RGBA color for the object. If None, will use a default color.
+        emdb_id: EMDB ID for the object.
+        pdb_id: PDB ID for the object.
+        identifier: Identifier for the object (e.g. Gene Ontology ID or UniProtKB accession).
+        map_threshold: Threshold to apply to the map when rendering the isosurface.
+        radius: Radius of the particle, when displaying as a sphere.
+        volume: Optional volume data to associate with the object.
+        voxel_size: Voxel size for the volume data. Required if volume is provided.
+        exist_ok: Whether to raise an error if the object already exists.
+        save_config: Whether to save the configuration to disk after adding the object.
+        config_path: Path to save the configuration. Required if save_config is True.
+        log: Whether to log the operation.
+
+    Returns:
+        CopickObject: The newly created object.
+
+    Raises:
+        ValueError: If volume is provided but voxel_size is not, or if save_config is True but config_path is not provided.
+    """
+    if volume is not None and voxel_size is None:
+        e = ValueError("voxel_size must be provided if volume is provided.")
+        if log:
+            logging.exception(e)
+        raise e
+
+    if save_config and config_path is None:
+        e = ValueError("config_path must be provided if save_config is True.")
+        if log:
+            logging.exception(e)
+        raise e
+
+    # Create the object
+    obj = root.new_object(
+        name=name,
+        is_particle=is_particle,
+        label=label,
+        color=color,
+        emdb_id=emdb_id,
+        pdb_id=pdb_id,
+        identifier=identifier,
+        map_threshold=map_threshold,
+        radius=radius,
+        exist_ok=exist_ok,
+    )
+
+    # Add volume data if provided
+    if volume is not None:
+        obj.from_numpy(volume, voxel_size)
+
+    # Save configuration if requested
+    if save_config:
+        root.save_config(config_path)
+
+    if log:
+        logging.log(logging.INFO, f"Added object {name} to root configuration.")
+
+    return obj
+
+
+def add_object_volume(
+    root: CopickRoot,
+    object_name: str,
+    volume: np.ndarray,
+    voxel_size: float,
+    log: bool = False,
+) -> CopickObject:
+    """Add volume data to an existing pickable object.
+
+    Args:
+        root: The copick root object.
+        object_name: Name of the existing object.
+        volume: Volume data to add.
+        voxel_size: Voxel size of the volume data.
+        log: Whether to log the operation.
+
+    Returns:
+        CopickObject: The updated object.
+
+    Raises:
+        ValueError: If the object does not exist or if the object is not a particle.
+    """
+    obj = root.get_object(object_name)
+    if obj is None:
+        e = ValueError(f"Object {object_name} not found in root configuration.")
+        if log:
+            logging.exception(e)
+        raise e
+
+    if not obj.is_particle:
+        e = ValueError(f"Object {object_name} is not a particle object and cannot have volume data.")
+        if log:
+            logging.exception(e)
+        raise e
+
+    # Check if the object is read-only
+    if obj.read_only:
+        e = ValueError(
+            f"Object {object_name} is read-only and cannot be modified. Volume data cannot be added to read-only objects.",
+        )
+        if log:
+            logging.exception(e)
+        raise e
+
+    obj.from_numpy(volume, voxel_size)
+
+    if log:
+        logging.log(logging.INFO, f"Added volume data to object {object_name}.")
+
+    return obj

--- a/src/copick/util/formats.py
+++ b/src/copick/util/formats.py
@@ -1,0 +1,50 @@
+from typing import Tuple, Union
+
+import mrcfile
+import numpy as np
+import zarr
+
+from copick.util.ome import get_voxel_size_from_zarr
+
+
+def get_format_from_extension(path: str) -> Union[str, None]:
+    """
+    Get the format name from a file extension.
+
+    Args:
+        path (str): The file path or name from which to extract the extension.
+
+    Returns:
+        str: The format name corresponding to the extension.
+    """
+    formats = {
+        "mrc": "mrc",
+        "zarr": "zarr",
+        "map": "mrc",
+    }
+    return formats.get(path.split(".")[-1], None)
+
+
+def get_data_from_file(path: str, file_format: str) -> Tuple[np.ndarray, float]:
+    """
+    Get the data from a file based on its format.
+
+    Args:
+        path (str): The file path or name.
+        file_format (str): The format of the file.
+
+    Returns:
+        (array, voxel_size): The data read from the file and the voxel size.
+    """
+    if file_format == "mrc":
+        with mrcfile.open(path) as mrc:
+            volume_data = mrc.data
+            voxel_spacing = float(mrc.voxel_size.y)  # Assuming isotropic voxel size
+    elif file_format == "zarr":
+        zarr_group = zarr.open(path)
+        volume_data = zarr_group["0"][:]
+        voxel_spacing = get_voxel_size_from_zarr(zarr_group)
+    else:
+        raise ValueError(f"Unsupported file format: {file_format}")
+
+    return volume_data, voxel_spacing

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1110,27 +1110,6 @@ class TestCLIAddObject:
 
         assert result2.exit_code == 0, f"Command failed: {result2.output}"
 
-    def test_add_object_definition_volume_without_voxel_size(self, test_payload, runner, sample_mrc_file):
-        """Test adding object with volume but no voxel size (should fail)."""
-        config_file = test_payload["cfg_file"]
-
-        result = runner.invoke(
-            add,
-            [
-                "object-definition",
-                "--config",
-                str(config_file),
-                "--name",
-                "test-no-voxel-size",
-                "--volume",
-                sample_mrc_file,
-                # Missing --voxel-size
-            ],
-        )
-
-        assert result.exit_code != 0, "Command should fail without voxel size"
-        assert "Voxel size must be provided" in result.output
-
     def test_add_object_volume_nonexistent_object(self, test_payload, runner, sample_mrc_file):
         """Test adding volume to non-existent object (should fail)."""
         config_file = test_payload["cfg_file"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -841,7 +841,7 @@ class TestCLIAddObject:
         result = runner.invoke(
             add,
             [
-                "object-definition",
+                "object",
                 "--config",
                 str(config_file),
                 "--name",
@@ -878,7 +878,7 @@ class TestCLIAddObject:
         result = runner.invoke(
             add,
             [
-                "object-definition",
+                "object",
                 "--config",
                 str(config_file),
                 "--name",
@@ -909,7 +909,7 @@ class TestCLIAddObject:
         result = runner.invoke(
             add,
             [
-                "object-definition",
+                "object",
                 "--config",
                 str(config_file),
                 "--name",
@@ -941,7 +941,7 @@ class TestCLIAddObject:
         result = runner.invoke(
             add,
             [
-                "object-definition",
+                "object",
                 "--config",
                 str(config_file),
                 "--name",
@@ -969,7 +969,7 @@ class TestCLIAddObject:
         result = runner.invoke(
             add,
             [
-                "object-definition",
+                "object",
                 "--config",
                 str(config_file),
                 "--name",
@@ -998,7 +998,7 @@ class TestCLIAddObject:
         result1 = runner.invoke(
             add,
             [
-                "object-definition",
+                "object",
                 "--config",
                 str(config_file),
                 "--name",
@@ -1011,7 +1011,7 @@ class TestCLIAddObject:
         result2 = runner.invoke(
             add,
             [
-                "object-definition",
+                "object",
                 "--config",
                 str(config_file),
                 "--name",
@@ -1036,7 +1036,7 @@ class TestCLIAddObject:
         result1 = runner.invoke(
             add,
             [
-                "object-definition",
+                "object",
                 "--config",
                 str(config_file),
                 "--name",
@@ -1079,7 +1079,7 @@ class TestCLIAddObject:
         result1 = runner.invoke(
             add,
             [
-                "object-definition",
+                "object",
                 "--config",
                 str(config_file),
                 "--name",
@@ -1139,7 +1139,7 @@ class TestCLIAddObject:
         result1 = runner.invoke(
             add,
             [
-                "object-definition",
+                "object",
                 "--config",
                 str(config_file),
                 "--name",
@@ -1176,7 +1176,7 @@ class TestCLIAddObject:
         result = runner.invoke(
             add,
             [
-                "object-definition",
+                "object",
                 "--config",
                 str(config_file),
                 "--name",
@@ -1197,7 +1197,7 @@ class TestCLIAddObject:
         runner.invoke(
             add,
             [
-                "object-definition",
+                "object",
                 "--config",
                 str(config_file),
                 "--name",

--- a/tests/test_object_models.py
+++ b/tests/test_object_models.py
@@ -1,0 +1,421 @@
+from typing import Any, Dict
+
+import numpy as np
+import pytest
+from copick.impl.filesystem import CopickRootFSSpec
+from copick.ops.add import add_object, add_object_volume
+
+
+@pytest.fixture(params=pytest.common_cases)
+def test_payload(request) -> Dict[str, Any]:
+    payload = request.getfixturevalue(request.param)
+    payload["root"] = CopickRootFSSpec.from_file(payload["cfg_file"])
+    return payload
+
+
+class TestCopickRootNewObject:
+    """Test cases for the CopickRoot.new_object method."""
+
+    def test_new_object_basic(self, test_payload):
+        """Test creating a basic object with required parameters."""
+        root = test_payload["root"]
+
+        obj = root.new_object(
+            name="test-object",
+            is_particle=True,
+        )
+
+        assert obj.name == "test-object"
+        assert obj.is_particle is True
+        assert obj.label > 0  # Should get auto-assigned label
+        assert obj.color is not None  # Should get default color
+
+    def test_new_object_with_all_parameters(self, test_payload):
+        """Test creating an object with all parameters specified."""
+        root = test_payload["root"]
+
+        obj = root.new_object(
+            name="detailed-object",
+            is_particle=False,
+            label=42,
+            color=(255, 128, 64, 255),
+            emdb_id="EMD-1234",
+            pdb_id="4V9D",
+            identifier="GO:0005840",
+            map_threshold=0.7,
+            radius=150.0,
+        )
+
+        assert obj.name == "detailed-object"
+        assert obj.is_particle is False
+        assert obj.label == 42
+        assert obj.color == (255, 128, 64, 255)
+        assert obj.emdb_id == "EMD-1234"
+        assert obj.pdb_id == "4V9D"
+        assert obj.identifier == "GO:0005840"
+        assert obj.map_threshold == 0.7
+        assert obj.radius == 150.0
+
+    def test_new_object_auto_label_assignment(self, test_payload):
+        """Test automatic label assignment for multiple objects."""
+        root = test_payload["root"]
+
+        # Create multiple objects and verify they get different labels
+        obj1 = root.new_object(name="obj1", is_particle=True)
+        obj2 = root.new_object(name="obj2", is_particle=True)
+        obj3 = root.new_object(name="obj3", is_particle=False)
+
+        labels = {obj1.label, obj2.label, obj3.label}
+        assert len(labels) == 3, "All objects should have unique labels"
+        assert all(label > 0 for label in labels), "All labels should be positive"
+
+    def test_new_object_duplicate_name_no_exist_ok(self, test_payload):
+        """Test creating object with duplicate name (should fail)."""
+        root = test_payload["root"]
+
+        # Create first object
+        root.new_object(name="duplicate-name", is_particle=True)
+
+        # Try to create second object with same name
+        with pytest.raises(ValueError, match="already exists"):
+            root.new_object(name="duplicate-name", is_particle=True, exist_ok=False)
+
+    def test_new_object_duplicate_name_with_exist_ok(self, test_payload):
+        """Test creating object with duplicate name with exist_ok=True."""
+        root = test_payload["root"]
+
+        # Create first object
+        obj1 = root.new_object(name="duplicate-name", is_particle=True)
+
+        # Create second object with same name and exist_ok=True
+        obj2 = root.new_object(name="duplicate-name", is_particle=False, exist_ok=True)
+
+        # Should return the existing object (obj1) - compare by name and properties
+        assert obj1.name == obj2.name
+        assert obj1.label == obj2.label
+
+    def test_new_object_duplicate_label_no_exist_ok(self, test_payload):
+        """Test creating object with duplicate label (should fail)."""
+        root = test_payload["root"]
+
+        # Create first object with specific label
+        root.new_object(name="obj1", is_particle=True, label=100)
+
+        # Try to create second object with same label
+        with pytest.raises(ValueError, match="already exists"):
+            root.new_object(name="obj2", is_particle=True, label=100, exist_ok=False)
+
+    def test_new_object_invalid_name_characters(self, test_payload):
+        """Test creating object with invalid name characters (should fail)."""
+        root = test_payload["root"]
+
+        # Test various invalid characters from [<>:"/\\|?*\x00-\x1F\x7F\s_]
+        invalid_names = [
+            "invalid/name",  # forward slash
+            "invalid\\name",  # backslash
+            "invalid:name",  # colon
+            "invalid<name",  # less than
+            "invalid>name",  # greater than
+            'invalid"name',  # quote
+            "invalid|name",  # pipe
+            "invalid?name",  # question mark
+            "invalid*name",  # asterisk
+            "invalid name",  # space
+            "invalid_name",  # underscore
+            "invalid\x00name",  # null character
+            "invalid\x1fname",  # control character
+            "invalid\x7fname",  # del character
+        ]
+
+        for invalid_name in invalid_names:
+            with pytest.raises(ValueError, match="invalid characters"):
+                root.new_object(name=invalid_name, is_particle=True)
+
+    def test_new_object_valid_name_characters(self, test_payload):
+        """Test creating object with valid name characters."""
+        root = test_payload["root"]
+
+        # Test valid names (letters, numbers, hyphens, dots)
+        valid_names = [
+            "validname",
+            "valid-name",
+            "valid.name",
+            "valid123",
+            "123valid",
+            "VALIDNAME",
+            "Valid-Name.123",
+        ]
+
+        for valid_name in valid_names:
+            # Should not raise an exception
+            obj = root.new_object(name=valid_name, is_particle=True)
+            assert obj.name == valid_name
+
+    def test_new_object_zero_label(self, test_payload):
+        """Test creating object with label=0 (should fail)."""
+        root = test_payload["root"]
+
+        from pydantic_core import ValidationError
+
+        with pytest.raises(ValidationError, match="Label 0 is reserved"):
+            root.new_object(name="zero-label", is_particle=True, label=0)
+
+    def test_new_object_invalid_color(self, test_payload):
+        """Test creating object with invalid color (should fail)."""
+        root = test_payload["root"]
+
+        from pydantic_core import ValidationError
+
+        # Test color with wrong number of values
+        with pytest.raises(ValidationError, match="Field required"):
+            root.new_object(name="bad-color", is_particle=True, color=(255, 0, 0))  # Missing alpha
+
+        # Test color with values out of range
+        with pytest.raises(ValidationError, match="Color values must be in the range"):
+            root.new_object(name="bad-color2", is_particle=True, color=(256, 0, 0, 255))  # 256 > 255
+
+
+class TestCopickRootSaveConfig:
+    """Test cases for the CopickRoot.save_config method."""
+
+    def test_save_config_basic(self, test_payload, tmp_path):
+        """Test saving configuration to a file."""
+        root = test_payload["root"]
+
+        # Add an object to modify the config
+        root.new_object(name="test-save", is_particle=True)
+
+        # Save to temporary file
+        config_path = tmp_path / "test-config.json"
+        root.save_config(str(config_path))
+
+        # Verify file was created
+        assert config_path.exists()
+
+        # Verify we can load the saved config
+        new_root = CopickRootFSSpec.from_file(str(config_path))
+        saved_obj = new_root.get_object("test-save")
+        assert saved_obj is not None
+        assert saved_obj.name == "test-save"
+
+    def test_save_config_preserves_objects(self, test_payload, tmp_path):
+        """Test that saving config preserves all object properties."""
+        root = test_payload["root"]
+
+        # Add object with all properties
+        original_obj = root.new_object(
+            name="full-object",
+            is_particle=False,
+            label=99,
+            color=(200, 100, 50, 255),
+            emdb_id="EMD-9999",
+            pdb_id="9ABC",
+            identifier="GO:1234567",
+            map_threshold=0.3,
+            radius=75.0,
+        )
+
+        # Save config
+        config_path = tmp_path / "full-config.json"
+        root.save_config(str(config_path))
+
+        # Load and verify
+        new_root = CopickRootFSSpec.from_file(str(config_path))
+        loaded_obj = new_root.get_object("full-object")
+
+        assert loaded_obj.name == original_obj.name
+        assert loaded_obj.is_particle == original_obj.is_particle
+        assert loaded_obj.label == original_obj.label
+        assert loaded_obj.color == original_obj.color
+        assert loaded_obj.emdb_id == original_obj.emdb_id
+        assert loaded_obj.pdb_id == original_obj.pdb_id
+        assert loaded_obj.identifier == original_obj.identifier
+        assert loaded_obj.map_threshold == original_obj.map_threshold
+        assert loaded_obj.radius == original_obj.radius
+
+
+class TestAddObjectFunction:
+    """Test cases for the add_object function."""
+
+    def test_add_object_basic(self, test_payload):
+        """Test basic object addition via add_object function."""
+        root = test_payload["root"]
+
+        obj = add_object(
+            root=root,
+            name="func-test-object",
+            is_particle=True,
+        )
+
+        assert obj.name == "func-test-object"
+        assert obj.is_particle is True
+
+        # Verify object is accessible from root
+        retrieved_obj = root.get_object("func-test-object")
+        assert retrieved_obj is not None
+        assert retrieved_obj.name == "func-test-object"
+
+    def test_add_object_with_volume(self, test_payload):
+        """Test adding object with volume data."""
+        root = test_payload["root"]
+
+        # Create sample volume data
+        np.random.seed(42)
+        volume_data = np.random.randn(32, 32, 32).astype(np.float32)
+
+        obj = add_object(
+            root=root,
+            name="object-with-volume",
+            is_particle=True,
+            volume=volume_data,
+            voxel_size=10.0,
+        )
+
+        assert obj.name == "object-with-volume"
+        # Verify volume data was stored
+        assert obj.zarr() is not None
+
+    def test_add_object_save_config(self, test_payload, tmp_path):
+        """Test adding object with config saving."""
+        root = test_payload["root"]
+        config_path = tmp_path / "saved-config.json"
+
+        add_object(
+            root=root,
+            name="save-test-object",
+            is_particle=True,
+            save_config=True,
+            config_path=str(config_path),
+        )
+
+        # Verify config was saved
+        assert config_path.exists()
+
+        # Verify object is in saved config
+        new_root = CopickRootFSSpec.from_file(str(config_path))
+        saved_obj = new_root.get_object("save-test-object")
+        assert saved_obj is not None
+
+    def test_add_object_volume_without_voxel_size(self, test_payload):
+        """Test adding object with volume but no voxel size (should fail)."""
+        root = test_payload["root"]
+        volume_data = np.random.randn(32, 32, 32).astype(np.float32)
+
+        with pytest.raises(ValueError, match="voxel_size must be provided"):
+            add_object(
+                root=root,
+                name="no-voxel-size",
+                is_particle=True,
+                volume=volume_data,
+                # Missing voxel_size
+            )
+
+    def test_add_object_save_config_without_path(self, test_payload):
+        """Test adding object with save_config=True but no config_path (should fail)."""
+        root = test_payload["root"]
+
+        with pytest.raises(ValueError, match="config_path must be provided"):
+            add_object(
+                root=root,
+                name="no-config-path",
+                is_particle=True,
+                save_config=True,
+                # Missing config_path
+            )
+
+
+class TestAddObjectVolumeFunction:
+    """Test cases for the add_object_volume function."""
+
+    def test_add_object_volume_basic(self, test_payload):
+        """Test adding volume to existing object."""
+        root = test_payload["root"]
+
+        # First create an object
+        root.new_object(name="volume-target", is_particle=True)
+
+        # Create volume data
+        np.random.seed(42)
+        volume_data = np.random.randn(32, 32, 32).astype(np.float32)
+
+        # Add volume to object
+        obj = add_object_volume(
+            root=root,
+            object_name="volume-target",
+            volume=volume_data,
+            voxel_size=15.0,
+        )
+
+        assert obj.name == "volume-target"
+        assert obj.zarr() is not None
+
+    def test_add_object_volume_nonexistent_object(self, test_payload):
+        """Test adding volume to non-existent object (should fail)."""
+        root = test_payload["root"]
+        volume_data = np.random.randn(32, 32, 32).astype(np.float32)
+
+        with pytest.raises(ValueError, match="not found in root configuration"):
+            add_object_volume(
+                root=root,
+                object_name="nonexistent-object",
+                volume=volume_data,
+                voxel_size=10.0,
+            )
+
+    def test_add_object_volume_segmentation_object(self, test_payload):
+        """Test adding volume to segmentation object (should fail)."""
+        root = test_payload["root"]
+
+        # Create a segmentation object (is_particle=False)
+        root.new_object(name="segmentation-object", is_particle=False)
+
+        volume_data = np.random.randn(32, 32, 32).astype(np.float32)
+
+        with pytest.raises(ValueError, match="not a particle object"):
+            add_object_volume(
+                root=root,
+                object_name="segmentation-object",
+                volume=volume_data,
+                voxel_size=10.0,
+            )
+
+    def test_add_object_volume_to_particle_object(self, test_payload):
+        """Test adding volume to particle object (should succeed)."""
+        root = test_payload["root"]
+
+        # Create a particle object (is_particle=True)
+        root.new_object(name="particle-object", is_particle=True)
+
+        volume_data = np.random.randn(32, 32, 32).astype(np.float32)
+
+        # This should work
+        obj = add_object_volume(
+            root=root,
+            object_name="particle-object",
+            volume=volume_data,
+            voxel_size=10.0,
+        )
+
+        assert obj.name == "particle-object"
+        assert obj.is_particle is True
+        assert obj.zarr() is not None
+
+    def test_add_object_volume_to_read_only_object(self, test_payload):
+        """Test adding volume to read-only object (should fail)."""
+        root = test_payload["root"]
+
+        # Check if we can find an existing object that might be read-only
+        existing_obj = root.get_object("proteasome")
+        if existing_obj and existing_obj.is_particle and hasattr(existing_obj, "read_only") and existing_obj.read_only:
+            volume_data = np.random.randn(32, 32, 32).astype(np.float32)
+
+            with pytest.raises(ValueError, match="read-only"):
+                add_object_volume(
+                    root=root,
+                    object_name="proteasome",
+                    volume=volume_data,
+                    voxel_size=10.0,
+                )
+        else:
+            # Skip test if no read-only objects available
+            pytest.skip("No read-only particle objects available for testing")


### PR DESCRIPTION
This PR introduces the ability to add objects to copick projects. 

### Model API
Using the model API, you can add a copick object and store the resulting config using `project.new_object` and `project.save_config`.

```python
    def new_object(
        self,
        name: str,
        is_particle: bool,
        label: Optional[int] = None,
        color: Optional[Tuple[int, int, int, int]] = None,
        emdb_id: Optional[str] = None,
        pdb_id: Optional[str] = None,
        identifier: Optional[str] = None,
        map_threshold: Optional[float] = None,
        radius: Optional[float] = None,
        exist_ok: bool = False,
    ) -> "CopickObject":
        """Create a new pickable object and add it to the configuration.

        Args:
            name: Name of the object.
            is_particle: Whether this object should be represented by points (True) or segmentation masks (False).
            label: Numeric label/id for the object. If None, will use the next available label.
            color: RGBA color for the object. If None, will use a default color.
            emdb_id: EMDB ID for the object.
            pdb_id: PDB ID for the object.
            identifier: Identifier for the object (e.g. Gene Ontology ID or UniProtKB accession).
            map_threshold: Threshold to apply to the map when rendering the isosurface.
            radius: Radius of the particle, when displaying as a sphere.
            exist_ok: Whether existing objects with the same name should be overwritten..

        Returns:
            CopickObject: The newly created object.

        Raises:
            ValueError: If an object with the given name already exists and exist_ok is False.
        """
```

```python
    def save_config(self, config_path: str) -> None:
        """Save the configuration to a JSON file.

        Args:
            config_path: Path to the configuration file to save.
        """
```

### Functional API 
There is an equivalent functional API: 

```python 
def add_object(
    root: CopickRoot,
    name: str,
    is_particle: bool,
    label: Optional[int] = None,
    color: Optional[Tuple[int, int, int, int]] = None,
    emdb_id: Optional[str] = None,
    pdb_id: Optional[str] = None,
    identifier: Optional[str] = None,
    map_threshold: Optional[float] = None,
    radius: Optional[float] = None,
    volume: Optional[np.ndarray] = None,
    voxel_size: Optional[float] = None,
    exist_ok: bool = False,
    save_config: bool = False,
    config_path: Optional[str] = None,
    log: bool = False,
) -> CopickObject:
    """Add a new pickable object to the copick root configuration.

    Args:
        root: The copick root object.
        name: Name of the object.
        is_particle: Whether this object should be represented by points (True) or segmentation masks (False).
        label: Numeric label/id for the object. If None, will use the next available label.
        color: RGBA color for the object. If None, will use a default color.
        emdb_id: EMDB ID for the object.
        pdb_id: PDB ID for the object.
        identifier: Identifier for the object (e.g. Gene Ontology ID or UniProtKB accession).
        map_threshold: Threshold to apply to the map when rendering the isosurface.
        radius: Radius of the particle, when displaying as a sphere.
        volume: Optional volume data to associate with the object.
        voxel_size: Voxel size for the volume data. Required if volume is provided.
        exist_ok: Whether existing objects with the same name should be overwritten..
        save_config: Whether to save the configuration to disk after adding the object.
        config_path: Path to save the configuration. Required if save_config is True.
        log: Whether to log the operation.

    Returns:
        CopickObject: The newly created object.

    Raises:
        ValueError: If volume is provided but voxel_size is not, or if save_config is True but config_path is not provided.
    """
```

And another one to add/update the map volume of an object: 

```python
def add_object_volume(
    root: CopickRoot,
    object_name: str,
    volume: np.ndarray,
    voxel_size: float,
    log: bool = False,
) -> CopickObject:
    """Add volume data to an existing pickable object.

    Args:
        root: The copick root object.
        object_name: Name of the existing object.
        volume: Volume data to add.
        voxel_size: Voxel size of the volume data.
        log: Whether to log the operation.

    Returns:
        CopickObject: The updated object.

    Raises:
        ValueError: If the object does not exist or if the object is not a particle.
    """
```

### CLI

There are also equivalent CLI commands: 

```bash
copick add object-definition --help
```

```
copick 1.6.1
------------
Usage: copick add object [OPTIONS]

  Add a pickable object to the project configuration.

Options:
  -c, --config PATH               Path to the configuration file.  [env var:
                                  COPICK_CONFIG]
  --name TEXT                     Name of the object to add.  [required]
  --object-type [particle|segmentation]
                                  Type of object: 'particle' for point
                                  annotations or 'segmentation' for mask
                                  annotations.  [default: particle]
  --label INTEGER                 Numeric label/id for the object. If not
                                  provided, will use the next available label.
  --color R,G,B,A                 RGBA color for the object as comma-separated
                                  values (e.g. '255,0,0,255' for red).
  --emdb-id TEXT                  EMDB ID for the object.
  --pdb-id TEXT                   PDB ID for the object.
  --identifier TEXT               Identifier for the object (e.g. Gene
                                  Ontology ID or UniProtKB accession).
  --map-threshold FLOAT           Threshold to apply to the map when rendering
                                  the isosurface.
  --radius FLOAT                  Radius of the particle, when displaying as a
                                  sphere.
  --volume PATH                   Path to volume file to associate with the
                                  object.
  --volume-format [mrc|zarr]      Format of the volume file ('mrc' or 'zarr').
                                  Will guess from extension if not provided.
  --voxel-size FLOAT              Voxel size for the volume data. Required if
                                  volume is provided.
  --exist-ok / --no-exist-ok      Whether existing objects with the same name
                                  should be overwritten.  [default: no-exist-
                                  ok]
  --debug / --no-debug            Enable debug logging.  [default: no-debug]
  --help                          Show this message and exit.
```

and 

```bash
 copick add object-volume --help  
```

```
copick 1.6.1
------------
Usage: copick add object-volume [OPTIONS]

  Add volume data to an existing pickable object.

Options:
  -c, --config PATH           Path to the configuration file.  [env var:
                              COPICK_CONFIG]
  --object-name TEXT          Name of the existing object.  [required]
  --volume-path PATH          Path to the volume file.  [required]
  --volume-format [mrc|zarr]  Format of the volume file ('mrc' or 'zarr').
                              Will guess from extension if not provided.
  --voxel-size FLOAT          Voxel size of the volume data in Angstrom.
                              [required]
  --debug / --no-debug        Enable debug logging.  [default: no-debug]
  --help                      Show this message and exit.
```