### PR TITLE
fix: Fix overwrite option on CLI

### DIFF
--- a/src/copick/cli/add.py
+++ b/src/copick/cli/add.py
@@ -173,6 +173,7 @@ def tomogram(
                     chunks=chunk_size,
                     create=create,
                     overwrite=overwrite,
+                    exist_ok=overwrite,
                     log=debug,
                 )
             elif ft == "zarr":
@@ -187,6 +188,7 @@ def tomogram(
                     chunks=chunk_size,
                     create=create,
                     overwrite=overwrite,
+                    exist_ok=overwrite,
                     log=debug,
                 )
             else:
@@ -342,6 +344,7 @@ def segmentation(
                 multilabel=True,
                 create=create,
                 overwrite=overwrite,
+                exist_ok=overwrite,
                 log=debug,
             )
 


### PR DESCRIPTION
CLI tools for adding tomograms were failing because the `overwrite` option was not being passed into `exist_ok`, but only the zarr `overwrite` parameter.