### PR TITLE
fix: Store OME metadata correctly.

### DIFF
--- a/src/copick/util/ome.py
+++ b/src/copick/util/ome.py
@@ -65,7 +65,6 @@ def _ome_zarr_transforms(voxel_size: float) -> Dict[str, Any]:
     return {
         "scale": [voxel_size, voxel_size, voxel_size],
         "type": "scale",
-        "unit": "angstrom",
     }
 
 
@@ -176,6 +175,15 @@ def get_voxel_size_from_zarr(zarr_group: zarr.Group) -> float:
         The voxel size in Angstrom from the coordinate transformations.
     """
     multiscales = zarr_group.attrs["multiscales"]
+
+    # Get unit from axes (should be consistent across spatial axes)
+    axes = multiscales[0]["axes"]
+    unit = "angstrom"  # Default
+    for axis in axes:
+        if axis.get("type") == "space" and "unit" in axis:
+            unit = axis["unit"]
+            break
+
     datasets = multiscales[0]["datasets"]
     first_dataset = datasets[0]
     coord_transforms = first_dataset["coordinateTransformations"]
@@ -186,7 +194,6 @@ def get_voxel_size_from_zarr(zarr_group: zarr.Group) -> float:
             scale_value = float(transform["scale"][0])
 
             # Handle unit conversion
-            unit = transform.get("unit", "angstrom")  # Default to angstrom if no unit specified
             conversion_factor = UNITFACTOR.get(unit, 1.0)  # Default to 1.0 if unknown unit
 
             # Convert to Angstrom

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,9 +90,9 @@ def sample_zarr_file_nanometer():
         store.attrs["multiscales"] = [
             {
                 "axes": [
-                    {"name": "z", "type": "space", "unit": "angstrom"},
-                    {"name": "y", "type": "space", "unit": "angstrom"},
-                    {"name": "x", "type": "space", "unit": "angstrom"},
+                    {"name": "z", "type": "space", "unit": "nanometer"},
+                    {"name": "y", "type": "space", "unit": "nanometer"},
+                    {"name": "x", "type": "space", "unit": "nanometer"},
                 ],
                 "datasets": [
                     {
@@ -100,7 +100,6 @@ def sample_zarr_file_nanometer():
                             {
                                 "scale": [1.0, 1.0, 1.0],  # 1 nanometer = 10 Angstrom
                                 "type": "scale",
-                                "unit": "nanometer",
                             },
                         ],
                         "path": "0",


### PR DESCRIPTION
Units where incorrectly stored in the transformation metadata, instead of the axes metadata. 

Also updated `get_voxel_size_from_zarr` to read the voxelsize correctly. 