### PR TITLE
feat: Add sync command and CLI

### DIFF
--- a/docs/api_reference/functional/sync.md
+++ b/docs/api_reference/functional/sync.md
@@ -1,0 +1,226 @@
+# Sync Operations
+
+The `copick.ops.sync` module provides functions for synchronizing data between Copick projects, including picks, meshes, segmentations, and tomograms. These functions enable efficient copying and migration of annotations and volume data between different Copick projects with support for parallel processing, name mapping, and user filtering.
+
+## Core Features
+
+- **Parallel Processing**: Multi-threaded synchronization for improved performance
+- **Name Mapping**: Flexible mapping of source names to target names for runs, objects, and users
+- **User Filtering**: Selective synchronization based on user IDs
+- **Object Validation**: Automatic creation of missing pickable objects in target projects
+- **Progress Tracking**: Optional logging and progress reporting
+- **Error Handling**: Comprehensive error reporting with detailed failure information
+
+## Functions
+
+::: copick.ops.sync.sync_picks
+    options:
+        show_root_heading: true
+        show_root_full_path: true
+
+::: copick.ops.sync.sync_meshes
+    options:
+        show_root_heading: true
+        show_root_full_path: true
+
+::: copick.ops.sync.sync_segmentations
+    options:
+        show_root_heading: true
+        show_root_full_path: true
+
+::: copick.ops.sync.sync_tomograms
+    options:
+        show_root_heading: true
+        show_root_full_path: true
+
+## Usage Examples
+
+### Basic Synchronization
+
+```python
+import copick
+from copick.ops.sync import sync_picks
+
+# Load source and target projects
+source_root = copick.from_file("source_config.json")
+target_root = copick.from_file("target_config.json")
+
+# Sync all picks from all runs
+sync_picks(
+    source_root=source_root,
+    target_root=target_root,
+    log=True
+)
+```
+
+### Selective Synchronization with Name Mapping
+
+```python
+# Sync specific runs with name mapping
+sync_picks(
+    source_root=source_root,
+    target_root=target_root,
+    source_runs=["run1", "run2"],
+    target_runs={"run1": "experiment_A", "run2": "experiment_B"},
+    source_objects=["ribosome", "membrane"],
+    target_objects={"ribosome": "ribo", "membrane": "mem"},
+    log=True
+)
+```
+
+### User-Specific Synchronization
+
+```python
+# Sync picks from specific users with user ID mapping
+sync_picks(
+    source_root=source_root,
+    target_root=target_root,
+    source_users=["user123", "user456"],
+    target_users={"user123": "analyst1", "user456": "analyst2"},
+    exist_ok=True,  # Allow overwriting existing picks
+    max_workers=8,  # Use more threads for faster processing
+    log=True
+)
+```
+
+### Synchronizing Segmentations with Voxel Spacing Filtering
+
+```python
+from copick.ops.sync import sync_segmentations
+
+# Sync segmentations for specific voxel spacings
+sync_segmentations(
+    source_root=source_root,
+    target_root=target_root,
+    voxel_spacings=[10.0, 20.0],  # Only sync these voxel spacings
+    source_names=["membrane", "organelle"],
+    target_names={"membrane": "cell_membrane", "organelle": "mitochondria"},
+    log=True
+)
+```
+
+### Synchronizing Tomograms with Type Mapping
+
+```python
+from copick.ops.sync import sync_tomograms
+
+# Sync tomograms with type mapping
+sync_tomograms(
+    source_root=source_root,
+    target_root=target_root,
+    voxel_spacings=[10.0],
+    source_tomo_types=["wbp", "raw"],
+    target_tomo_types={"wbp": "filtered", "raw": "original"},
+    exist_ok=True,
+    log=True
+)
+```
+
+### Complete Multi-Data Type Synchronization
+
+```python
+from copick.ops.sync import sync_picks, sync_meshes, sync_segmentations
+
+# Sync multiple data types in sequence
+data_types = [
+    (sync_picks, {}),
+    (sync_meshes, {}),
+    (sync_segmentations, {"voxel_spacings": [10.0, 20.0]})
+]
+
+common_args = {
+    "source_root": source_root,
+    "target_root": target_root,
+    "source_runs": ["run1", "run2"],
+    "target_runs": {"run1": "exp1", "run2": "exp2"},
+    "max_workers": 6,
+    "log": True
+}
+
+for sync_func, extra_args in data_types:
+    print(f"Synchronizing {sync_func.__name__}...")
+    sync_func(**common_args, **extra_args)
+    print(f"Completed {sync_func.__name__}")
+```
+
+## Common Patterns
+
+### Name Mapping Syntax
+
+All synchronization functions support flexible name mapping using dictionaries:
+
+```python
+# Run name mapping
+target_runs = {
+    "source_run1": "target_run1",
+    "source_run2": "target_run2"
+}
+
+# Object name mapping
+target_objects = {
+    "ribosome": "large_ribosomal_subunit",
+    "membrane": "plasma_membrane",
+    "vesicle": "transport_vesicle"
+}
+
+# User ID mapping
+target_users = {
+    "original_user": "new_user_id",
+    "temp_user": "permanent_user"
+}
+```
+
+### Error Handling and Logging
+
+```python
+import logging
+
+# Configure logging for detailed output
+logging.basicConfig(level=logging.INFO)
+
+try:
+    sync_picks(
+        source_root=source_root,
+        target_root=target_root,
+        log=True  # Enable verbose logging
+    )
+except Exception as e:
+    print(f"Synchronization failed: {e}")
+    # Check logs for detailed error information
+```
+
+### Performance Optimization
+
+```python
+# Optimize for large datasets
+sync_picks(
+    source_root=source_root,
+    target_root=target_root,
+    max_workers=12,  # Increase parallelism
+    exist_ok=True,   # Skip duplicate checks
+    log=False        # Reduce logging overhead
+)
+```
+
+## Integration with CLI
+
+The sync operations are also available through the CLI interface:
+
+```bash
+# Basic synchronization
+copick sync picks -c source_config.json --target-config target_config.json
+
+# With name mapping and user filtering
+copick sync picks -c source_config.json --target-config target_config.json \
+    --source-runs "run1,run2" \
+    --target-runs "run1:exp1,run2:exp2" \
+    --source-users "user1,user2" \
+    --target-users "user1:analyst1,user2:analyst2" \
+    --log
+
+# From CryoET Data Portal
+copick sync picks \
+    --source-dataset-ids "12345,67890" \
+    --target-config target_config.json \
+    --log
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -470,6 +470,217 @@ copick new voxelspacing --config config.json --run TS_001 --overwrite 5.0
 
 ---
 
+### :material-sync: `copick sync`
+
+Synchronize data between Copick projects with support for parallel processing, name mapping, and user filtering.
+
+**Subcommands:**
+
+- [`copick sync picks`](#copick-sync-picks) - Synchronize picks between two Copick projects
+- [`copick sync meshes`](#copick-sync-meshes) - Synchronize meshes between two Copick projects
+- [`copick sync segmentations`](#copick-sync-segmentations) - Synchronize segmentations between two Copick projects
+- [`copick sync tomograms`](#copick-sync-tomograms) - Synchronize tomograms between two Copick projects
+
+#### :material-target: `copick sync picks`
+
+Synchronize pick annotations between two Copick projects with support for name mapping and user filtering.
+
+**Usage:**
+```bash
+copick sync picks [OPTIONS]
+```
+
+**Options:**
+
+| Option                    | Type    | Description                                                                                             | Default                      |
+|---------------------------|---------|---------------------------------------------------------------------------------------------------------|------------------------------|
+| `-c, --config PATH`       | Path    | Path to the source configuration file                                                                   | Uses `COPICK_CONFIG` env var |
+| `--source-dataset-ids`    | String  | Comma-separated list of dataset IDs to use as source from CryoET Data Portal                           | `""`                         |
+| `--target-config PATH`    | Path    | Path to the target configuration file (required)                                                       | None                         |
+| `--source-runs`           | String  | Comma-separated list of source run names to synchronize                                                | `""` (all runs)              |
+| `--target-runs`           | String  | Comma-separated mapping of source run names to target run names (e.g. 'run1:target1,run2:target2')    | `""` (same names)            |
+| `--source-objects`        | String  | Comma-separated list of source object names to synchronize                                             | `""` (all objects)           |
+| `--target-objects`        | String  | Comma-separated mapping of source object names to target object names (e.g. 'ribosome:ribo,membrane:mem') | `""` (same names)            |
+| `--source-users`          | String  | Comma-separated list of source user IDs to synchronize                                                 | `""` (all users)             |
+| `--target-users`          | String  | Comma-separated mapping of source user IDs to target user IDs (e.g. 'user1:target1,user2:target2')    | `""` (same user IDs)         |
+| `--exist-ok/--no-exist-ok` | Boolean | Allow overwriting existing picks in the target project                                                 | `no-exist-ok`                |
+| `--max-workers`           | Integer | Maximum number of worker threads to use for synchronization                                            | `4`                          |
+| `--log/--no-log`          | Boolean | Enable verbose logging of the synchronization process                                                  | `no-log`                     |
+| `--debug/--no-debug`      | Boolean | Enable debug logging                                                                                   | `no-debug`                   |
+
+**Examples:**
+
+```bash
+# Sync all picks from all runs
+copick sync picks -c source_config.json --target-config target_config.json
+
+# Sync specific runs with name mapping
+copick sync picks -c source_config.json --target-config target_config.json \
+    --source-runs "run1,run2" --target-runs "run1:new_run1,run2:new_run2"
+
+# Sync specific objects with name mapping
+copick sync picks -c source_config.json --target-config target_config.json \
+    --source-objects "ribosome,membrane" --target-objects "ribosome:ribo,membrane:mem"
+
+# Sync picks from specific users with user mapping
+copick sync picks -c source_config.json --target-config target_config.json \
+    --source-users "user1,user2" --target-users "user1:analyst1,user2:analyst2" \
+    --exist-ok --log
+
+# Sync from CryoET Data Portal to local project
+copick sync picks \
+    --source-dataset-ids "12345,67890" \
+    --target-config target_config.json \
+    --max-workers 8 --log
+```
+
+#### :material-vector-triangle: `copick sync meshes`
+
+Synchronize mesh data between two Copick projects with support for name mapping and user filtering.
+
+**Usage:**
+```bash
+copick sync meshes [OPTIONS]
+```
+
+**Options:**
+
+| Option                    | Type    | Description                                                                                             | Default                      |
+|---------------------------|---------|---------------------------------------------------------------------------------------------------------|------------------------------|
+| `-c, --config PATH`       | Path    | Path to the source configuration file                                                                   | Uses `COPICK_CONFIG` env var |
+| `--source-dataset-ids`    | String  | Comma-separated list of dataset IDs to use as source from CryoET Data Portal                           | `""`                         |
+| `--target-config PATH`    | Path    | Path to the target configuration file (required)                                                       | None                         |
+| `--source-runs`           | String  | Comma-separated list of source run names to synchronize                                                | `""` (all runs)              |
+| `--target-runs`           | String  | Comma-separated mapping of source run names to target run names (e.g. 'run1:target1,run2:target2')    | `""` (same names)            |
+| `--source-objects`        | String  | Comma-separated list of source object names to synchronize                                             | `""` (all objects)           |
+| `--target-objects`        | String  | Comma-separated mapping of source object names to target object names (e.g. 'ribosome:ribo,membrane:mem') | `""` (same names)            |
+| `--source-users`          | String  | Comma-separated list of source user IDs to synchronize                                                 | `""` (all users)             |
+| `--target-users`          | String  | Comma-separated mapping of source user IDs to target user IDs (e.g. 'user1:target1,user2:target2')    | `""` (same user IDs)         |
+| `--exist-ok/--no-exist-ok` | Boolean | Allow overwriting existing meshes in the target project                                                | `no-exist-ok`                |
+| `--max-workers`           | Integer | Maximum number of worker threads to use for synchronization                                            | `4`                          |
+| `--log/--no-log`          | Boolean | Enable verbose logging of the synchronization process                                                  | `no-log`                     |
+| `--debug/--no-debug`      | Boolean | Enable debug logging                                                                                   | `no-debug`                   |
+
+**Examples:**
+
+```bash
+# Sync all meshes from all runs
+copick sync meshes -c source_config.json --target-config target_config.json
+
+# Sync specific runs with name mapping
+copick sync meshes -c source_config.json --target-config target_config.json \
+    --source-runs "run1,run2" --target-runs "run1:new_run1,run2:new_run2"
+
+# Sync specific objects with name mapping
+copick sync meshes -c source_config.json --target-config target_config.json \
+    --source-objects "ribosome,membrane" --target-objects "ribosome:ribo,membrane:mem"
+
+# Parallel processing with logging
+copick sync meshes -c source_config.json --target-config target_config.json \
+    --max-workers 8 --log
+```
+
+#### :material-layers: `copick sync segmentations`
+
+Synchronize segmentation data between two Copick projects with voxel spacing filtering, name mapping, and user filtering.
+
+**Usage:**
+```bash
+copick sync segmentations [OPTIONS]
+```
+
+**Options:**
+
+| Option                    | Type    | Description                                                                                             | Default                      |
+|---------------------------|---------|---------------------------------------------------------------------------------------------------------|------------------------------|
+| `-c, --config PATH`       | Path    | Path to the source configuration file                                                                   | Uses `COPICK_CONFIG` env var |
+| `--source-dataset-ids`    | String  | Comma-separated list of dataset IDs to use as source from CryoET Data Portal                           | `""`                         |
+| `--target-config PATH`    | Path    | Path to the target configuration file (required)                                                       | None                         |
+| `--source-runs`           | String  | Comma-separated list of source run names to synchronize                                                | `""` (all runs)              |
+| `--target-runs`           | String  | Comma-separated mapping of source run names to target run names (e.g. 'run1:target1,run2:target2')    | `""` (same names)            |
+| `--voxel-spacings`        | String  | Comma-separated list of voxel spacings to consider for synchronization                                 | `""` (all voxel spacings)    |
+| `--source-names`          | String  | Comma-separated list of source segmentation names to synchronize                                       | `""` (all segmentations)     |
+| `--target-names`          | String  | Comma-separated mapping of source segmentation names to target names (e.g. 'seg1:target1,seg2:target2') | `""` (same names)            |
+| `--source-users`          | String  | Comma-separated list of source user IDs to synchronize                                                 | `""` (all users)             |
+| `--target-users`          | String  | Comma-separated mapping of source user IDs to target user IDs (e.g. 'user1:target1,user2:target2')    | `""` (same user IDs)         |
+| `--exist-ok/--no-exist-ok` | Boolean | Allow overwriting existing segmentations in the target project                                         | `no-exist-ok`                |
+| `--max-workers`           | Integer | Maximum number of worker threads to use for synchronization                                            | `4`                          |
+| `--log/--no-log`          | Boolean | Enable verbose logging of the synchronization process                                                  | `no-log`                     |
+| `--debug/--no-debug`      | Boolean | Enable debug logging                                                                                   | `no-debug`                   |
+
+**Examples:**
+
+```bash
+# Sync all segmentations from all runs
+copick sync segmentations -c source_config.json --target-config target_config.json
+
+# Sync specific runs and voxel spacings
+copick sync segmentations -c source_config.json --target-config target_config.json \
+    --source-runs "run1,run2" --voxel-spacings "10.0,20.0"
+
+# Sync specific segmentations with name mapping
+copick sync segmentations -c source_config.json --target-config target_config.json \
+    --source-names "membrane,organelle" --target-names "membrane:cell_membrane,organelle:mitochondria"
+
+# Complete synchronization with all options
+copick sync segmentations -c source_config.json --target-config target_config.json \
+    --source-runs "run1,run2" --target-runs "run1:exp1,run2:exp2" \
+    --voxel-spacings "10.0,20.0" \
+    --source-names "membrane,organelle" --target-names "membrane:cell_membrane,organelle:mitochondria" \
+    --source-users "user1,user2" --target-users "user1:analyst1,user2:analyst2" \
+    --exist-ok --max-workers 8 --log
+```
+
+#### :material-cube: `copick sync tomograms`
+
+Synchronize tomogram data between two Copick projects with voxel spacing and tomogram type filtering.
+
+**Usage:**
+```bash
+copick sync tomograms [OPTIONS]
+```
+
+**Options:**
+
+| Option                    | Type    | Description                                                                                             | Default                      |
+|---------------------------|---------|---------------------------------------------------------------------------------------------------------|------------------------------|
+| `-c, --config PATH`       | Path    | Path to the source configuration file                                                                   | Uses `COPICK_CONFIG` env var |
+| `--source-dataset-ids`    | String  | Comma-separated list of dataset IDs to use as source from CryoET Data Portal                           | `""`                         |
+| `--target-config PATH`    | Path    | Path to the target configuration file (required)                                                       | None                         |
+| `--source-runs`           | String  | Comma-separated list of source run names to synchronize                                                | `""` (all runs)              |
+| `--target-runs`           | String  | Comma-separated mapping of source run names to target run names (e.g. 'run1:target1,run2:target2')    | `""` (same names)            |
+| `--voxel-spacings`        | String  | Comma-separated list of voxel spacings to consider for synchronization                                 | `""` (all voxel spacings)    |
+| `--source-tomo-types`     | String  | Comma-separated list of source tomogram types to synchronize                                           | `""` (all tomogram types)    |
+| `--target-tomo-types`     | String  | Comma-separated mapping of source tomogram types to target types (e.g. 'wbp:filtered,raw:original')   | `""` (same types)            |
+| `--exist-ok/--no-exist-ok` | Boolean | Allow overwriting existing tomograms in the target project                                             | `no-exist-ok`                |
+| `--max-workers`           | Integer | Maximum number of worker threads to use for synchronization                                            | `4`                          |
+| `--log/--no-log`          | Boolean | Enable verbose logging of the synchronization process                                                  | `no-log`                     |
+| `--debug/--no-debug`      | Boolean | Enable debug logging                                                                                   | `no-debug`                   |
+
+**Examples:**
+
+```bash
+# Sync all tomograms from all runs
+copick sync tomograms -c source_config.json --target-config target_config.json
+
+# Sync specific runs and voxel spacings
+copick sync tomograms -c source_config.json --target-config target_config.json \
+    --source-runs "run1,run2" --voxel-spacings "10.0,20.0"
+
+# Sync specific tomogram types with name mapping
+copick sync tomograms -c source_config.json --target-config target_config.json \
+    --source-tomo-types "wbp,raw" --target-tomo-types "wbp:filtered,raw:original"
+
+# Complete tomogram synchronization
+copick sync tomograms -c source_config.json --target-config target_config.json \
+    --source-runs "run1,run2" --target-runs "run1:exp1,run2:exp2" \
+    --voxel-spacings "10.0" \
+    --source-tomo-types "wbp,denoised" --target-tomo-types "wbp:processed,denoised:clean" \
+    --exist-ok --max-workers 6 --log
+```
+
+---
+
 ### :material-information: `copick info`
 
 Display information about the Copick CLI and available plugins.
@@ -670,6 +881,42 @@ copick config dataportal -ds 10000 -ds 10001 -ds 10002 --overlay ./overlay --out
 copick browse --config multi_project.json
 ```
 
+### Synchronize Data Between Projects
+
+Synchronize data between different Copick projects:
+
+```bash
+# Basic synchronization of all data types
+copick sync picks -c source_config.json --target-config target_config.json --log
+copick sync meshes -c source_config.json --target-config target_config.json --log
+copick sync segmentations -c source_config.json --target-config target_config.json --log
+copick sync tomograms -c source_config.json --target-config target_config.json --log
+
+# Sync from CryoET Data Portal to local project
+copick sync picks \
+    --source-dataset-ids "12345,67890" \
+    --target-config local_project.json \
+    --max-workers 8 --log
+
+# Sync with name mapping and user filtering
+copick sync picks -c source_config.json --target-config target_config.json \
+    --source-runs "run1,run2" --target-runs "run1:experiment_A,run2:experiment_B" \
+    --source-objects "ribosome,membrane" --target-objects "ribosome:large_ribosomal_subunit,membrane:plasma_membrane" \
+    --source-users "user1,user2" --target-users "user1:analyst1,user2:analyst2" \
+    --exist-ok --log
+
+# Selective synchronization of specific voxel spacings and segmentation types
+copick sync segmentations -c source_config.json --target-config target_config.json \
+    --voxel-spacings "10.0,20.0" \
+    --source-names "membrane,organelle" --target-names "membrane:cell_membrane,organelle:mitochondria" \
+    --log
+
+copick sync tomograms -c source_config.json --target-config target_config.json \
+    --voxel-spacings "10.0" \
+    --source-tomo-types "wbp,denoised" --target-tomo-types "wbp:processed,denoised:clean" \
+    --log
+```
+
 ### Development and Debugging
 
 Debug and test your Copick workflows:
@@ -686,4 +933,7 @@ copick new voxelspacing --config project.json --run TEST_RUN 10.0
 
 # Add a tomogram with detailed output
 copick add tomogram --config project.json --run TEST_RUN --debug data/test_tomogram.mrc
+
+# Test synchronization with debug logging
+copick sync picks -c source_config.json --target-config target_config.json --debug --log
 ```

--- a/src/copick/__init__.py
+++ b/src/copick/__init__.py
@@ -1,13 +1,14 @@
 __version__ = "1.9.0"
 
 from copick.models import COPICK_TYPES
-from copick.ops.open import from_czcdp_datasets, from_file, from_string
+from copick.ops.open import from_czcdp_datasets, from_file, from_string, new_config
 
 __all__ = [
     "from_file",
     "from_string",
     "from_czcdp_datasets",
     "from_string",
+    "new_config",
     "__version__",
     "COPICK_TYPES",
 ]

--- a/src/copick/cli/cli.py
+++ b/src/copick/cli/cli.py
@@ -7,6 +7,7 @@ from copick.cli.config import config
 from copick.cli.ext import load_plugin_commands
 from copick.cli.info import info
 from copick.cli.new import new
+from copick.cli.sync import sync
 from copick.util.log import get_logger
 
 logger = get_logger(__name__)
@@ -92,6 +93,7 @@ def add_core_commands(cmd: click.group) -> click.group:
     cmd.add_command(config)
     cmd.add_command(info)
     cmd.add_command(new)
+    cmd.add_command(sync)
 
     return cmd
 

--- a/src/copick/cli/config.py
+++ b/src/copick/cli/config.py
@@ -1,5 +1,3 @@
-import json
-import os
 from typing import List
 
 import click
@@ -147,6 +145,9 @@ def filesystem(
         --objects membrane,False --objects apoferritin,True,60,4V1W \
         --proj-name 24sep24a --proj-description "Synaptic Vesicles collected on 24sep24"
     """
+    import copick
+    from copick.models import PickableObject
+
     logger = get_logger(__name__, debug=debug)
     logger.info("Generating configuration file for a local project directory...")
 
@@ -166,25 +167,15 @@ def filesystem(
             if pdb_id:
                 obj_dict["pdb_id"] = pdb_id
 
-        pickable_objects.append(obj_dict)
+        pickable_objects.append(PickableObject(**obj_dict))
         label_counter += 1
 
-    config_data = {
-        "config_type": "filesystem",
-        "name": proj_name,
-        "description": proj_description,
-        "version": "0.1.6",  # TODO: Update this to the actual version - how to do this automatically?
-        "pickable_objects": pickable_objects,
-        "overlay_root": "local://" + overlay_root,
-        "overlay_fs_args": {"auto_mkdir": True},
-    }
-
-    # Only create the directory if it is non-empty (i.e., the file is not in the current directory)
-    directory = os.path.dirname(config)
-    if directory:
-        os.makedirs(directory, exist_ok=True)
-    # Write the JSON data to the file
-    with open(config, "w") as f:
-        json.dump(config_data, f, indent=4)
+    copick.new_config(
+        config=config,
+        proj_name=proj_name,
+        proj_description=proj_description,
+        overlay_root=overlay_root,
+        pickable_objects=pickable_objects,
+    )
 
     logger.info(f"Generated configuration file at {config}.")

--- a/src/copick/cli/sync.py
+++ b/src/copick/cli/sync.py
@@ -1,0 +1,716 @@
+import os
+
+import click
+
+from copick.cli.util import add_config_option, add_debug_option
+from copick.ops.sync import sync_meshes, sync_picks, sync_segmentations, sync_tomograms
+from copick.util.log import get_logger
+from copick.util.sync import (
+    create_dataportal_config,
+    ensure_pickable_objects,
+    parse_dataset_ids,
+    parse_list,
+    parse_mapping,
+)
+
+
+@click.group()
+@click.pass_context
+def sync(ctx):
+    """Synchronize data between Copick projects."""
+    pass
+
+
+@sync.command(short_help="Synchronize picks between two Copick projects.")
+@add_config_option
+@click.option(
+    "--source-dataset-ids",
+    type=str,
+    help="Comma-separated list of dataset IDs to use as source from CryoET Data Portal. If provided, --config will be ignored and a temporary dataportal configuration will be created.",
+    default="",
+    required=False,
+)
+@click.option(
+    "--target-config",
+    type=str,
+    help="Path to the target configuration file.",
+    required=True,
+    metavar="PATH",
+)
+@click.option(
+    "--source-runs",
+    type=str,
+    help="Comma-separated list of source run names to synchronize. If not specified, all runs will be synced.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--target-runs",
+    type=str,
+    help="Comma-separated mapping of source run names to target run names (e.g. 'run1:target1,run2:target2'). If not specified, source run names will be used.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--source-objects",
+    type=str,
+    help="Comma-separated list of source object names to synchronize. If not specified, all objects will be synced.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--target-objects",
+    type=str,
+    help="Comma-separated mapping of source object names to target object names (e.g. 'ribosome:ribo,membrane:mem'). If not specified, source object names will be used.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--source-users",
+    type=str,
+    help="Comma-separated list of source user IDs to synchronize. If not specified, all users will be synced.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--target-users",
+    type=str,
+    help="Comma-separated mapping of source user IDs to target user IDs (e.g. 'user1:target1,user2:target2'). If not specified, source user IDs will be used.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--exist-ok/--no-exist-ok",
+    is_flag=True,
+    help="Allow overwriting existing picks in the target project.",
+    show_default=True,
+    default=False,
+)
+@click.option(
+    "--max-workers",
+    type=int,
+    help="Maximum number of worker threads to use for synchronization.",
+    default=4,
+    show_default=True,
+)
+@click.option(
+    "--log/--no-log",
+    is_flag=True,
+    help="Enable verbose logging of the synchronization process.",
+    show_default=True,
+    default=False,
+)
+@add_debug_option
+def picks(
+    config,
+    source_dataset_ids,
+    target_config,
+    source_runs,
+    target_runs,
+    source_objects,
+    target_objects,
+    source_users,
+    target_users,
+    exist_ok,
+    max_workers,
+    log,
+    debug,
+):
+    """Synchronize picks between two Copick projects.
+
+    This command copies pick annotations from a source Copick project to a target project.
+    You can specify which runs and objects to sync, and optionally map source names to
+    different target names.
+
+    Examples:
+
+    # Sync all picks from all runs
+    copick sync picks -c source_config.json --target-config target_config.json
+
+    # Sync specific runs with name mapping
+    copick sync picks -c source_config.json --target-config target_config.json \\
+        --source-runs "run1,run2" --target-runs "run1:new_run1,run2:new_run2"
+
+    # Sync specific objects with name mapping
+    copick sync picks -c source_config.json --target-config target_config.json \\
+        --source-objects "ribosome,membrane" --target-objects "ribosome:ribo,membrane:mem"
+    """
+
+    logger = get_logger(__name__, debug=debug)
+
+    # Parse arguments
+    source_runs_list = parse_list(source_runs) if source_runs else None
+    target_runs_dict = parse_mapping(target_runs) if target_runs else None
+    source_objects_list = parse_list(source_objects) if source_objects else None
+    target_objects_dict = parse_mapping(target_objects) if target_objects else None
+    source_users_list = parse_list(source_users) if source_users else None
+    target_users_dict = parse_mapping(target_users) if target_users else None
+
+    # Handle dataportal source configuration
+    temp_config_path = None
+    if source_dataset_ids:
+        dataset_ids = parse_dataset_ids(source_dataset_ids)
+        temp_config_path = create_dataportal_config(dataset_ids)
+        source_config = temp_config_path
+    else:
+        source_config = config
+
+    # Load configurations
+    import copick
+
+    source_root = copick.from_file(source_config)
+    target_root = copick.from_file(target_config)
+
+    try:
+        # Get objects to process (default to all objects if not specified)
+        if source_objects_list is None:
+            source_objects_list = [obj.name for obj in source_root.pickable_objects]
+        if target_objects_dict is None:
+            target_objects_dict = {obj: obj for obj in source_objects_list}
+
+        # Ensure pickable objects exist in target before synchronization
+        ensure_pickable_objects(
+            source_root=source_root,
+            target_root=target_root,
+            target_config_path=target_config,
+            source_objects_list=source_objects_list,
+            target_objects_dict=target_objects_dict,
+            log=log,
+        )
+
+        # Perform synchronization
+        sync_picks(
+            source_root=source_root,
+            target_root=target_root,
+            source_runs=source_runs_list,
+            target_runs=target_runs_dict,
+            source_objects=source_objects_list,
+            target_objects=target_objects_dict,
+            source_users=source_users_list,
+            target_users=target_users_dict,
+            exist_ok=exist_ok,
+            max_workers=max_workers,
+            log=log,
+        )
+
+        logger.info("Picks synchronization completed successfully.")
+    finally:
+        # Clean up temporary files
+        if temp_config_path and os.path.exists(temp_config_path):
+            os.unlink(temp_config_path)
+
+
+@sync.command(short_help="Synchronize meshes between two Copick projects.")
+@add_config_option
+@click.option(
+    "--source-dataset-ids",
+    type=str,
+    help="Comma-separated list of dataset IDs to use as source from CryoET Data Portal. If provided, --config will be ignored and a temporary dataportal configuration will be created.",
+    default="",
+    required=False,
+)
+@click.option(
+    "--target-config",
+    type=str,
+    help="Path to the target configuration file.",
+    required=True,
+    metavar="PATH",
+)
+@click.option(
+    "--source-runs",
+    type=str,
+    help="Comma-separated list of source run names to synchronize. If not specified, all runs will be synced.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--target-runs",
+    type=str,
+    help="Comma-separated mapping of source run names to target run names (e.g. 'run1:target1,run2:target2'). If not specified, source run names will be used.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--source-objects",
+    type=str,
+    help="Comma-separated list of source object names to synchronize. If not specified, all objects will be synced.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--target-objects",
+    type=str,
+    help="Comma-separated mapping of source object names to target object names (e.g. 'ribosome:ribo,membrane:mem'). If not specified, source object names will be used.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--source-users",
+    type=str,
+    help="Comma-separated list of source user IDs to synchronize. If not specified, all users will be synced.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--target-users",
+    type=str,
+    help="Comma-separated mapping of source user IDs to target user IDs (e.g. 'user1:target1,user2:target2'). If not specified, source user IDs will be used.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--exist-ok/--no-exist-ok",
+    is_flag=True,
+    help="Allow overwriting existing meshes in the target project.",
+    show_default=True,
+    default=False,
+)
+@click.option(
+    "--max-workers",
+    type=int,
+    help="Maximum number of worker threads to use for synchronization.",
+    default=4,
+    show_default=True,
+)
+@click.option(
+    "--log/--no-log",
+    is_flag=True,
+    help="Enable verbose logging of the synchronization process.",
+    show_default=True,
+    default=False,
+)
+@add_debug_option
+def meshes(
+    config,
+    source_dataset_ids,
+    target_config,
+    source_runs,
+    target_runs,
+    source_objects,
+    target_objects,
+    source_users,
+    target_users,
+    exist_ok,
+    max_workers,
+    log,
+    debug,
+):
+    """Synchronize meshes between two Copick projects.
+
+    This command copies mesh data from a source Copick project to a target project.
+    You can specify which runs and objects to sync, and optionally map source names to
+    different target names.
+
+    Examples:
+
+    # Sync all meshes from all runs
+    copick sync meshes -c source_config.json --target-config target_config.json
+
+    # Sync specific runs with name mapping
+    copick sync meshes -c source_config.json --target-config target_config.json \\
+        --source-runs "run1,run2" --target-runs "run1:new_run1,run2:new_run2"
+
+    # Sync specific objects with name mapping
+    copick sync meshes -c source_config.json --target-config target_config.json \\
+        --source-objects "ribosome,membrane" --target-objects "ribosome:ribo,membrane:mem"
+    """
+    logger = get_logger(__name__, debug=debug)
+
+    # Parse arguments
+    source_runs_list = parse_list(source_runs) if source_runs else None
+    target_runs_dict = parse_mapping(target_runs) if target_runs else None
+    source_objects_list = parse_list(source_objects) if source_objects else None
+    target_objects_dict = parse_mapping(target_objects) if target_objects else None
+    source_users_list = parse_list(source_users) if source_users else None
+    target_users_dict = parse_mapping(target_users) if target_users else None
+
+    # Handle dataportal source configuration
+    temp_config_path = None
+    if source_dataset_ids:
+        dataset_ids = parse_dataset_ids(source_dataset_ids)
+        temp_config_path = create_dataportal_config(dataset_ids)
+        source_config = temp_config_path
+    else:
+        source_config = config
+
+    # Load configurations
+    import copick
+
+    source_root = copick.from_file(source_config)
+    target_root = copick.from_file(target_config)
+
+    try:
+        # Get objects to process (default to all objects if not specified)
+        if source_objects_list is None:
+            source_objects_list = [obj.name for obj in source_root.pickable_objects]
+        if target_objects_dict is None:
+            target_objects_dict = {obj: obj for obj in source_objects_list}
+
+        # Ensure pickable objects exist in target before synchronization
+        ensure_pickable_objects(
+            source_root=source_root,
+            target_root=target_root,
+            target_config_path=target_config,
+            source_objects_list=source_objects_list,
+            target_objects_dict=target_objects_dict,
+            log=log,
+        )
+
+        # Perform synchronization
+        sync_meshes(
+            source_root=source_root,
+            target_root=target_root,
+            source_runs=source_runs_list,
+            target_runs=target_runs_dict,
+            source_objects=source_objects_list,
+            target_objects=target_objects_dict,
+            source_users=source_users_list,
+            target_users=target_users_dict,
+            exist_ok=exist_ok,
+            max_workers=max_workers,
+            log=log,
+        )
+
+        logger.info("Meshes synchronization completed successfully.")
+    finally:
+        # Clean up temporary files
+        if temp_config_path and os.path.exists(temp_config_path):
+            os.unlink(temp_config_path)
+
+
+@sync.command(short_help="Synchronize segmentations between two Copick projects.")
+@add_config_option
+@click.option(
+    "--source-dataset-ids",
+    type=str,
+    help="Comma-separated list of dataset IDs to use as source from CryoET Data Portal. If provided, --config will be ignored and a temporary dataportal configuration will be created.",
+    default="",
+    required=False,
+)
+@click.option(
+    "--target-config",
+    type=str,
+    help="Path to the target configuration file.",
+    required=True,
+    metavar="PATH",
+)
+@click.option(
+    "--source-runs",
+    type=str,
+    help="Comma-separated list of source run names to synchronize. If not specified, all runs will be synced.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--target-runs",
+    type=str,
+    help="Comma-separated mapping of source run names to target run names (e.g. 'run1:target1,run2:target2'). If not specified, source run names will be used.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--voxel-spacings",
+    type=str,
+    help="Comma-separated list of voxel spacings to consider for synchronization. If not specified, all voxel spacings will be synced.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--source-names",
+    type=str,
+    help="Comma-separated list of source segmentation names to synchronize. If not specified, all segmentations will be synced.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--target-names",
+    type=str,
+    help="Comma-separated mapping of source segmentation names to target names (e.g. 'seg1:target1,seg2:target2'). If not specified, source names will be used.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--source-users",
+    type=str,
+    help="Comma-separated list of source user IDs to synchronize. If not specified, all users will be synced.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--target-users",
+    type=str,
+    help="Comma-separated mapping of source user IDs to target user IDs (e.g. 'user1:target1,user2:target2'). If not specified, source user IDs will be used.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--exist-ok/--no-exist-ok",
+    is_flag=True,
+    help="Allow overwriting existing segmentations in the target project.",
+    show_default=True,
+    default=False,
+)
+@click.option(
+    "--max-workers",
+    type=int,
+    help="Maximum number of worker threads to use for synchronization.",
+    default=4,
+    show_default=True,
+)
+@click.option(
+    "--log/--no-log",
+    is_flag=True,
+    help="Enable verbose logging of the synchronization process.",
+    show_default=True,
+    default=False,
+)
+@add_debug_option
+def segmentations(
+    config,
+    source_dataset_ids,
+    target_config,
+    source_runs,
+    target_runs,
+    voxel_spacings,
+    source_names,
+    target_names,
+    source_users,
+    target_users,
+    exist_ok,
+    max_workers,
+    log,
+    debug,
+):
+    """Synchronize segmentations between two Copick projects.
+
+    This command copies segmentation data from a source Copick project to a target project.
+    You can specify which runs, voxel spacings, and objects to sync, and optionally map
+    source names to different target names.
+
+    Examples:
+
+    # Sync all segmentations from all runs
+    copick sync segmentations -c source_config.json --target-config target_config.json
+
+    # Sync specific runs and voxel spacings
+    copick sync segmentations -c source_config.json --target-config target_config.json \\
+        --source-runs "run1,run2" --voxel-spacings "10.0,20.0"
+
+    # Sync specific objects with name mapping
+    copick sync segmentations -c source_config.json --target-config target_config.json \\
+        --source-objects "ribosome,membrane" --target-objects "ribosome:ribo,membrane:mem"
+    """
+    logger = get_logger(__name__, debug=debug)
+
+    # Parse arguments
+    source_runs_list = parse_list(source_runs) if source_runs else None
+    target_runs_dict = parse_mapping(target_runs) if target_runs else None
+    voxel_spacings_list = [float(x) for x in parse_list(voxel_spacings)] if voxel_spacings else None
+    source_names_list = parse_list(source_names) if source_names else None
+    target_names_dict = parse_mapping(target_names) if target_names else None
+    source_users_list = parse_list(source_users) if source_users else None
+    target_users_dict = parse_mapping(target_users) if target_users else None
+
+    # Handle dataportal source configuration
+    temp_config_path = None
+    if source_dataset_ids:
+        dataset_ids = parse_dataset_ids(source_dataset_ids)
+        temp_config_path = create_dataportal_config(dataset_ids)
+        source_config = temp_config_path
+    else:
+        source_config = config
+
+    # Load configurations
+    import copick
+
+    source_root = copick.from_file(source_config)
+    target_root = copick.from_file(target_config)
+
+    try:
+        # For segmentations, ensure pickable objects exist if we have specific segmentation names
+        # (non-multilabel segmentations require the segmentation name to match a pickable object)
+        if source_names_list is not None:
+            # Use segmentation names as pickable object names for validation
+            target_names_for_objects = target_names_dict if target_names_dict else {}
+            ensure_pickable_objects(
+                source_root=source_root,
+                target_root=target_root,
+                target_config_path=target_config,
+                source_objects_list=source_names_list,
+                target_objects_dict=target_names_for_objects,
+                log=log,
+            )
+
+        # Perform synchronization
+        sync_segmentations(
+            source_root=source_root,
+            target_root=target_root,
+            source_runs=source_runs_list,
+            target_runs=target_runs_dict,
+            voxel_spacings=voxel_spacings_list,
+            source_names=source_names_list,
+            target_names=target_names_dict,
+            source_users=source_users_list,
+            target_users=target_users_dict,
+            exist_ok=exist_ok,
+            max_workers=max_workers,
+            log=log,
+        )
+
+        logger.info("Segmentations synchronization completed successfully.")
+    finally:
+        # Clean up temporary files
+        if temp_config_path and os.path.exists(temp_config_path):
+            os.unlink(temp_config_path)
+
+
+@sync.command(short_help="Synchronize tomograms between two Copick projects.")
+@add_config_option
+@click.option(
+    "--source-dataset-ids",
+    type=str,
+    help="Comma-separated list of dataset IDs to use as source from CryoET Data Portal. If provided, --config will be ignored and a temporary dataportal configuration will be created.",
+    default="",
+    required=False,
+)
+@click.option(
+    "--target-config",
+    type=str,
+    help="Path to the target configuration file.",
+    required=True,
+    metavar="PATH",
+)
+@click.option(
+    "--source-runs",
+    type=str,
+    help="Comma-separated list of source run names to synchronize. If not specified, all runs will be synced.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--target-runs",
+    type=str,
+    help="Comma-separated mapping of source run names to target run names (e.g. 'run1:target1,run2:target2'). If not specified, source run names will be used.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--voxel-spacings",
+    type=str,
+    help="Comma-separated list of voxel spacings to consider for synchronization. If not specified, all voxel spacings will be synced.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--source-tomo-types",
+    type=str,
+    help="Comma-separated list of source tomogram types to synchronize. If not specified, all tomogram types will be synced.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--target-tomo-types",
+    type=str,
+    help="Comma-separated mapping of source tomogram types to target types (e.g. 'wbp:filtered,raw:original'). If not specified, source tomogram types will be used.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--exist-ok/--no-exist-ok",
+    is_flag=True,
+    help="Allow overwriting existing tomograms in the target project.",
+    show_default=True,
+    default=False,
+)
+@click.option(
+    "--max-workers",
+    type=int,
+    help="Maximum number of worker threads to use for synchronization.",
+    default=4,
+    show_default=True,
+)
+@click.option(
+    "--log/--no-log",
+    is_flag=True,
+    help="Enable verbose logging of the synchronization process.",
+    show_default=True,
+    default=False,
+)
+@add_debug_option
+def tomograms(
+    config,
+    source_dataset_ids,
+    target_config,
+    source_runs,
+    target_runs,
+    voxel_spacings,
+    source_tomo_types,
+    target_tomo_types,
+    exist_ok,
+    max_workers,
+    log,
+    debug,
+):
+    """Synchronize tomograms between two Copick projects.
+
+    This command copies tomogram data from a source Copick project to a target project.
+    You can specify which runs, voxel spacings, and tomogram types to sync, and optionally
+    map source names to different target names.
+
+    Examples:
+
+    # Sync all tomograms from all runs
+    copick sync tomograms -c source_config.json --target-config target_config.json
+
+    # Sync specific runs and voxel spacings
+    copick sync tomograms -c source_config.json --target-config target_config.json \\
+        --source-runs "run1,run2" --voxel-spacings "10.0,20.0"
+
+    # Sync specific tomogram types with name mapping
+    copick sync tomograms -c source_config.json --target-config target_config.json \\
+        --source-tomo-types "wbp,raw" --target-tomo-types "wbp:filtered,raw:original"
+    """
+    logger = get_logger(__name__, debug=debug)
+
+    # Parse arguments
+    source_runs_list = parse_list(source_runs) if source_runs else None
+    target_runs_dict = parse_mapping(target_runs) if target_runs else None
+    voxel_spacings_list = [float(x) for x in parse_list(voxel_spacings)] if voxel_spacings else None
+    source_tomo_types_list = parse_list(source_tomo_types) if source_tomo_types else None
+    target_tomo_types_dict = parse_mapping(target_tomo_types) if target_tomo_types else None
+
+    # Handle dataportal source configuration
+    temp_config_path = None
+    if source_dataset_ids:
+        dataset_ids = parse_dataset_ids(source_dataset_ids)
+        temp_config_path = create_dataportal_config(dataset_ids)
+        source_config = temp_config_path
+    else:
+        source_config = config
+
+    # Load configurations
+    import copick
+
+    source_root = copick.from_file(source_config)
+    target_root = copick.from_file(target_config)
+
+    try:
+        # Perform synchronization
+        sync_tomograms(
+            source_root=source_root,
+            target_root=target_root,
+            source_runs=source_runs_list,
+            target_runs=target_runs_dict,
+            voxel_spacings=voxel_spacings_list,
+            source_tomo_types=source_tomo_types_list,
+            target_tomo_types=target_tomo_types_dict,
+            exist_ok=exist_ok,
+            max_workers=max_workers,
+            log=log,
+        )
+
+        logger.info("Tomograms synchronization completed successfully.")
+    finally:
+        # Clean up temporary files
+        if temp_config_path and os.path.exists(temp_config_path):
+            os.unlink(temp_config_path)

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -2089,7 +2089,7 @@ class CopickPicks:
 
         """
 
-        if positions.shape[0] != transforms.shape[0]:
+        if transforms is not None and positions.shape[0] != transforms.shape[0]:
             raise ValueError("Number of positions and transforms must be the same.")
 
         points = []

--- a/src/copick/ops/run.py
+++ b/src/copick/ops/run.py
@@ -111,11 +111,11 @@ def report_results(
 
     # Report results
     if all_errors:
-        logger.error(f"Failed to process {len(all_errors)} runs:")
+        logger.error(f"Failed to process {len(all_errors)} items:")
         for error in all_errors:
             logger.error(error)
 
         if total_processed > 0:
-            logger.info(f"Successfully processed {total_processed} out of {total_files} runs")
+            logger.info(f"Successfully processed {total_processed} out of {total_files} items")
     else:
-        logger.info(f"Successfully processed all {total_processed} runs")
+        logger.info(f"Successfully processed all {total_processed} items")

--- a/src/copick/ops/sync.py
+++ b/src/copick/ops/sync.py
@@ -1,0 +1,671 @@
+from typing import Any, Dict, List, Optional
+
+from zarr.convenience import copy_store
+
+from copick.models import CopickRoot, CopickRun
+from copick.ops.run import map_runs
+from copick.util.log import get_logger
+
+logger = get_logger(__name__)
+
+
+def _sync_picks_worker(
+    run: CopickRun,
+    target_root: CopickRoot,
+    target_run_name: str,
+    source_objects: List[str],
+    target_objects: Dict[str, str],
+    source_users: Optional[List[str]],
+    target_users: Optional[Dict[str, str]],
+    exist_ok: bool,
+    log: bool,
+) -> Dict[str, Any]:
+    """Worker function for syncing picks from one run to another.
+
+    Args:
+        run: The source CopickRun to sync picks from.
+        target_root: The target CopickRoot where picks will be synced to.
+        target_run_name: The name of the target run in the target root.
+        source_objects: List of source object names to sync picks for.
+        target_objects: Dictionary mapping source object names to target object names in the target root.
+        exist_ok: Whether to overwrite existing picks in the target project.
+        log: Whether to log the synchronization process.
+
+    Returns:
+        A dictionary with the number of processed picks and any errors encountered during the sync.
+    """
+    result = {"processed": 0, "errors": []}
+
+    try:
+        target_run = target_root.get_run(target_run_name)
+
+        for source_obj in source_objects:
+            target_obj = target_objects.get(source_obj, source_obj)
+
+            # Check if target object exists
+            if target_root.get_object(target_obj) is None:
+                result["errors"].append(f"Target object {target_obj} not found in target root")
+                continue
+
+            # Get all picks for this object in the source run
+            source_picks = run.get_picks(object_name=source_obj)
+
+            for pick in source_picks:
+                try:
+                    # Filter by source users if specified
+                    if source_users and pick.user_id not in source_users:
+                        continue
+
+                    # Map user ID
+                    target_user_id = target_users.get(pick.user_id, pick.user_id) if target_users else pick.user_id
+
+                    # Create or get target pick
+                    target_pick = target_run.new_picks(
+                        object_name=target_obj,
+                        user_id=target_user_id,
+                        session_id=pick.session_id,
+                        exist_ok=exist_ok,
+                    )
+
+                    # Copy points
+                    target_pick.points = pick.points
+                    target_pick.store()
+
+                    result["processed"] += 1
+
+                    if log:
+                        logger.info(f"Synced picks {source_obj} -> {target_obj} from {run.name} to {target_run_name}")
+
+                except Exception as e:
+                    result["errors"].append(f"Error syncing picks {source_obj} from {run.name}: {str(e)}")
+
+    except Exception as e:
+        result["errors"].append(f"Error processing run {run.name}: {str(e)}")
+
+    return result
+
+
+def _sync_meshes_worker(
+    run: CopickRun,
+    target_root: CopickRoot,
+    target_run_name: str,
+    source_objects: List[str],
+    target_objects: Dict[str, str],
+    source_users: Optional[List[str]],
+    target_users: Optional[Dict[str, str]],
+    exist_ok: bool,
+    log: bool,
+) -> Dict[str, Any]:
+    """Worker function for syncing meshes from one run to another.
+
+    Args:
+        run: The source CopickRun to sync meshes from.
+        target_root: The target CopickRoot where meshes will be synced to.
+        target_run_name: The name of the target run in the target root.
+        source_objects: List of source object names to sync meshes for.
+        target_objects: Dictionary mapping source object names to target object names in the target root.
+        exist_ok: Whether to overwrite existing meshes in the target project.
+        log: Whether to log the synchronization process.
+
+    Returns:
+        A dictionary with the number of processed meshes and any errors encountered.
+    """
+    result = {"processed": 0, "errors": []}
+
+    try:
+        target_run = target_root.get_run(target_run_name)
+
+        for source_obj in source_objects:
+            target_obj = target_objects.get(source_obj, source_obj)
+
+            # Check if target object exists
+            if target_root.get_object(target_obj) is None:
+                result["errors"].append(f"Target object {target_obj} not found in target root")
+                continue
+
+            # Get all meshes for this object in the source run
+            source_meshes = run.get_meshes(object_name=source_obj)
+
+            for mesh in source_meshes:
+                try:
+                    # Filter by source users if specified
+                    if source_users and mesh.user_id not in source_users:
+                        continue
+
+                    # Map user ID
+                    target_user_id = target_users.get(mesh.user_id, mesh.user_id) if target_users else mesh.user_id
+
+                    # Create or get target mesh
+                    target_mesh = target_run.new_mesh(
+                        object_name=target_obj,
+                        user_id=target_user_id,
+                        session_id=mesh.session_id,
+                        exist_ok=exist_ok,
+                    )
+
+                    # Copy mesh data
+                    target_mesh.mesh = mesh.mesh
+                    target_mesh.store()
+
+                    result["processed"] += 1
+
+                    if log:
+                        logger.info(f"Synced mesh {source_obj} -> {target_obj} from {run.name} to {target_run_name}")
+
+                except Exception as e:
+                    result["errors"].append(f"Error syncing mesh {source_obj} from {run.name}: {str(e)}")
+
+    except Exception as e:
+        result["errors"].append(f"Error processing run {run.name}: {str(e)}")
+
+    return result
+
+
+def _sync_segmentations_worker(
+    run: CopickRun,
+    target_root: CopickRoot,
+    target_run_name: str,
+    voxel_spacings: List[float],
+    source_names: Optional[List[str]],
+    target_names: Dict[str, str],
+    source_users: Optional[List[str]],
+    target_users: Optional[Dict[str, str]],
+    exist_ok: bool,
+    log: bool,
+) -> Dict[str, Any]:
+    """Worker function for syncing segmentations from one run to another.
+
+    Args:
+        run: The source CopickRun to sync segmentations from.
+        target_root: The target CopickRoot where segmentations will be synced to.
+        target_run_name: The name of the target run in the target root.
+        voxel_spacings: List of voxel spacings to consider for synchronization. If None, all voxel spacings are used.
+        source_names: List of source segmentation names to sync. If None, all segmentations are synced.
+        target_names: Dictionary mapping source segmentation names to target names.
+        source_users: List of source user IDs to sync. If None, all users are synced.
+        target_users: Dictionary mapping source user IDs to target user IDs.
+        exist_ok: Whether to overwrite existing segmentations in the target project.
+        log: Whether to log the synchronization process.
+
+    Returns:
+        A dictionary with the number of processed segmentations and any errors encountered.
+    """
+    result = {"processed": 0, "errors": []}
+
+    try:
+        target_run = target_root.get_run(target_run_name)
+        source_segmentations = run.get_segmentations(voxel_size=voxel_spacings)
+
+        for segmentation in source_segmentations:
+            try:
+                # Filter by source names if specified
+                seg_name = getattr(segmentation, "name", None)
+                if source_names is not None and seg_name and seg_name not in source_names:
+                    continue
+
+                # Filter by source users if specified
+                if source_users and segmentation.user_id not in source_users:
+                    continue
+
+                # Map user ID
+                target_user_id = (
+                    target_users.get(segmentation.user_id, segmentation.user_id)
+                    if target_users
+                    else segmentation.user_id
+                )
+
+                # Get target name
+                target_name = target_names.get(seg_name, seg_name) if seg_name else None
+
+                # Create or get target segmentation
+                target_seg = target_run.new_segmentation(
+                    name=target_name,
+                    user_id=target_user_id,
+                    session_id=segmentation.session_id,
+                    voxel_size=segmentation.voxel_size,
+                    is_multilabel=segmentation.is_multilabel,
+                    exist_ok=exist_ok,
+                )
+
+                # Copy segmentation data
+                if_exists = "replace" if exist_ok else "raise"
+                src = segmentation.zarr()
+                trg = target_seg.zarr()
+                copy_store(src, trg, if_exists=if_exists)
+
+                result["processed"] += 1
+
+                if log:
+                    logger.info(
+                        f"Synced segmentation {seg_name} from {run.name} to {target_run_name} at voxel size {segmentation.voxel_size}",
+                    )
+
+            except Exception as e:
+                result["errors"].append(f"Error syncing segmentation from {run.name}: {str(e)}")
+
+    except Exception as e:
+        result["errors"].append(f"Error processing run {run.name}: {str(e)}")
+
+    return result
+
+
+def _sync_tomograms_worker(
+    run: CopickRun,
+    target_root: CopickRoot,
+    target_run_name: str,
+    voxel_spacings: List[float],
+    source_tomo_types: List[str],
+    target_tomo_types: Dict[str, str],
+    exist_ok: bool,
+    log: bool,
+) -> Dict[str, Any]:
+    """Worker function for syncing tomograms from one run to another.
+
+    Args:
+        run: The source CopickRun to sync tomograms from.
+        target_root: The target CopickRoot where tomograms will be synced to.
+        target_run_name: The name of the target run in the target root.
+        voxel_spacings: List of voxel spacings to consider for synchronization. If None, all voxel spacings are used.
+        source_tomo_types: List of source tomogram types to sync. If None, all tomogram types are synced.
+        target_tomo_types: Dictionary mapping source tomogram types to target types in the target root.
+        exist_ok: Whether to overwrite existing tomograms in the target project.
+        log: Whether to log the synchronization process.
+
+    Returns:
+        A dictionary with the number of processed tomograms and any errors encountered.
+    """
+    result = {"processed": 0, "errors": []}
+
+    try:
+        target_run = target_root.get_run(target_run_name)
+
+        if voxel_spacings is None:
+            voxel_spacings = [vs.voxel_size for vs in run.voxel_spacings]
+
+        for voxel_size in voxel_spacings:
+            try:
+                source_voxel_spacing = run.get_voxel_spacing(voxel_size)
+                target_voxel_spacing = target_run.new_voxel_spacing(voxel_size, exist_ok=True)
+
+                if source_voxel_spacing is None:
+                    result["errors"].append(f"Source voxel spacing {voxel_size} not found in run {run.name}")
+                    continue
+
+                if target_voxel_spacing is None:
+                    result["errors"].append(f"Target voxel spacing {voxel_size} not found in run {target_run_name}")
+                    continue
+
+                if source_tomo_types is None:
+                    source_tomo_types = [tomo.tomo_type for tomo in source_voxel_spacing.tomograms]
+
+                for source_tomo_type in source_tomo_types:
+                    target_tomo_type = target_tomo_types.get(source_tomo_type, source_tomo_type)
+
+                    try:
+                        source_tomogram = source_voxel_spacing.get_tomograms(source_tomo_type)
+                        if len(source_tomogram) == 0:
+                            result["errors"].append(f"Source tomogram {source_tomo_type} not found in run {run.name}")
+                            continue
+                        else:
+                            source_tomogram = source_tomogram[0]
+
+                        # Create or get target tomogram
+                        target_tomogram = target_voxel_spacing.new_tomogram(
+                            tomo_type=target_tomo_type,
+                            exist_ok=exist_ok,
+                        )
+
+                        # Copy tomogram data
+                        if_exists = "replace" if exist_ok else "raise"
+                        src = source_tomogram.zarr()
+                        trg = target_tomogram.zarr()
+                        copy_store(src, trg, if_exists=if_exists)
+
+                        result["processed"] += 1
+
+                        if log:
+                            logger.info(
+                                f"Synced tomogram {source_tomo_type} -> {target_tomo_type} from {run.name} to {target_run_name} at voxel size {voxel_size}",
+                            )
+
+                    except Exception as e:
+                        result["errors"].append(f"Error syncing tomogram {source_tomo_type} from {run.name}: {str(e)}")
+
+            except Exception as e:
+                result["errors"].append(f"Error processing voxel spacing {voxel_size} in run {run.name}: {str(e)}")
+
+    except Exception as e:
+        result["errors"].append(f"Error processing run {run.name}: {str(e)}")
+
+    return result
+
+
+def sync_picks(
+    source_root: CopickRoot,
+    target_root: CopickRoot,
+    source_runs: Optional[List[str]] = None,
+    target_runs: Optional[Dict[str, str]] = None,
+    source_objects: Optional[List[str]] = None,
+    target_objects: Optional[Dict[str, str]] = None,
+    source_users: Optional[List[str]] = None,
+    target_users: Optional[Dict[str, str]] = None,
+    exist_ok: bool = False,
+    max_workers: int = 4,
+    log: bool = False,
+) -> None:
+    """
+    Synchronize picks between two Copick projects.
+
+    Args:
+        source_root: The source Copick project root.
+        target_root: The target Copick project root.
+        source_runs: The list of source run names to synchronize.
+        target_runs: A dictionary mapping source run names to target run names.
+        source_objects: The list of source object types to synchronize.
+        target_objects: The dictionary mapping source object types to target types.
+        source_users: The list of source user IDs to synchronize. If None, all users are synced.
+        target_users: The dictionary mapping source user IDs to target user IDs.
+        exist_ok: Whether to overwrite existing picks in the target project.
+        max_workers: The maximum number of worker threads to use for synchronization.
+        log: Whether to log the synchronization process.
+
+    """
+    # Get runs to process
+    if source_runs is None:
+        source_runs = [run.name for run in source_root.runs]
+
+    # Set up run name mapping
+    if target_runs is None:
+        target_runs = {run: run for run in source_runs}
+
+    # Get objects to process
+    if source_objects is None:
+        source_objects = [obj.name for obj in source_root.config.pickable_objects]
+
+    # Set up object name mapping
+    if target_objects is None:
+        target_objects = {obj: obj for obj in source_objects}
+
+    # Create target runs if they don't exist
+    for source_run_name in source_runs:
+        target_run_name = target_runs[source_run_name]
+        target_root.new_run(target_run_name, exist_ok=True)
+        if log:
+            logger.info(f"Ensured target run {target_run_name} exists")
+
+    # Create run args for parallel processing
+    run_args = [
+        {
+            "target_root": target_root,
+            "target_run_name": target_runs[run_name],
+            "source_objects": source_objects,
+            "target_objects": target_objects,
+            "source_users": source_users,
+            "target_users": target_users,
+            "exist_ok": exist_ok,
+            "log": log,
+        }
+        for run_name in source_runs
+    ]
+
+    # Execute in parallel
+    results = map_runs(
+        callback=_sync_picks_worker,
+        root=source_root,
+        runs=source_runs,
+        workers=max_workers,
+        run_args=run_args,
+        show_progress=log,
+        task_desc="Syncing picks",
+    )
+
+    # Report results
+    from copick.ops.run import report_results
+
+    report_results(results, len(source_runs), logger)
+
+
+def sync_segmentations(
+    source_root: CopickRoot,
+    target_root: CopickRoot,
+    source_runs: Optional[List[str]] = None,
+    target_runs: Optional[Dict[str, str]] = None,
+    voxel_spacings: Optional[List[float]] = None,
+    source_names: Optional[List[str]] = None,
+    target_names: Optional[Dict[str, str]] = None,
+    source_users: Optional[List[str]] = None,
+    target_users: Optional[Dict[str, str]] = None,
+    exist_ok: bool = False,
+    max_workers: int = 4,
+    log: bool = False,
+) -> None:
+    """
+    Synchronize segmentations between two Copick projects.
+
+    Args:
+        source_root: The source Copick project root.
+        target_root: The target Copick project root.
+        source_runs: The list of source run names to synchronize.
+        target_runs: A dictionary mapping source run names to target run names.
+        voxel_spacings: The voxel spacings to consider for synchronization.
+        source_names: The list of source segmentation names to synchronize. If None, all segmentations are synced.
+        target_names: The dictionary mapping source segmentation names to target names.
+        source_users: The list of source user IDs to synchronize. If None, all users are synced.
+        target_users: The dictionary mapping source user IDs to target user IDs.
+        exist_ok: Whether to overwrite existing segmentations in the target project.
+        max_workers: The maximum number of worker threads to use for synchronization.
+        log: Whether to log the synchronization process.
+
+    """
+    # Get runs to process
+    if source_runs is None:
+        source_runs = [run.name for run in source_root.runs]
+
+    # Set up run name mapping
+    if target_runs is None:
+        target_runs = {run: run for run in source_runs}
+
+    # Set up name mapping (source_names can be None to sync all segmentations)
+    if target_names is None:
+        target_names = {}
+
+    # Create target runs if they don't exist
+    for source_run_name in source_runs:
+        target_run_name = target_runs[source_run_name]
+        target_root.new_run(target_run_name, exist_ok=True)
+        if log:
+            logger.info(f"Ensured target run {target_run_name} exists")
+
+    # Create run args for parallel processing
+    run_args = [
+        {
+            "target_root": target_root,
+            "target_run_name": target_runs[run_name],
+            "voxel_spacings": voxel_spacings,
+            "source_names": source_names,
+            "target_names": target_names,
+            "source_users": source_users,
+            "target_users": target_users,
+            "exist_ok": exist_ok,
+            "log": log,
+        }
+        for run_name in source_runs
+    ]
+
+    # Execute in parallel
+    results = map_runs(
+        callback=_sync_segmentations_worker,
+        root=source_root,
+        runs=source_runs,
+        workers=max_workers,
+        run_args=run_args,
+        show_progress=log,
+        task_desc="Syncing segmentations",
+    )
+
+    # Report results
+    from copick.ops.run import report_results
+
+    report_results(results, len(source_runs), logger)
+
+
+def sync_meshes(
+    source_root: CopickRoot,
+    target_root: CopickRoot,
+    source_runs: Optional[List[str]] = None,
+    target_runs: Optional[Dict[str, str]] = None,
+    source_objects: Optional[List[str]] = None,
+    target_objects: Optional[Dict[str, str]] = None,
+    source_users: Optional[List[str]] = None,
+    target_users: Optional[Dict[str, str]] = None,
+    exist_ok: bool = False,
+    max_workers: int = 4,
+    log: bool = False,
+) -> None:
+    """
+    Synchronize meshes between two Copick projects.
+
+    Args:
+        source_root: The source Copick project root.
+        target_root: The target Copick project root.
+        source_runs: The list of source run names to synchronize.
+        target_runs: A dictionary mapping source run names to target run names.
+        source_objects: The list of source object types to synchronize.
+        target_objects: The dictionary mapping source object types to target types.
+        source_users: The list of source user IDs to synchronize. If None, all users are synced.
+        target_users: The dictionary mapping source user IDs to target user IDs.
+        exist_ok: Whether to overwrite existing meshes in the target project.
+        max_workers: The maximum number of worker threads to use for synchronization.
+        log: Whether to log the synchronization process.
+
+    """
+    # Get runs to process
+    if source_runs is None:
+        source_runs = [run.name for run in source_root.runs]
+
+    # Set up run name mapping
+    if target_runs is None:
+        target_runs = {run: run for run in source_runs}
+
+    # Get objects to process
+    if source_objects is None:
+        source_objects = [obj.name for obj in source_root.config.pickable_objects]
+
+    # Set up object name mapping
+    if target_objects is None:
+        target_objects = {obj: obj for obj in source_objects}
+
+    # Create target runs if they don't exist
+    for source_run_name in source_runs:
+        target_run_name = target_runs[source_run_name]
+        target_root.new_run(target_run_name, exist_ok=True)
+        if log:
+            logger.info(f"Ensured target run {target_run_name} exists")
+
+    # Create run args for parallel processing
+    run_args = [
+        {
+            "target_root": target_root,
+            "target_run_name": target_runs[run_name],
+            "source_objects": source_objects,
+            "target_objects": target_objects,
+            "source_users": source_users,
+            "target_users": target_users,
+            "exist_ok": exist_ok,
+            "log": log,
+        }
+        for run_name in source_runs
+    ]
+
+    # Execute in parallel
+    results = map_runs(
+        callback=_sync_meshes_worker,
+        root=source_root,
+        runs=source_runs,
+        workers=max_workers,
+        run_args=run_args,
+        show_progress=log,
+        task_desc="Syncing meshes",
+    )
+
+    # Report results
+    from copick.ops.run import report_results
+
+    report_results(results, len(source_runs), logger)
+
+
+def sync_tomograms(
+    source_root: CopickRoot,
+    target_root: CopickRoot,
+    source_runs: Optional[List[str]] = None,
+    target_runs: Optional[Dict[str, str]] = None,
+    voxel_spacings: Optional[List[float]] = None,
+    source_tomo_types: Optional[List[str]] = None,
+    target_tomo_types: Optional[Dict[str, str]] = None,
+    exist_ok: bool = False,
+    max_workers: int = 4,
+    log: bool = False,
+) -> None:
+    """
+    Synchronize tomograms between two Copick projects.
+
+    Args:
+        source_root: The source Copick project root.
+        target_root: The target Copick project root.
+        source_runs: The list of source run names to synchronize.
+        target_runs: A dictionary mapping source run names to target run names.
+        voxel_spacings: The voxel spacings to consider for synchronization.
+        source_tomo_types: The list of source tomogram types to synchronize.
+        target_tomo_types: The dictionary mapping source tomogram types to target types.
+        exist_ok: Whether to overwrite existing tomograms in the target project.
+        max_workers: The maximum number of worker threads to use for synchronization.
+        log: Whether to log the synchronization process.
+
+    """
+    # Get runs to process
+    if source_runs is None:
+        source_runs = [run.name for run in source_root.runs]
+
+    # Set up run name mapping
+    if target_runs is None:
+        target_runs = {run: run for run in source_runs}
+
+    if target_tomo_types is None:
+        target_tomo_types = {}
+
+    # Create target runs if they don't exist
+    for source_run_name in source_runs:
+        target_run_name = target_runs[source_run_name]
+        target_root.new_run(target_run_name, exist_ok=True)
+        if log:
+            logger.info(f"Ensured target run {target_run_name} exists")
+
+    # Create run args for parallel processing
+    run_args = [
+        {
+            "target_root": target_root,
+            "target_run_name": target_runs[run_name],
+            "voxel_spacings": voxel_spacings,
+            "source_tomo_types": source_tomo_types,
+            "target_tomo_types": target_tomo_types,
+            "exist_ok": exist_ok,
+            "log": log,
+        }
+        for run_name in source_runs
+    ]
+
+    # Execute in parallel
+    results = map_runs(
+        callback=_sync_tomograms_worker,
+        root=source_root,
+        runs=source_runs,
+        workers=max_workers,
+        run_args=run_args,
+        show_progress=log,
+        task_desc="Syncing tomograms",
+    )
+
+    # Report results
+    from copick.ops.run import report_results
+
+    report_results(results, len(source_runs), logger)

--- a/src/copick/util/sync.py
+++ b/src/copick/util/sync.py
@@ -1,0 +1,184 @@
+"""Utilities for synchronization operations between Copick projects."""
+
+import os
+import tempfile
+from typing import Dict, List
+
+from copick.models import CopickRoot
+from copick.util.log import get_logger
+
+
+def parse_mapping(mapping_str: str) -> Dict[str, str]:
+    """Parse a mapping string like 'run1:target1,run2:target2' into a dictionary.
+
+    Args:
+        mapping_str: String containing comma-separated mappings with optional colons.
+
+    Returns:
+        Dictionary mapping source names to target names.
+    """
+    if not mapping_str:
+        return {}
+
+    mapping = {}
+    for pair in mapping_str.split(","):
+        if ":" in pair:
+            source, target = pair.split(":", 1)
+            mapping[source.strip()] = target.strip()
+        else:
+            # If no colon, map to itself
+            mapping[pair.strip()] = pair.strip()
+    return mapping
+
+
+def parse_list(list_str: str) -> List[str]:
+    """Parse a comma-separated string into a list.
+
+    Args:
+        list_str: String containing comma-separated values.
+
+    Returns:
+        List of trimmed string values.
+    """
+    if not list_str:
+        return []
+    return [item.strip() for item in list_str.split(",")]
+
+
+def parse_dataset_ids(dataset_ids_str: str) -> List[int]:
+    """Parse a comma-separated string into a list of dataset IDs.
+
+    Args:
+        dataset_ids_str: String containing comma-separated dataset IDs.
+
+    Returns:
+        List of integer dataset IDs.
+    """
+    if not dataset_ids_str:
+        return []
+    return [int(item.strip()) for item in dataset_ids_str.split(",")]
+
+
+def create_dataportal_config(dataset_ids: List[int]) -> str:
+    """Create a temporary dataportal configuration file.
+
+    Args:
+        dataset_ids: List of dataset IDs to include in the configuration.
+
+    Returns:
+        str: Path to the temporary configuration file.
+    """
+    import copick
+
+    # Create a temporary directory for the overlay
+    temp_dir = tempfile.mkdtemp(prefix="copick_sync_")
+    overlay_root = os.path.join(temp_dir, "overlay")
+
+    # Create a temporary config file
+    config_fd, config_path = tempfile.mkstemp(suffix=".json", prefix="copick_sync_config_")
+    os.close(config_fd)
+
+    # Create the dataportal configuration
+    copick.from_czcdp_datasets(
+        dataset_ids=dataset_ids,
+        overlay_root=overlay_root,
+        overlay_fs_args={"auto_mkdir": True},
+        output_path=config_path,
+    )
+
+    return config_path
+
+
+def ensure_pickable_objects(
+    source_root: CopickRoot,
+    target_root: CopickRoot,
+    target_config_path: str,
+    source_objects_list: List[str],
+    target_objects_dict: Dict[str, str],
+    log: bool = False,
+) -> None:
+    """Ensure that all required pickable objects exist in the target project.
+
+    Creates missing pickable objects in the target project by copying them from
+    the source project, respecting the intended target names. Saves the target
+    configuration after creating new objects.
+
+    Args:
+        source_root: The source Copick project root.
+        target_root: The target Copick project root.
+        target_config_path: Path to the target configuration file to save.
+        source_objects_list: List of source object names to sync.
+        target_objects_dict: Dictionary mapping source object names to target names.
+        log: Whether to log the object creation process.
+    """
+    logger = get_logger(__name__)
+
+    # Get all target object names we need to ensure exist
+    target_objects_needed = set()
+    for source_obj in source_objects_list:
+        target_obj = target_objects_dict.get(source_obj, source_obj)
+        target_objects_needed.add(target_obj)
+
+    # Check which objects already exist in target
+    existing_target_objects = {obj.name for obj in target_root.pickable_objects}
+
+    # Find objects that need to be created
+    objects_to_create = target_objects_needed - existing_target_objects
+
+    if not objects_to_create:
+        if log:
+            logger.info("All required pickable objects already exist in target project.")
+        return
+
+    # Create missing objects by copying from source
+    objects_created = False
+    for source_obj in source_objects_list:
+        target_obj = target_objects_dict.get(source_obj, source_obj)
+
+        if target_obj not in objects_to_create:
+            continue
+
+        # Find the source object definition
+        source_obj_def = source_root.get_object(source_obj)
+        if source_obj_def is None:
+            logger.warning(f"Source object '{source_obj}' not found in source project - skipping")
+            continue
+
+        # Copy the object definition to target, using the target name
+        # Find an available label to avoid conflicts
+        existing_labels = {obj.label for obj in target_root.pickable_objects}
+        target_label = source_obj_def.label
+        while target_label in existing_labels:
+            target_label += 1
+
+        try:
+            target_root.new_object(
+                name=target_obj,
+                is_particle=source_obj_def.is_particle,
+                label=target_label,  # Use a non-conflicting label
+                color=source_obj_def.color,
+                emdb_id=source_obj_def.emdb_id,
+                pdb_id=source_obj_def.pdb_id,
+                identifier=source_obj_def.identifier,
+                map_threshold=source_obj_def.map_threshold,
+                radius=source_obj_def.radius,
+                exist_ok=True,
+            )
+
+            objects_created = True
+            if log:
+                logger.info(f"Created pickable object '{target_obj}' in target project (copied from '{source_obj}')")
+
+        except Exception as e:
+            logger.error(f"Failed to create pickable object '{target_obj}': {e}")
+            raise
+
+    # Save the target configuration if any objects were created
+    if objects_created:
+        try:
+            target_root.save_config(target_config_path)
+            if log:
+                logger.info(f"Saved target configuration to {target_config_path}")
+        except Exception as e:
+            logger.error(f"Failed to save target configuration: {e}")
+            raise

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -1,0 +1,1078 @@
+"""Tests for the sync CLI commands."""
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+import pytest
+import trimesh
+from click.testing import CliRunner
+from copick.cli.sync import sync
+from copick.impl.filesystem import CopickRootFSSpec
+
+
+@pytest.fixture(params=pytest.common_cases)
+def test_payload(request) -> Dict[str, Any]:
+    payload = request.getfixturevalue(request.param)
+    payload["root"] = CopickRootFSSpec.from_file(payload["cfg_file"])
+    return payload
+
+
+@pytest.fixture
+def runner():
+    """CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def source_target_configs(test_payload):
+    """Create source and target configurations for sync CLI tests."""
+    # Create a target configuration in a temporary location
+    with tempfile.TemporaryDirectory() as tmpdir:
+        target_config_path = Path(tmpdir) / "target_config.json"
+
+        # Copy and modify source config for target
+        with open(test_payload["cfg_file"], "r") as f:
+            source_config = json.load(f)
+
+        # Create target config with different overlay root
+        target_config = source_config.copy()
+        if "overlay_root" in target_config:
+            # Modify the overlay root to point to a different directory
+            overlay_root = target_config["overlay_root"]
+            if overlay_root.startswith("local://"):
+                target_overlay_path = Path(tmpdir) / "target_overlay"
+                target_overlay_path.mkdir()
+                target_config["overlay_root"] = f"local://{target_overlay_path}"
+            else:
+                # For other protocols, just modify the path
+                target_config["overlay_root"] = overlay_root.rstrip("/") + "_target"
+
+        # Write target config
+        with open(target_config_path, "w") as f:
+            json.dump(target_config, f)
+
+        yield {
+            "source_config": test_payload["cfg_file"],
+            "target_config": str(target_config_path),
+            "source_root": test_payload["root"],
+            "target_root": CopickRootFSSpec.from_file(target_config_path),
+        }
+
+
+class TestSyncPicksCLI:
+    """Test cases for the sync picks CLI command."""
+
+    def test_sync_picks_basic(self, source_target_configs, runner):
+        """Test basic picks synchronization via CLI."""
+        source_config = source_target_configs["source_config"]
+        target_config = source_target_configs["target_config"]
+        source_root = source_target_configs["source_root"]
+
+        # Add test picks to source
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("test_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+        objects = list(source_root.pickable_objects)
+        if not objects:
+            pytest.skip("No pickable objects available for testing")
+
+        source_obj = objects[0]
+
+        # Create test picks
+        picks = source_run.new_picks(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+            exist_ok=True,
+        )
+        picks.from_numpy(np.array([[10, 20, 30], [40, 50, 60]]))
+        picks.store()
+
+        # Run sync command
+        result = runner.invoke(
+            sync,
+            [
+                "picks",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--log",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "completed successfully" in result.output
+
+        # Verify picks were synchronized
+        target_root = CopickRootFSSpec.from_file(target_config)
+        target_run = target_root.get_run(source_run.name)
+        assert target_run is not None, "Target run should be created"
+
+        target_picks_list = target_run.get_picks(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+        )
+        assert len(target_picks_list) > 0, "Target picks should be created"
+
+        target_picks = target_picks_list[0]
+        assert len(target_picks.points) == 2, "Target picks should have same number of points"
+
+    def test_sync_picks_with_name_mapping(self, source_target_configs, runner):
+        """Test picks synchronization with name mapping via CLI."""
+        source_config = source_target_configs["source_config"]
+        target_config = source_target_configs["target_config"]
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Add test picks to source
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("source_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+        objects = list(source_root.pickable_objects)
+        if not objects:
+            pytest.skip("No pickable objects available for testing")
+
+        source_obj = objects[0]
+
+        picks = source_run.new_picks(
+            object_name=source_obj.name,
+            user_id="source-user",
+            session_id="test-session",
+            exist_ok=True,
+        )
+        picks.from_numpy(np.array([[10, 20, 30]]))
+        picks.store()
+
+        # Ensure target object exists
+        target_root.new_object(
+            name="target-object",
+            is_particle=source_obj.is_particle,
+            label=999,  # Use a unique label to avoid conflicts
+            exist_ok=True,
+        )
+
+        # Run sync command with name mapping
+        result = runner.invoke(
+            sync,
+            [
+                "picks",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--source-runs",
+                source_run.name,
+                "--target-runs",
+                f"{source_run.name}:target_run",
+                "--source-objects",
+                source_obj.name,
+                "--target-objects",
+                f"{source_obj.name}:target-object",
+                "--source-users",
+                "source-user",
+                "--target-users",
+                "source-user:target-user",
+                "--log",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+
+        # Verify with mapped names
+        target_run = target_root.get_run("target_run")
+        assert target_run is not None, "Target run should be created with mapped name"
+
+        target_picks_list = target_run.get_picks(
+            object_name="target-object",
+            user_id="target-user",  # Fix hyphen vs underscore
+            session_id="test-session",
+        )
+        assert len(target_picks_list) > 0, "Target picks should be created with mapped names"
+
+    def test_sync_picks_with_user_filtering(self, source_target_configs, runner):
+        """Test picks synchronization with user filtering via CLI."""
+        source_config = source_target_configs["source_config"]
+        target_config = source_target_configs["target_config"]
+        source_root = source_target_configs["source_root"]
+
+        # Add test picks from multiple users
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("test_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+        objects = list(source_root.pickable_objects)
+        if not objects:
+            pytest.skip("No pickable objects available for testing")
+
+        source_obj = objects[0]
+
+        # Create picks from user1
+        picks1 = source_run.new_picks(
+            object_name=source_obj.name,
+            user_id="user1",
+            session_id="session1",
+            exist_ok=True,
+        )
+        picks1.from_numpy(np.array([[10, 20, 30]]))
+        picks1.store()
+
+        # Create picks from user2
+        picks2 = source_run.new_picks(
+            object_name=source_obj.name,
+            user_id="user2",
+            session_id="session2",
+            exist_ok=True,
+        )
+        picks2.from_numpy(np.array([[40, 50, 60]]))
+        picks2.store()
+
+        # Sync only user1's picks
+        result = runner.invoke(
+            sync,
+            [
+                "picks",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--source-users",
+                "user1",
+                "--log",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+
+        # Verify only user1's picks were synchronized
+        target_root = CopickRootFSSpec.from_file(target_config)
+        target_run = target_root.get_run(source_run.name)
+
+        user1_picks = target_run.get_picks(
+            object_name=source_obj.name,
+            user_id="user1",
+            session_id="session1",
+        )
+        assert len(user1_picks) > 0, "User1 picks should be synchronized"
+
+        user2_picks = target_run.get_picks(
+            object_name=source_obj.name,
+            user_id="user2",
+            session_id="session2",
+        )
+        assert len(user2_picks) == 0, "User2 picks should not be synchronized"
+
+    def test_sync_picks_with_exist_ok(self, source_target_configs, runner):
+        """Test picks synchronization with exist_ok flag via CLI."""
+        source_config = source_target_configs["source_config"]
+        target_config = source_target_configs["target_config"]
+        source_root = source_target_configs["source_root"]
+
+        # Add test picks to source
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("test_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+        objects = list(source_root.pickable_objects)
+        if not objects:
+            pytest.skip("No pickable objects available for testing")
+
+        source_obj = objects[0]
+
+        picks = source_run.new_picks(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+            exist_ok=True,
+        )
+        picks.from_numpy(np.array([[10.0, 20.0, 30.0]]))
+        picks.store()
+
+        # First sync
+        result1 = runner.invoke(
+            sync,
+            [
+                "picks",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--log",
+            ],
+        )
+        assert result1.exit_code == 0
+
+        # Modify source picks
+        picks.from_numpy(np.array([[10.0, 20.0, 30.0], [70.0, 80.0, 90.0]]))
+        picks.store()
+
+        # Second sync with exist_ok
+        result2 = runner.invoke(
+            sync,
+            [
+                "picks",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--exist-ok",
+                "--log",
+            ],
+        )
+        assert result2.exit_code == 0, f"Second sync failed: {result2.output}"
+
+        # Verify updated picks
+        target_root = CopickRootFSSpec.from_file(target_config)
+        target_run = target_root.get_run(source_run.name)
+        target_picks_list = target_run.get_picks(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+        )
+        target_picks = target_picks_list[0]
+        assert len(target_picks.points) == 2, "Target picks should be updated"
+
+    def test_sync_picks_max_workers(self, source_target_configs, runner):
+        """Test picks synchronization with custom max_workers via CLI."""
+        source_config = source_target_configs["source_config"]
+        target_config = source_target_configs["target_config"]
+        source_root = source_target_configs["source_root"]
+
+        # Add test data to multiple runs
+        for i in range(3):
+            test_run = source_root.new_run(f"test_run_{i}", exist_ok=True)
+            objects = list(source_root.pickable_objects)
+            if objects:
+                source_obj = objects[0]
+                picks = test_run.new_picks(
+                    object_name=source_obj.name,
+                    user_id="test-user",
+                    session_id="test-session",
+                    exist_ok=True,
+                )
+                picks.from_numpy(np.array([[i * 10.0, i * 20.0, i * 30.0]]))
+                picks.store()
+
+        # Run sync with custom max_workers
+        result = runner.invoke(
+            sync,
+            [
+                "picks",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--max-workers",
+                "2",
+                "--log",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+
+    def test_sync_picks_invalid_config(self, runner):
+        """Test picks synchronization with invalid config files."""
+        # Test with non-existent source config
+        result = runner.invoke(
+            sync,
+            [
+                "picks",
+                "--config",
+                "nonexistent_source.json",
+                "--target-config",
+                "nonexistent_target.json",
+            ],
+        )
+
+        assert result.exit_code != 0, "Command should fail with non-existent config"
+
+    def test_sync_picks_missing_target_config(self, source_target_configs, runner):
+        """Test picks synchronization without target config (should fail)."""
+        source_config = source_target_configs["source_config"]
+
+        result = runner.invoke(
+            sync,
+            [
+                "picks",
+                "--config",
+                source_config,
+                # Missing --target-config
+            ],
+        )
+
+        assert result.exit_code != 0, "Command should fail without target config"
+
+
+class TestSyncMeshesCLI:
+    """Test cases for the sync meshes CLI command."""
+
+    def test_sync_meshes_basic(self, source_target_configs, runner):
+        """Test basic meshes synchronization via CLI."""
+        source_config = source_target_configs["source_config"]
+        target_config = source_target_configs["target_config"]
+        source_root = source_target_configs["source_root"]
+
+        # Add test mesh to source
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("test_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+        objects = list(source_root.pickable_objects)
+        if not objects:
+            pytest.skip("No pickable objects available for testing")
+
+        source_obj = objects[0]
+
+        # Create test mesh
+        mesh = source_run.new_mesh(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+            exist_ok=True,
+        )
+
+        # Create simple mesh data
+        vertices = np.array([[0, 0, 0], [1, 0, 0], [0.5, 1, 0]], dtype=np.float32)
+        faces = np.array([[0, 1, 2]], dtype=np.uint32)
+        mesh.mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
+        mesh.store()
+
+        # Run sync command
+        result = runner.invoke(
+            sync,
+            [
+                "meshes",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--log",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "completed successfully" in result.output
+
+        # Verify mesh was synchronized
+        target_root = CopickRootFSSpec.from_file(target_config)
+        target_run = target_root.get_run(source_run.name)
+        assert target_run is not None, "Target run should be created"
+
+        target_meshes = target_run.get_meshes(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+        )
+        assert len(target_meshes) > 0, "Target mesh should be created"
+
+    def test_sync_meshes_with_mapping(self, source_target_configs, runner):
+        """Test meshes synchronization with name mapping via CLI."""
+        source_config = source_target_configs["source_config"]
+        target_config = source_target_configs["target_config"]
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Add test mesh to source
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("source_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+        objects = list(source_root.pickable_objects)
+        if not objects:
+            pytest.skip("No pickable objects available for testing")
+
+        source_obj = objects[0]
+
+        mesh = source_run.new_mesh(
+            object_name=source_obj.name,
+            user_id="source-user",
+            session_id="test-session",
+            exist_ok=True,
+        )
+        vertices = np.array([[0, 0, 0]], dtype=np.float32)
+        faces = np.array([[0]], dtype=np.uint32)
+        mesh.mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
+        mesh.store()
+
+        # Ensure target object exists
+        target_root.new_object(
+            name="target-object",
+            is_particle=source_obj.is_particle,
+            label=998,  # Use a unique label to avoid conflicts
+            exist_ok=True,
+        )
+
+        # Run sync with mapping
+        result = runner.invoke(
+            sync,
+            [
+                "meshes",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--source-runs",
+                source_run.name,
+                "--target-runs",
+                f"{source_run.name}:target_run",
+                "--source-objects",
+                source_obj.name,
+                "--target-objects",
+                f"{source_obj.name}:target-object",
+                "--source-users",
+                "source-user",
+                "--target-users",
+                "source-user:target-user",
+                "--log",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+
+        # Verify with mapped names
+        target_run = target_root.get_run("target_run")
+        assert target_run is not None, "Target run should be created with mapped name"
+
+        target_meshes = target_run.get_meshes(
+            object_name="target-object",
+            user_id="target-user",
+            session_id="test-session",
+        )
+        assert len(target_meshes) > 0, "Target mesh should be created with mapped names"
+
+
+class TestSyncSegmentationsCLI:
+    """Test cases for the sync segmentations CLI command."""
+
+    def test_sync_segmentations_basic(self, source_target_configs, runner):
+        """Test basic segmentations synchronization via CLI."""
+        source_config = source_target_configs["source_config"]
+        target_config = source_target_configs["target_config"]
+        source_root = source_target_configs["source_root"]
+
+        # Add test segmentation to source
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("test_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+
+        segmentation = source_run.new_segmentation(
+            name="test-segmentation",
+            user_id="test-user",
+            session_id="test-session",
+            voxel_size=10.0,
+            is_multilabel=True,  # Use multilabel to avoid needing pickable object
+            exist_ok=True,
+        )
+        test_data = np.random.randint(0, 3, (16, 16, 16), dtype=np.uint8)
+        segmentation.from_numpy(test_data)
+
+        # Run sync command
+        result = runner.invoke(
+            sync,
+            [
+                "segmentations",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--log",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "completed successfully" in result.output
+
+        # Verify segmentation was synchronized
+        target_root = CopickRootFSSpec.from_file(target_config)
+        target_run = target_root.get_run(source_run.name)
+        assert target_run is not None, "Target run should be created"
+
+        target_segmentations = target_run.get_segmentations(
+            name="test-segmentation",
+            user_id="test-user",
+            session_id="test-session",
+            voxel_size=10.0,
+        )
+        assert len(target_segmentations) > 0, "Target segmentation should be created"
+
+    def test_sync_segmentations_with_voxel_filtering(self, source_target_configs, runner):
+        """Test segmentations synchronization with voxel spacing filtering via CLI."""
+        source_config = source_target_configs["source_config"]
+        target_config = source_target_configs["target_config"]
+        source_root = source_target_configs["source_root"]
+
+        # Add test segmentations at different voxel spacings
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("test_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+
+        # Create segmentations at different voxel sizes
+        seg1 = source_run.new_segmentation(
+            name="test-seg-10",
+            user_id="test-user",
+            session_id="test-session",
+            voxel_size=10.0,
+            is_multilabel=True,  # Use multilabel to avoid needing pickable object
+            exist_ok=True,
+        )
+        test_data = np.random.randint(0, 3, (8, 8, 8), dtype=np.uint8)
+        seg1.from_numpy(test_data)
+
+        seg2 = source_run.new_segmentation(
+            name="test-seg-20",
+            user_id="test-user",
+            session_id="test-session",
+            voxel_size=20.0,
+            is_multilabel=True,  # Use multilabel to avoid needing pickable object
+            exist_ok=True,
+        )
+        seg2.from_numpy(test_data)
+
+        # Sync only 10.0 voxel spacing
+        result = runner.invoke(
+            sync,
+            [
+                "segmentations",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--voxel-spacings",
+                "10.0",
+                "--log",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+
+        # Verify only 10.0 spacing was synchronized
+        target_root = CopickRootFSSpec.from_file(target_config)
+        target_run = target_root.get_run(source_run.name)
+
+        target_segs_10 = target_run.get_segmentations(voxel_size=10.0)
+        assert len(target_segs_10) > 0, "10.0 voxel spacing should be synchronized"
+
+        target_segs_20 = target_run.get_segmentations(voxel_size=20.0)
+        assert len(target_segs_20) == 0, "20.0 voxel spacing should not be synchronized"
+
+    def test_sync_segmentations_with_name_mapping(self, source_target_configs, runner):
+        """Test segmentations synchronization with name mapping via CLI."""
+        source_config = source_target_configs["source_config"]
+        target_config = source_target_configs["target_config"]
+        source_root = source_target_configs["source_root"]
+
+        # Add test segmentation
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("source_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+
+        segmentation = source_run.new_segmentation(
+            name="source-segmentation",
+            user_id="source-user",
+            session_id="test-session",
+            voxel_size=10.0,
+            is_multilabel=True,  # Use multilabel to avoid needing pickable object
+            exist_ok=True,
+        )
+        test_data = np.random.randint(0, 3, (8, 8, 8), dtype=np.uint8)
+        segmentation.from_numpy(test_data)
+
+        # Run sync with mapping
+        result = runner.invoke(
+            sync,
+            [
+                "segmentations",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--source-runs",
+                source_run.name,
+                "--target-runs",
+                f"{source_run.name}:target_run",
+                "--source-names",
+                "source-segmentation",
+                "--target-names",
+                "source-segmentation:target-segmentation",
+                "--source-users",
+                "source-user",
+                "--target-users",
+                "source-user:target-user",
+                "--log",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+
+        # Verify with mapped names
+        target_root = CopickRootFSSpec.from_file(target_config)
+        target_run = target_root.get_run("target_run")
+        assert target_run is not None, "Target run should be created with mapped name"
+
+        target_segmentations = target_run.get_segmentations(
+            name="target-segmentation",
+            user_id="target-user",
+            session_id="test-session",
+            voxel_size=10.0,
+        )
+        assert len(target_segmentations) > 0, "Target segmentation should be created with mapped names"
+
+
+class TestSyncTomogramsCLI:
+    """Test cases for the sync tomograms CLI command."""
+
+    def test_sync_tomograms_basic(self, source_target_configs, runner):
+        """Test basic tomograms synchronization via CLI."""
+        source_config = source_target_configs["source_config"]
+        target_config = source_target_configs["target_config"]
+        source_root = source_target_configs["source_root"]
+
+        # Check if we have existing tomograms to sync
+        runs = list(source_root.runs)
+        if not runs:
+            pytest.skip("No runs available for testing")
+
+        source_run = runs[0]
+        voxel_spacings = list(source_run.voxel_spacings)
+        if not voxel_spacings:
+            pytest.skip("No voxel spacings available for testing")
+
+        source_vs = voxel_spacings[0]
+        tomograms = source_vs.tomograms
+        if not tomograms:
+            pytest.skip("No tomograms available for testing")
+
+        # Run sync command
+        result = runner.invoke(
+            sync,
+            [
+                "tomograms",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--log",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        assert "completed successfully" in result.output
+
+        # Verify tomogram was synchronized
+        target_root = CopickRootFSSpec.from_file(target_config)
+        target_run = target_root.get_run(source_run.name)
+        assert target_run is not None, "Target run should be created"
+
+        target_vs = target_run.get_voxel_spacing(source_vs.voxel_size)
+        assert target_vs is not None, "Target voxel spacing should be created"
+
+    def test_sync_tomograms_with_type_mapping(self, source_target_configs, runner):
+        """Test tomograms synchronization with type mapping via CLI."""
+        source_config = source_target_configs["source_config"]
+        target_config = source_target_configs["target_config"]
+        source_root = source_target_configs["source_root"]
+
+        # Check for existing tomograms
+        runs = list(source_root.runs)
+        if not runs:
+            pytest.skip("No runs available for testing")
+
+        source_run = runs[0]
+        voxel_spacings = list(source_run.voxel_spacings)
+        if not voxel_spacings:
+            pytest.skip("No voxel spacings available for testing")
+
+        source_vs = voxel_spacings[0]
+        tomograms = source_vs.tomograms
+        if not tomograms:
+            pytest.skip("No tomograms available for testing")
+
+        source_tomo_type = tomograms[0].tomo_type
+
+        # Run sync with type mapping
+        result = runner.invoke(
+            sync,
+            [
+                "tomograms",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--source-runs",
+                source_run.name,
+                "--target-runs",
+                f"{source_run.name}:target_run",
+                "--source-tomo-types",
+                source_tomo_type,
+                "--target-tomo-types",
+                f"{source_tomo_type}:mapped-type",
+                "--log",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+
+        # Verify with mapped names
+        target_root = CopickRootFSSpec.from_file(target_config)
+        target_run = target_root.get_run("target_run")
+        assert target_run is not None, "Target run should be created with mapped name"
+
+        target_vs = target_run.get_voxel_spacing(source_vs.voxel_size)
+        assert target_vs is not None, "Target voxel spacing should be created"
+
+        target_tomos = target_vs.get_tomograms("mapped-type")
+        assert len(target_tomos) > 0, "Target tomogram should be created with mapped type"
+
+    def test_sync_tomograms_with_voxel_filtering(self, source_target_configs, runner):
+        """Test tomograms synchronization with voxel spacing filtering via CLI."""
+        source_config = source_target_configs["source_config"]
+        target_config = source_target_configs["target_config"]
+        source_root = source_target_configs["source_root"]
+
+        # Check for existing tomograms at different voxel spacings
+        runs = list(source_root.runs)
+        if not runs:
+            pytest.skip("No runs available for testing")
+
+        source_run = runs[0]
+        voxel_spacings = list(source_run.voxel_spacings)
+        if len(voxel_spacings) < 1:
+            pytest.skip("Need at least one voxel spacing for testing")
+
+        # Use the first voxel spacing for filtering
+        target_voxel_size = voxel_spacings[0].voxel_size
+
+        # Run sync with voxel spacing filtering
+        result = runner.invoke(
+            sync,
+            [
+                "tomograms",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--voxel-spacings",
+                str(target_voxel_size),
+                "--log",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+
+        # Verify only the specified voxel spacing was synchronized
+        target_root = CopickRootFSSpec.from_file(target_config)
+        target_run = target_root.get_run(source_run.name)
+        target_vs = target_run.get_voxel_spacing(target_voxel_size)
+        assert target_vs is not None, f"Target voxel spacing {target_voxel_size} should be created"
+
+
+class TestSyncCLIIntegration:
+    """Integration tests for sync CLI commands."""
+
+    def test_sync_all_data_types_cli(self, source_target_configs, runner):
+        """Test syncing all data types via CLI commands."""
+        source_config = source_target_configs["source_config"]
+        target_config = source_target_configs["target_config"]
+        source_root = source_target_configs["source_root"]
+
+        # Add test data to source
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("test_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+        objects = list(source_root.pickable_objects)
+        if not objects:
+            pytest.skip("No pickable objects available for testing")
+
+        source_obj = objects[0]
+
+        # Add picks
+        picks = source_run.new_picks(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+            exist_ok=True,
+        )
+        picks.from_numpy(np.array([[10, 20, 30]]))
+        picks.store()
+
+        # Add mesh
+        mesh = source_run.new_mesh(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+            exist_ok=True,
+        )
+        vertices = np.array([[0, 0, 0]], dtype=np.float32)
+        faces = np.array([[0]], dtype=np.uint32)
+        mesh.mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
+        mesh.store()
+
+        # Add segmentation
+        segmentation = source_run.new_segmentation(
+            name="test-segmentation",
+            user_id="test-user",
+            session_id="test-session",
+            voxel_size=10.0,
+            is_multilabel=True,  # Use multilabel to avoid needing pickable object
+            exist_ok=True,
+        )
+        test_data = np.random.randint(0, 3, (8, 8, 8), dtype=np.uint8)
+        segmentation.from_numpy(test_data)
+
+        # Sync picks
+        result1 = runner.invoke(
+            sync,
+            [
+                "picks",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--log",
+            ],
+        )
+        assert result1.exit_code == 0, f"Picks sync failed: {result1.output}"
+
+        # Sync meshes
+        result2 = runner.invoke(
+            sync,
+            [
+                "meshes",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--log",
+            ],
+        )
+        assert result2.exit_code == 0, f"Meshes sync failed: {result2.output}"
+
+        # Sync segmentations
+        result3 = runner.invoke(
+            sync,
+            [
+                "segmentations",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--log",
+            ],
+        )
+        assert result3.exit_code == 0, f"Segmentations sync failed: {result3.output}"
+
+        # Verify all data types were synchronized
+        target_root = CopickRootFSSpec.from_file(target_config)
+        target_run = target_root.get_run(source_run.name)
+        assert target_run is not None, "Target run should be created"
+
+        # Check picks
+        target_picks = target_run.get_picks(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+        )
+        assert len(target_picks) > 0, "Target picks should be created"
+
+        # Check meshes
+        target_meshes = target_run.get_meshes(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+        )
+        assert len(target_meshes) > 0, "Target meshes should be created"
+
+        # Check segmentations
+        target_segmentations = target_run.get_segmentations(
+            name="test-segmentation",
+            user_id="test-user",
+            session_id="test-session",
+            voxel_size=10.0,
+        )
+        assert len(target_segmentations) > 0, "Target segmentations should be created"
+
+    def test_sync_cli_help_commands(self, runner):
+        """Test help output for sync CLI commands."""
+        # Test main sync help
+        result = runner.invoke(sync, ["--help"])
+        assert result.exit_code == 0
+        assert "Synchronize data between Copick projects" in result.output
+
+        # Test picks help
+        result = runner.invoke(sync, ["picks", "--help"])
+        assert result.exit_code == 0
+        assert "Synchronize picks between two Copick projects" in result.output
+
+        # Test meshes help
+        result = runner.invoke(sync, ["meshes", "--help"])
+        assert result.exit_code == 0
+        assert "Synchronize meshes between two Copick projects" in result.output
+
+        # Test segmentations help
+        result = runner.invoke(sync, ["segmentations", "--help"])
+        assert result.exit_code == 0
+        assert "Synchronize segmentations between two Copick projects" in result.output
+
+        # Test tomograms help
+        result = runner.invoke(sync, ["tomograms", "--help"])
+        assert result.exit_code == 0
+        assert "Synchronize tomograms between two Copick projects" in result.output
+
+    def test_sync_cli_debug_mode(self, source_target_configs, runner):
+        """Test sync CLI commands with debug mode enabled."""
+        source_config = source_target_configs["source_config"]
+        target_config = source_target_configs["target_config"]
+        source_root = source_target_configs["source_root"]
+
+        # Add minimal test data
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("test_run", exist_ok=True)
+            runs = [test_run]
+
+        # Run sync with debug mode
+        result = runner.invoke(
+            sync,
+            [
+                "picks",
+                "--config",
+                source_config,
+                "--target-config",
+                target_config,
+                "--debug",
+                "--log",
+            ],
+        )
+
+        assert result.exit_code == 0, f"Command failed: {result.output}"
+        # Debug mode should still complete successfully

--- a/tests/test_sync_ops.py
+++ b/tests/test_sync_ops.py
@@ -1,0 +1,879 @@
+"""Tests for the sync operations module."""
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+import pytest
+import trimesh
+from copick.impl.filesystem import CopickRootFSSpec
+from copick.ops.sync import sync_meshes, sync_picks, sync_segmentations, sync_tomograms
+
+
+@pytest.fixture(params=pytest.common_cases)
+def test_payload(request) -> Dict[str, Any]:
+    payload = request.getfixturevalue(request.param)
+    payload["root"] = CopickRootFSSpec.from_file(payload["cfg_file"])
+    return payload
+
+
+@pytest.fixture
+def source_target_configs(test_payload):
+    """Create source and target configurations for sync tests."""
+    # Create a target configuration in a temporary location
+    with tempfile.TemporaryDirectory() as tmpdir:
+        target_config_path = Path(tmpdir) / "target_config.json"
+
+        # Copy and modify source config for target
+        with open(test_payload["cfg_file"], "r") as f:
+            source_config = json.load(f)
+
+        # Create target config with different overlay root
+        target_config = source_config.copy()
+        if "overlay_root" in target_config:
+            # Modify the overlay root to point to a different directory
+            overlay_root = target_config["overlay_root"]
+            if overlay_root.startswith("local://"):
+                target_overlay_path = Path(tmpdir) / "target_overlay"
+                target_overlay_path.mkdir()
+                target_config["overlay_root"] = f"local://{target_overlay_path}"
+            else:
+                # For other protocols, just modify the path
+                target_config["overlay_root"] = overlay_root.rstrip("/") + "_target"
+
+        # Write target config
+        with open(target_config_path, "w") as f:
+            json.dump(target_config, f)
+
+        yield {
+            "source_config": test_payload["cfg_file"],
+            "target_config": str(target_config_path),
+            "source_root": test_payload["root"],
+            "target_root": CopickRootFSSpec.from_file(target_config_path),
+        }
+
+
+class TestSyncPicks:
+    """Test cases for picks synchronization."""
+
+    def test_sync_picks_basic(self, source_target_configs):
+        """Test basic picks synchronization."""
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Add some test picks to the source
+        runs = list(source_root.runs)
+        if not runs:
+            # Create a test run if none exist
+            test_run = source_root.new_run("test_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+
+        # Get a pickable object
+        objects = list(source_root.pickable_objects)
+        if not objects:
+            pytest.skip("No pickable objects available for testing")
+
+        source_obj = objects[0]
+
+        # Create test picks
+        picks = source_run.new_picks(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+            exist_ok=True,
+        )
+        picks.from_numpy(np.array([[10, 20, 30], [40, 50, 60]]))
+        picks.store()
+
+        # Perform synchronization
+        sync_picks(
+            source_root=source_root,
+            target_root=target_root,
+            log=True,
+        )
+
+        # Verify picks were synchronized
+        target_run = target_root.get_run(source_run.name)
+        assert target_run is not None, "Target run should be created"
+
+        target_picks_list = target_run.get_picks(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+        )
+        assert len(target_picks_list) > 0, "Target picks should be created"
+
+        target_picks = target_picks_list[0]
+        assert len(target_picks.points) == 2, "Target picks should have same number of points"
+
+    def test_sync_picks_with_name_mapping(self, source_target_configs):
+        """Test picks synchronization with name mapping."""
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Add test picks to source
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("source_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+        objects = list(source_root.pickable_objects)
+        if not objects:
+            pytest.skip("No pickable objects available for testing")
+
+        source_obj = objects[0]
+
+        picks = source_run.new_picks(
+            object_name=source_obj.name,
+            user_id="source-user",
+            session_id="test-session",
+            exist_ok=True,
+        )
+        picks.from_numpy(np.array([[10, 20, 30]]))
+        picks.store()
+
+        # Ensure the target object exists
+        target_root.new_object(
+            name="target-object",
+            is_particle=source_obj.is_particle,
+            exist_ok=True,
+        )
+
+        # Perform synchronization with mapping
+        sync_picks(
+            source_root=source_root,
+            target_root=target_root,
+            source_runs=[source_run.name],
+            target_runs={source_run.name: "target_run"},
+            source_objects=[source_obj.name],
+            target_objects={source_obj.name: "target-object"},
+            source_users=["source-user"],
+            target_users={"source-user": "target-user"},
+            log=True,
+        )
+
+        # Verify with mapped names
+        target_run = target_root.get_run("target_run")
+        assert target_run is not None, "Target run should be created with mapped name"
+
+        target_picks_list = target_run.get_picks(
+            object_name="target-object",
+            user_id="target-user",
+            session_id="test-session",
+        )
+        assert len(target_picks_list) > 0, "Target picks should be created with mapped names"
+
+    def test_sync_picks_with_user_filtering(self, source_target_configs):
+        """Test picks synchronization with user filtering."""
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Add test picks from multiple users
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("test_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+        objects = list(source_root.pickable_objects)
+        if not objects:
+            pytest.skip("No pickable objects available for testing")
+
+        source_obj = objects[0]
+
+        # Create picks from user1
+        picks1 = source_run.new_picks(
+            object_name=source_obj.name,
+            user_id="user1",
+            session_id="session1",
+            exist_ok=True,
+        )
+        picks1.from_numpy(np.array([[10, 20, 30]]))
+        picks1.store()
+
+        # Create picks from user2
+        picks2 = source_run.new_picks(
+            object_name=source_obj.name,
+            user_id="user2",
+            session_id="session2",
+            exist_ok=True,
+        )
+        picks2.from_numpy(np.array([[40, 50, 60]]))
+        picks2.store()
+
+        # Sync only user1's picks
+        sync_picks(
+            source_root=source_root,
+            target_root=target_root,
+            source_users=["user1"],
+            log=True,
+        )
+
+        # Verify only user1's picks were synchronized
+        target_run = target_root.get_run(source_run.name)
+
+        user1_picks = target_run.get_picks(
+            object_name=source_obj.name,
+            user_id="user1",
+            session_id="session1",
+        )
+        assert len(user1_picks) > 0, "User1 picks should be synchronized"
+
+        user2_picks = target_run.get_picks(
+            object_name=source_obj.name,
+            user_id="user2",
+            session_id="session2",
+        )
+        assert len(user2_picks) == 0, "User2 picks should not be synchronized"
+
+    def test_sync_picks_exist_ok(self, source_target_configs):
+        """Test picks synchronization with exist_ok flag."""
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Add test picks to source
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("test_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+        objects = list(source_root.pickable_objects)
+        if not objects:
+            pytest.skip("No pickable objects available for testing")
+
+        source_obj = objects[0]
+
+        # Create initial picks
+        picks = source_run.new_picks(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+            exist_ok=True,
+        )
+        picks.from_numpy(np.array([[10, 20, 30]]))
+        picks.store()
+
+        # First sync
+        sync_picks(
+            source_root=source_root,
+            target_root=target_root,
+            log=True,
+        )
+
+        # Modify source picks
+        picks.from_numpy(np.array([[10, 20, 30], [70, 80, 90]]))
+        picks.store()
+
+        # Second sync with exist_ok=True
+        sync_picks(
+            source_root=source_root,
+            target_root=target_root,
+            exist_ok=True,
+            log=True,
+        )
+
+        # Verify updated picks
+        target_run = target_root.get_run(source_run.name)
+        target_picks_list = target_run.get_picks(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+        )
+        target_picks = target_picks_list[0]
+        assert len(target_picks.points) == 2, "Target picks should be updated"
+
+
+class TestSyncMeshes:
+    """Test cases for meshes synchronization."""
+
+    def test_sync_meshes_basic(self, source_target_configs):
+        """Test basic meshes synchronization."""
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Add test mesh to source
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("test_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+        objects = list(source_root.pickable_objects)
+        if not objects:
+            pytest.skip("No pickable objects available for testing")
+
+        source_obj = objects[0]
+
+        # Create test mesh
+        mesh = source_run.new_mesh(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+            exist_ok=True,
+        )
+
+        # Create simple mesh data (triangle)
+        vertices = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.5, 1.0, 0.0],
+            ],
+            dtype=np.float32,
+        )
+
+        faces = np.array(
+            [
+                [0, 1, 2],
+            ],
+            dtype=np.uint32,
+        )
+
+        mesh.mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
+        mesh.store()
+
+        # Perform synchronization
+        sync_meshes(
+            source_root=source_root,
+            target_root=target_root,
+            log=True,
+        )
+
+        # Verify mesh was synchronized
+        target_run = target_root.get_run(source_run.name)
+        assert target_run is not None, "Target run should be created"
+
+        target_meshes = target_run.get_meshes(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+        )
+        assert len(target_meshes) > 0, "Target mesh should be created"
+
+        target_mesh = target_meshes[0]
+        assert target_mesh.mesh is not None, "Target mesh should have data"
+        assert hasattr(target_mesh.mesh, "vertices"), "Target mesh should have vertices"
+        assert hasattr(target_mesh.mesh, "faces"), "Target mesh should have faces"
+
+    def test_sync_meshes_with_mapping(self, source_target_configs):
+        """Test meshes synchronization with name mapping."""
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Add test mesh to source
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("source_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+        objects = list(source_root.pickable_objects)
+        if not objects:
+            pytest.skip("No pickable objects available for testing")
+
+        source_obj = objects[0]
+
+        # Create test mesh
+        mesh = source_run.new_mesh(
+            object_name=source_obj.name,
+            user_id="source-user",
+            session_id="test-session",
+            exist_ok=True,
+        )
+        mesh.mesh = trimesh.Trimesh(
+            vertices=np.array([[0, 0, 0]], dtype=np.float32),
+            faces=np.array([[0]], dtype=np.uint32),
+        )
+        mesh.store()
+
+        # Ensure target object exists
+        target_root.new_object(
+            name="target-object",
+            is_particle=source_obj.is_particle,
+            exist_ok=True,
+        )
+
+        # Perform synchronization with mapping
+        sync_meshes(
+            source_root=source_root,
+            target_root=target_root,
+            source_runs=[source_run.name],
+            target_runs={source_run.name: "target_run"},
+            source_objects=[source_obj.name],
+            target_objects={source_obj.name: "target-object"},
+            source_users=["source-user"],
+            target_users={"source-user": "target-user"},
+            log=True,
+        )
+
+        # Verify with mapped names
+        target_run = target_root.get_run("target_run")
+        assert target_run is not None, "Target run should be created with mapped name"
+
+        target_meshes = target_run.get_meshes(
+            object_name="target-object",
+            user_id="target-user",
+            session_id="test-session",
+        )
+        assert len(target_meshes) > 0, "Target mesh should be created with mapped names"
+
+
+class TestSyncSegmentations:
+    """Test cases for segmentations synchronization."""
+
+    def test_sync_segmentations_basic(self, source_target_configs):
+        """Test basic segmentations synchronization."""
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Add test segmentation to source
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("test_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+
+        # Create test segmentation (multilabel to avoid pickable object requirement)
+        segmentation = source_run.new_segmentation(
+            name="test-segmentation",
+            user_id="test-user",
+            session_id="test-session",
+            voxel_size=10.0,
+            is_multilabel=True,
+            exist_ok=True,
+        )
+
+        # Add test data
+        test_data = np.random.randint(0, 3, (32, 32, 32), dtype=np.uint8)
+        segmentation.from_numpy(test_data)
+
+        # Perform synchronization
+        sync_segmentations(
+            source_root=source_root,
+            target_root=target_root,
+            log=True,
+        )
+
+        # Verify segmentation was synchronized
+        target_run = target_root.get_run(source_run.name)
+        assert target_run is not None, "Target run should be created"
+
+        target_segmentations = target_run.get_segmentations(
+            name="test-segmentation",
+            user_id="test-user",
+            session_id="test-session",
+            voxel_size=10.0,
+        )
+        assert len(target_segmentations) > 0, "Target segmentation should be created"
+
+    def test_sync_segmentations_with_voxel_filtering(self, source_target_configs):
+        """Test segmentations synchronization with voxel spacing filtering."""
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Add test segmentations at different voxel spacings
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("test_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+
+        # Create segmentations at different voxel sizes
+        seg1 = source_run.new_segmentation(
+            name="test-seg-10",
+            user_id="test-user",
+            session_id="test-session",
+            voxel_size=10.0,
+            is_multilabel=True,
+            exist_ok=True,
+        )
+        test_data = np.random.randint(0, 3, (16, 16, 16), dtype=np.uint8)
+        seg1.from_numpy(test_data)
+
+        seg2 = source_run.new_segmentation(
+            name="test-seg-20",
+            user_id="test-user",
+            session_id="test-session",
+            voxel_size=20.0,
+            is_multilabel=True,
+            exist_ok=True,
+        )
+        seg2.from_numpy(test_data)
+
+        # Sync only 10.0 voxel spacing
+        sync_segmentations(
+            source_root=source_root,
+            target_root=target_root,
+            voxel_spacings=[10.0],
+            log=True,
+        )
+
+        # Verify only 10.0 spacing was synchronized
+        target_run = target_root.get_run(source_run.name)
+
+        target_segs_10 = target_run.get_segmentations(voxel_size=10.0)
+        assert len(target_segs_10) > 0, "10.0 voxel spacing should be synchronized"
+
+        target_segs_20 = target_run.get_segmentations(voxel_size=20.0)
+        assert len(target_segs_20) == 0, "20.0 voxel spacing should not be synchronized"
+
+    def test_sync_segmentations_with_name_mapping(self, source_target_configs):
+        """Test segmentations synchronization with name mapping."""
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Add test segmentation
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("source_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+
+        segmentation = source_run.new_segmentation(
+            name="source-segmentation",
+            user_id="source-user",
+            session_id="test-session",
+            voxel_size=10.0,
+            is_multilabel=True,
+            exist_ok=True,
+        )
+        test_data = np.random.randint(0, 3, (16, 16, 16), dtype=np.uint8)
+        segmentation.from_numpy(test_data)
+
+        # Perform synchronization with mapping
+        sync_segmentations(
+            source_root=source_root,
+            target_root=target_root,
+            source_runs=[source_run.name],
+            target_runs={source_run.name: "target_run"},
+            source_names=["source-segmentation"],
+            target_names={"source-segmentation": "target-segmentation"},
+            source_users=["source-user"],
+            target_users={"source-user": "target-user"},
+            log=True,
+        )
+
+        # Verify with mapped names
+        target_run = target_root.get_run("target_run")
+        assert target_run is not None, "Target run should be created with mapped name"
+
+        target_segmentations = target_run.get_segmentations(
+            name="target-segmentation",
+            user_id="target-user",
+            session_id="test-session",
+            voxel_size=10.0,
+        )
+        assert len(target_segmentations) > 0, "Target segmentation should be created with mapped names"
+
+
+class TestSyncTomograms:
+    """Test cases for tomograms synchronization."""
+
+    def test_sync_tomograms_basic(self, source_target_configs):
+        """Test basic tomograms synchronization."""
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Check if we have existing tomograms to sync
+        runs = list(source_root.runs)
+        if not runs:
+            pytest.skip("No runs available for testing")
+
+        source_run = runs[0]
+        voxel_spacings = list(source_run.voxel_spacings)
+        if not voxel_spacings:
+            pytest.skip("No voxel spacings available for testing")
+
+        source_vs = voxel_spacings[0]
+        tomograms = source_vs.tomograms
+        if not tomograms:
+            pytest.skip("No tomograms available for testing")
+
+        # Perform synchronization
+        sync_tomograms(
+            source_root=source_root,
+            target_root=target_root,
+            log=True,
+        )
+
+        # Verify tomogram was synchronized
+        target_run = target_root.get_run(source_run.name)
+        assert target_run is not None, "Target run should be created"
+
+        target_vs = target_run.get_voxel_spacing(source_vs.voxel_size)
+        assert target_vs is not None, "Target voxel spacing should be created"
+
+        source_tomo_types = [tomo.tomo_type for tomo in tomograms]
+        target_tomos = []
+        for tomo_type in source_tomo_types:
+            tomos = target_vs.get_tomograms(tomo_type)
+            target_tomos.extend(tomos)
+
+        assert len(target_tomos) > 0, "Target tomograms should be created"
+
+    def test_sync_tomograms_with_type_mapping(self, source_target_configs):
+        """Test tomograms synchronization with type mapping."""
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Check for existing tomograms
+        runs = list(source_root.runs)
+        if not runs:
+            pytest.skip("No runs available for testing")
+
+        source_run = runs[0]
+        voxel_spacings = list(source_run.voxel_spacings)
+        if not voxel_spacings:
+            pytest.skip("No voxel spacings available for testing")
+
+        source_vs = voxel_spacings[0]
+        tomograms = source_vs.tomograms
+        if not tomograms:
+            pytest.skip("No tomograms available for testing")
+
+        source_tomo_type = tomograms[0].tomo_type
+
+        # Perform synchronization with type mapping
+        sync_tomograms(
+            source_root=source_root,
+            target_root=target_root,
+            source_runs=[source_run.name],
+            target_runs={source_run.name: "target_run"},
+            source_tomo_types=[source_tomo_type],
+            target_tomo_types={source_tomo_type: "mapped-type"},
+            log=True,
+        )
+
+        # Verify with mapped names
+        target_run = target_root.get_run("target_run")
+        assert target_run is not None, "Target run should be created with mapped name"
+
+        target_vs = target_run.get_voxel_spacing(source_vs.voxel_size)
+        assert target_vs is not None, "Target voxel spacing should be created"
+
+        target_tomos = target_vs.get_tomograms("mapped-type")
+        assert len(target_tomos) > 0, "Target tomogram should be created with mapped type"
+
+    def test_sync_tomograms_with_voxel_filtering(self, source_target_configs):
+        """Test tomograms synchronization with voxel spacing filtering."""
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Check for existing tomograms at different voxel spacings
+        runs = list(source_root.runs)
+        if not runs:
+            pytest.skip("No runs available for testing")
+
+        source_run = runs[0]
+        voxel_spacings = list(source_run.voxel_spacings)
+        if len(voxel_spacings) < 1:
+            pytest.skip("Need at least one voxel spacing for testing")
+
+        # Use the first voxel spacing for filtering
+        target_voxel_size = voxel_spacings[0].voxel_size
+
+        # Sync only specific voxel spacing
+        sync_tomograms(
+            source_root=source_root,
+            target_root=target_root,
+            voxel_spacings=[target_voxel_size],
+            log=True,
+        )
+
+        # Verify only the specified voxel spacing was synchronized
+        target_run = target_root.get_run(source_run.name)
+        target_vs = target_run.get_voxel_spacing(target_voxel_size)
+        assert target_vs is not None, f"Target voxel spacing {target_voxel_size} should be created"
+
+        # Check that other voxel spacings were not synchronized
+        for vs in voxel_spacings[1:]:
+            other_target_vs = target_run.get_voxel_spacing(vs.voxel_size)
+            if other_target_vs is not None:
+                assert (
+                    len(other_target_vs.tomograms) == 0
+                ), f"Other voxel spacing {vs.voxel_size} should not have tomograms"
+
+
+class TestSyncIntegration:
+    """Integration tests for sync operations."""
+
+    def test_sync_all_data_types(self, source_target_configs):
+        """Test synchronizing all data types together."""
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Add test data to source
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("test_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+        objects = list(source_root.pickable_objects)
+        if not objects:
+            pytest.skip("No pickable objects available for testing")
+
+        source_obj = objects[0]
+
+        # Add picks
+        picks = source_run.new_picks(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+            exist_ok=True,
+        )
+        picks.from_numpy(np.array([[10, 20, 30]]))
+        picks.store()
+
+        # Add mesh
+        mesh = source_run.new_mesh(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+            exist_ok=True,
+        )
+        mesh.mesh = trimesh.Trimesh(
+            vertices=np.array([[0, 0, 0]], dtype=np.float32),
+            faces=np.array([[0]], dtype=np.uint32),
+        )
+        mesh.store()
+
+        # Add segmentation
+        segmentation = source_run.new_segmentation(
+            name="test-segmentation",
+            user_id="test-user",
+            session_id="test-session",
+            voxel_size=10.0,
+            is_multilabel=True,
+            exist_ok=True,
+        )
+        test_data = np.random.randint(0, 3, (16, 16, 16), dtype=np.uint8)
+        segmentation.from_numpy(test_data)
+
+        # Sync all data types
+        sync_picks(source_root=source_root, target_root=target_root, log=True)
+        sync_meshes(source_root=source_root, target_root=target_root, log=True)
+        sync_segmentations(source_root=source_root, target_root=target_root, log=True)
+
+        # Sync tomograms if they exist
+        voxel_spacings = list(source_run.voxel_spacings)
+        if voxel_spacings and voxel_spacings[0].tomograms:
+            sync_tomograms(source_root=source_root, target_root=target_root, log=True)
+
+        # Verify all data types were synchronized
+        target_run = target_root.get_run(source_run.name)
+        assert target_run is not None, "Target run should be created"
+
+        # Check picks
+        target_picks = target_run.get_picks(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+        )
+        assert len(target_picks) > 0, "Target picks should be created"
+
+        # Check meshes
+        target_meshes = target_run.get_meshes(
+            object_name=source_obj.name,
+            user_id="test-user",
+            session_id="test-session",
+        )
+        assert len(target_meshes) > 0, "Target meshes should be created"
+
+        # Check segmentations
+        target_segmentations = target_run.get_segmentations(
+            name="test-segmentation",
+            user_id="test-user",
+            session_id="test-session",
+            voxel_size=10.0,
+        )
+        assert len(target_segmentations) > 0, "Target segmentations should be created"
+
+    def test_sync_with_parallel_workers(self, source_target_configs):
+        """Test synchronization with multiple parallel workers."""
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Add test data to multiple runs
+        test_runs = []
+        for i in range(3):
+            run_name = f"test_run_{i}"
+            test_run = source_root.new_run(run_name, exist_ok=True)
+            test_runs.append(test_run)
+
+            objects = list(source_root.pickable_objects)
+            if objects:
+                source_obj = objects[0]
+                picks = test_run.new_picks(
+                    object_name=source_obj.name,
+                    user_id="test-user",
+                    session_id="test-session",
+                    exist_ok=True,
+                )
+                picks.from_numpy(np.array([[i * 10, i * 20, i * 30]]))
+                picks.store()
+
+        # Sync with multiple workers
+        sync_picks(
+            source_root=source_root,
+            target_root=target_root,
+            max_workers=3,
+            log=True,
+        )
+
+        # Verify all runs were synchronized
+        for test_run in test_runs:
+            target_run = target_root.get_run(test_run.name)
+            assert target_run is not None, f"Target run {test_run.name} should be created"
+
+    def test_sync_error_handling(self, source_target_configs):
+        """Test sync error handling for missing objects."""
+        source_root = source_target_configs["source_root"]
+        target_root = source_target_configs["target_root"]
+
+        # Add test picks with an object that won't exist in target
+        runs = list(source_root.runs)
+        if not runs:
+            test_run = source_root.new_run("test_run", exist_ok=True)
+            runs = [test_run]
+
+        source_run = runs[0]
+
+        # Create a temporary object in source
+        source_root.new_object(
+            name="temp-object",
+            is_particle=True,
+            exist_ok=True,
+        )
+
+        picks = source_run.new_picks(
+            object_name="temp-object",
+            user_id="test-user",
+            session_id="test-session",
+            exist_ok=True,
+        )
+        picks.from_numpy(np.array([[10, 20, 30]]))
+        picks.store()
+
+        # Remove object from target (or don't create it)
+        # Sync should handle missing target object gracefully
+        sync_picks(
+            source_root=source_root,
+            target_root=target_root,
+            source_objects=["temp-object"],
+            log=True,
+        )
+
+        # The sync should complete without raising exceptions
+        # but the specific pick may not be created due to missing target object
+        target_run = target_root.get_run(source_run.name)
+        assert target_run is not None, "Target run should still be created"


### PR DESCRIPTION
Adds functions and CLI tools to sync tomograms, picks, meshes and segmentations between copick projects. 

#### Functional API

Adds 4 functions: 

```python
def sync_picks(
    source_root: CopickRoot,
    target_root: CopickRoot,
    source_runs: Optional[List[str]] = None,
    target_runs: Optional[Dict[str, str]] = None,
    source_objects: Optional[List[str]] = None,
    target_objects: Optional[Dict[str, str]] = None,
    source_users: Optional[List[str]] = None,
    target_users: Optional[Dict[str, str]] = None,
    exist_ok: bool = False,
    max_workers: int = 4,
    log: bool = False,
) -> None:
    """
    Synchronize picks between two Copick projects.

    Args:
        source_root: The source Copick project root.
        target_root: The target Copick project root.
        source_runs: The list of source run names to synchronize.
        target_runs: A dictionary mapping source run names to target run names.
        source_objects: The list of source object types to synchronize.
        target_objects: The dictionary mapping source object types to target types.
        source_users: The list of source user IDs to synchronize. If None, all users are synced.
        target_users: The dictionary mapping source user IDs to target user IDs.
        exist_ok: Whether to overwrite existing picks in the target project.
        max_workers: The maximum number of worker threads to use for synchronization.
        log: Whether to log the synchronization process.

    """
```

```python
def sync_segmentations(
    source_root: CopickRoot,
    target_root: CopickRoot,
    source_runs: Optional[List[str]] = None,
    target_runs: Optional[Dict[str, str]] = None,
    voxel_spacings: Optional[List[float]] = None,
    source_names: Optional[List[str]] = None,
    target_names: Optional[Dict[str, str]] = None,
    source_users: Optional[List[str]] = None,
    target_users: Optional[Dict[str, str]] = None,
    exist_ok: bool = False,
    max_workers: int = 4,
    log: bool = False,
) -> None:
    """
    Synchronize segmentations between two Copick projects.

    Args:
        source_root: The source Copick project root.
        target_root: The target Copick project root.
        source_runs: The list of source run names to synchronize.
        target_runs: A dictionary mapping source run names to target run names.
        voxel_spacings: The voxel spacings to consider for synchronization.
        source_names: The list of source segmentation names to synchronize. If None, all segmentations are synced.
        target_names: The dictionary mapping source segmentation names to target names.
        source_users: The list of source user IDs to synchronize. If None, all users are synced.
        target_users: The dictionary mapping source user IDs to target user IDs.
        exist_ok: Whether to overwrite existing segmentations in the target project.
        max_workers: The maximum number of worker threads to use for synchronization.
        log: Whether to log the synchronization process.

    """
```

```python 
def sync_meshes(
    source_root: CopickRoot,
    target_root: CopickRoot,
    source_runs: Optional[List[str]] = None,
    target_runs: Optional[Dict[str, str]] = None,
    source_objects: Optional[List[str]] = None,
    target_objects: Optional[Dict[str, str]] = None,
    source_users: Optional[List[str]] = None,
    target_users: Optional[Dict[str, str]] = None,
    exist_ok: bool = False,
    max_workers: int = 4,
    log: bool = False,
) -> None:
    """
    Synchronize meshes between two Copick projects.

    Args:
        source_root: The source Copick project root.
        target_root: The target Copick project root.
        source_runs: The list of source run names to synchronize.
        target_runs: A dictionary mapping source run names to target run names.
        source_objects: The list of source object types to synchronize.
        target_objects: The dictionary mapping source object types to target types.
        source_users: The list of source user IDs to synchronize. If None, all users are synced.
        target_users: The dictionary mapping source user IDs to target user IDs.
        exist_ok: Whether to overwrite existing meshes in the target project.
        max_workers: The maximum number of worker threads to use for synchronization.
        log: Whether to log the synchronization process.

    """
```

```python
def sync_tomograms(
    source_root: CopickRoot,
    target_root: CopickRoot,
    source_runs: Optional[List[str]] = None,
    target_runs: Optional[Dict[str, str]] = None,
    voxel_spacings: Optional[List[float]] = None,
    source_tomo_types: Optional[List[str]] = None,
    target_tomo_types: Optional[Dict[str, str]] = None,
    exist_ok: bool = False,
    max_workers: int = 4,
    log: bool = False,
) -> None:
    """
    Synchronize tomograms between two Copick projects.

    Args:
        source_root: The source Copick project root.
        target_root: The target Copick project root.
        source_runs: The list of source run names to synchronize.
        target_runs: A dictionary mapping source run names to target run names.
        voxel_spacings: The voxel spacings to consider for synchronization.
        source_tomo_types: The list of source tomogram types to synchronize.
        target_tomo_types: The dictionary mapping source tomogram types to target types.
        exist_ok: Whether to overwrite existing tomograms in the target project.
        max_workers: The maximum number of worker threads to use for synchronization.
        log: Whether to log the synchronization process.

    """
```


#### CLI

Adds 4 CLI commands: 

```
copick sync picks --help    
copick 1.9.0
------------
Usage: copick sync picks [OPTIONS]

  Synchronize picks between two Copick projects.

  This command copies pick annotations from a source Copick project to a
  target project. You can specify which runs and objects to sync, and
  optionally map source names to different target names.

  Examples:

  # Sync all picks from all runs copick sync picks -c source_config.json
  --target-config target_config.json

  # Sync specific runs with name mapping copick sync picks -c
  source_config.json --target-config target_config.json \     --source-runs
  "run1,run2" --target-runs "run1:new_run1,run2:new_run2"

  # Sync specific objects with name mapping copick sync picks -c
  source_config.json --target-config target_config.json \     --source-objects
  "ribosome,membrane" --target-objects "ribosome:ribo,membrane:mem"

Options:
  -c, --config PATH           Path to the configuration file.  [env var:
                              COPICK_CONFIG]
  --source-dataset-ids TEXT   Comma-separated list of dataset IDs to use as
                              source from CryoET Data Portal. If provided,
                              --config will be ignored and a temporary
                              dataportal configuration will be created.
  --target-config PATH        Path to the target configuration file.
                              [required]
  --source-runs TEXT          Comma-separated list of source run names to
                              synchronize. If not specified, all runs will be
                              synced.  [default: ""]
  --target-runs TEXT          Comma-separated mapping of source run names to
                              target run names (e.g.
                              'run1:target1,run2:target2'). If not specified,
                              source run names will be used.  [default: ""]
  --source-objects TEXT       Comma-separated list of source object names to
                              synchronize. If not specified, all objects will
                              be synced.  [default: ""]
  --target-objects TEXT       Comma-separated mapping of source object names
                              to target object names (e.g.
                              'ribosome:ribo,membrane:mem'). If not specified,
                              source object names will be used.  [default: ""]
  --source-users TEXT         Comma-separated list of source user IDs to
                              synchronize. If not specified, all users will be
                              synced.  [default: ""]
  --target-users TEXT         Comma-separated mapping of source user IDs to
                              target user IDs (e.g.
                              'user1:target1,user2:target2'). If not
                              specified, source user IDs will be used.
                              [default: ""]
  --exist-ok / --no-exist-ok  Allow overwriting existing picks in the target
                              project.  [default: no-exist-ok]
  --max-workers INTEGER       Maximum number of worker threads to use for
                              synchronization.  [default: 4]
  --log / --no-log            Enable verbose logging of the synchronization
                              process.  [default: no-log]
  --debug / --no-debug        Enable debug logging.  [default: no-debug]
  --help                      Show this message and exit.
```

```
copick sync meshes --help   
copick 1.9.0
------------
Usage: copick sync meshes [OPTIONS]

  Synchronize meshes between two Copick projects.

  This command copies mesh data from a source Copick project to a target
  project. You can specify which runs and objects to sync, and optionally map
  source names to different target names.

  Examples:

  # Sync all meshes from all runs copick sync meshes -c source_config.json
  --target-config target_config.json

  # Sync specific runs with name mapping copick sync meshes -c
  source_config.json --target-config target_config.json \     --source-runs
  "run1,run2" --target-runs "run1:new_run1,run2:new_run2"

  # Sync specific objects with name mapping copick sync meshes -c
  source_config.json --target-config target_config.json \     --source-objects
  "ribosome,membrane" --target-objects "ribosome:ribo,membrane:mem"

Options:
  -c, --config PATH           Path to the configuration file.  [env var:
                              COPICK_CONFIG]
  --source-dataset-ids TEXT   Comma-separated list of dataset IDs to use as
                              source from CryoET Data Portal. If provided,
                              --config will be ignored and a temporary
                              dataportal configuration will be created.
  --target-config PATH        Path to the target configuration file.
                              [required]
  --source-runs TEXT          Comma-separated list of source run names to
                              synchronize. If not specified, all runs will be
                              synced.  [default: ""]
  --target-runs TEXT          Comma-separated mapping of source run names to
                              target run names (e.g.
                              'run1:target1,run2:target2'). If not specified,
                              source run names will be used.  [default: ""]
  --source-objects TEXT       Comma-separated list of source object names to
                              synchronize. If not specified, all objects will
                              be synced.  [default: ""]
  --target-objects TEXT       Comma-separated mapping of source object names
                              to target object names (e.g.
                              'ribosome:ribo,membrane:mem'). If not specified,
                              source object names will be used.  [default: ""]
  --source-users TEXT         Comma-separated list of source user IDs to
                              synchronize. If not specified, all users will be
                              synced.  [default: ""]
  --target-users TEXT         Comma-separated mapping of source user IDs to
                              target user IDs (e.g.
                              'user1:target1,user2:target2'). If not
                              specified, source user IDs will be used.
                              [default: ""]
  --exist-ok / --no-exist-ok  Allow overwriting existing meshes in the target
                              project.  [default: no-exist-ok]
  --max-workers INTEGER       Maximum number of worker threads to use for
                              synchronization.  [default: 4]
  --log / --no-log            Enable verbose logging of the synchronization
                              process.  [default: no-log]
  --debug / --no-debug        Enable debug logging.  [default: no-debug]
  --help                      Show this message and exit.
```

```
copick sync segmentations --help
copick 1.9.0
------------
Usage: copick sync segmentations [OPTIONS]

  Synchronize segmentations between two Copick projects.

  This command copies segmentation data from a source Copick project to a
  target project. You can specify which runs, voxel spacings, and objects to
  sync, and optionally map source names to different target names.

  Examples:

  # Sync all segmentations from all runs copick sync segmentations -c
  source_config.json --target-config target_config.json

  # Sync specific runs and voxel spacings copick sync segmentations -c
  source_config.json --target-config target_config.json \     --source-runs
  "run1,run2" --voxel-spacings "10.0,20.0"

  # Sync specific objects with name mapping copick sync segmentations -c
  source_config.json --target-config target_config.json \     --source-objects
  "ribosome,membrane" --target-objects "ribosome:ribo,membrane:mem"

Options:
  -c, --config PATH           Path to the configuration file.  [env var:
                              COPICK_CONFIG]
  --source-dataset-ids TEXT   Comma-separated list of dataset IDs to use as
                              source from CryoET Data Portal. If provided,
                              --config will be ignored and a temporary
                              dataportal configuration will be created.
  --target-config PATH        Path to the target configuration file.
                              [required]
  --source-runs TEXT          Comma-separated list of source run names to
                              synchronize. If not specified, all runs will be
                              synced.  [default: ""]
  --target-runs TEXT          Comma-separated mapping of source run names to
                              target run names (e.g.
                              'run1:target1,run2:target2'). If not specified,
                              source run names will be used.  [default: ""]
  --voxel-spacings TEXT       Comma-separated list of voxel spacings to
                              consider for synchronization. If not specified,
                              all voxel spacings will be synced.  [default:
                              ""]
  --source-names TEXT         Comma-separated list of source segmentation
                              names to synchronize. If not specified, all
                              segmentations will be synced.  [default: ""]
  --target-names TEXT         Comma-separated mapping of source segmentation
                              names to target names (e.g.
                              'seg1:target1,seg2:target2'). If not specified,
                              source names will be used.  [default: ""]
  --source-users TEXT         Comma-separated list of source user IDs to
                              synchronize. If not specified, all users will be
                              synced.  [default: ""]
  --target-users TEXT         Comma-separated mapping of source user IDs to
                              target user IDs (e.g.
                              'user1:target1,user2:target2'). If not
                              specified, source user IDs will be used.
                              [default: ""]
  --exist-ok / --no-exist-ok  Allow overwriting existing segmentations in the
                              target project.  [default: no-exist-ok]
  --max-workers INTEGER       Maximum number of worker threads to use for
                              synchronization.  [default: 4]
  --log / --no-log            Enable verbose logging of the synchronization
                              process.  [default: no-log]
  --debug / --no-debug        Enable debug logging.  [default: no-debug]
  --help                      Show this message and exit.
```

```
copick sync tomograms --help    
copick 1.9.0
------------
Usage: copick sync tomograms [OPTIONS]

  Synchronize tomograms between two Copick projects.

  This command copies tomogram data from a source Copick project to a target
  project. You can specify which runs, voxel spacings, and tomogram types to
  sync, and optionally map source names to different target names.

  Examples:

  # Sync all tomograms from all runs copick sync tomograms -c
  source_config.json --target-config target_config.json

  # Sync specific runs and voxel spacings copick sync tomograms -c
  source_config.json --target-config target_config.json \     --source-runs
  "run1,run2" --voxel-spacings "10.0,20.0"

  # Sync specific tomogram types with name mapping copick sync tomograms -c
  source_config.json --target-config target_config.json \     --source-tomo-
  types "wbp,raw" --target-tomo-types "wbp:filtered,raw:original"

Options:
  -c, --config PATH           Path to the configuration file.  [env var:
                              COPICK_CONFIG]
  --source-dataset-ids TEXT   Comma-separated list of dataset IDs to use as
                              source from CryoET Data Portal. If provided,
                              --config will be ignored and a temporary
                              dataportal configuration will be created.
  --target-config PATH        Path to the target configuration file.
                              [required]
  --source-runs TEXT          Comma-separated list of source run names to
                              synchronize. If not specified, all runs will be
                              synced.  [default: ""]
  --target-runs TEXT          Comma-separated mapping of source run names to
                              target run names (e.g.
                              'run1:target1,run2:target2'). If not specified,
                              source run names will be used.  [default: ""]
  --voxel-spacings TEXT       Comma-separated list of voxel spacings to
                              consider for synchronization. If not specified,
                              all voxel spacings will be synced.  [default:
                              ""]
  --source-tomo-types TEXT    Comma-separated list of source tomogram types to
                              synchronize. If not specified, all tomogram
                              types will be synced.  [default: ""]
  --target-tomo-types TEXT    Comma-separated mapping of source tomogram types
                              to target types (e.g.
                              'wbp:filtered,raw:original'). If not specified,
                              source tomogram types will be used.  [default:
                              ""]
  --exist-ok / --no-exist-ok  Allow overwriting existing tomograms in the
                              target project.  [default: no-exist-ok]
  --max-workers INTEGER       Maximum number of worker threads to use for
                              synchronization.  [default: 4]
  --log / --no-log            Enable verbose logging of the synchronization
                              process.  [default: no-log]
  --debug / --no-debug        Enable debug logging.  [default: no-debug]
  --help                      Show this message and exit.
```

