### PR TITLE
fix: Make sshfs a core dependency and update docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For more information, see the [documentation](https://copick.github.io/copick/).
 ## Installation
 
 copick can be installed using pip. Using the `all` extra installs necessary requirements for all tested filesystem
-implementations from the fsspec family (`local`, `s3fs`, `smb`, `sshfs`). Separate `s3`, `smb`, and `ssh` extras are available.
+implementations from the fsspec family (`local`, `s3fs`, `smb`, `sshfs`). A separate `smb` extra is available.
 
 ```shell
 pip install "copick[all]"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -14,11 +14,15 @@ It requires the following packages:
 ## Installation
 
 copick can be installed using pip. Using the `all` extra installs necessary requirements for all tested filesystem
-implementations from the fsspec family (`local`, `s3fs`, `smb`, `sshfs`). Separate `s3`, `smb`, and `ssh` extras are available.
+implementations from the fsspec family (`local`, `s3fs`, `smb`, `sshfs`). A separate `smb` extra is available.
 
 ```shell
 pip install "copick[all]"
 ```
+
+!!! note
+    `copick==1.2.0` will fail to install with `pip>=25`. We recommend using [`uv pip`](https://docs.astral.sh/uv/pip/) or `pip<=25` when installing copick.
+
 
 ## Example dataset
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 ]
 authors = [
     { name = "Utz H. Ermel", email = "utz.ermel@czii.org" },
+    { name = "Jonathan Schwartz", email = "jonathan.schwartz@czii.org" },
     { name = "Kyle I. S. Harrington", email = "kyle@kyleharrington.com" },
 ]
 description = "Definitions for a collaborative cryoET annotation tool."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "tqdm>=4.67.1",
     "trimesh>=4.6.12",
     "zarr<3",
+    "sshfs>=2025.2.0",
 ]
 authors = [
     { name = "Utz H. Ermel", email = "utz.ermel@czii.org" },
@@ -51,24 +52,18 @@ make_templates = "copick.cli.make_templates:create [docs]"
 smb = [
     "smbprotocol>=1.15.0",
 ]
-ssh = [
-    "sshfs>=2025.2.0",
-]
 all = [
     "smbprotocol>=1.15.0",
-    "sshfs>=2024.6.0",
 ]
 fledgeling = [
     "pooch>=1.8.2",
     "smbprotocol>=1.15.0",
-    "sshfs>=2024.6.0",
 ]
 test = [
     "pooch>=1.8.2",
     "pytest>=8.4.1",
     "pytest-cov>=6.2.1",
     "smbprotocol>=1.15.0",
-    "sshfs>=2025.2.0",
 ]
 dev = [
     "black>=25.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -687,6 +687,7 @@ dependencies = [
     { name = "s3fs" },
     { name = "scikit-image", version = "0.24.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "sshfs" },
     { name = "textual" },
     { name = "tqdm" },
     { name = "trimesh" },
@@ -698,7 +699,6 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "smbprotocol" },
-    { name = "sshfs" },
 ]
 dev = [
     { name = "black" },
@@ -719,20 +719,15 @@ docs = [
 fledgeling = [
     { name = "pooch" },
     { name = "smbprotocol" },
-    { name = "sshfs" },
 ]
 smb = [
     { name = "smbprotocol" },
-]
-ssh = [
-    { name = "sshfs" },
 ]
 test = [
     { name = "pooch" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "smbprotocol" },
-    { name = "sshfs" },
 ]
 
 [package.metadata]
@@ -766,17 +761,14 @@ requires-dist = [
     { name = "smbprotocol", marker = "extra == 'fledgeling'", specifier = ">=1.15.0" },
     { name = "smbprotocol", marker = "extra == 'smb'", specifier = ">=1.15.0" },
     { name = "smbprotocol", marker = "extra == 'test'", specifier = ">=1.15.0" },
-    { name = "sshfs", marker = "extra == 'all'", specifier = ">=2024.6.0" },
-    { name = "sshfs", marker = "extra == 'fledgeling'", specifier = ">=2024.6.0" },
-    { name = "sshfs", marker = "extra == 'ssh'", specifier = ">=2025.2.0" },
-    { name = "sshfs", marker = "extra == 'test'", specifier = ">=2025.2.0" },
+    { name = "sshfs", specifier = ">=2025.2.0" },
     { name = "textual", specifier = ">=3.5.0" },
     { name = "textual-dev", marker = "extra == 'dev'", specifier = ">=1.7.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "trimesh", specifier = ">=4.6.12" },
     { name = "zarr", specifier = "<3" },
 ]
-provides-extras = ["all", "dev", "docs", "fledgeling", "smb", "ssh", "test"]
+provides-extras = ["all", "dev", "docs", "fledgeling", "smb", "test"]
 
 [[package]]
 name = "coverage"


### PR DESCRIPTION
Using copick with data stored on a remote server with SSH access is a core part of the workflow now. To avoid confusion when users are installing for the first time (and potentially forget the extra dependencies), `sshfs` is moved to the core dependencies. The docs are updated to reflect this.