### PR TITLE
feat: Allow custom metadata on pickable objects

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -296,6 +296,7 @@ copick add object [OPTIONS]
 | `--identifier TEXT`          | String  | Identifier for the object (e.g. Gene Ontology ID or UniProtKB accession)            | None                         |
 | `--map-threshold FLOAT`      | Float   | Threshold to apply to the map when rendering the isosurface                         | None                         |
 | `--radius FLOAT`             | Float   | Radius of the particle, when displaying as a sphere                                 | `50`                         |
+| `--metadata TEXT`            | String  | JSON string containing custom metadata for the object (e.g. '{"source": "experimental_data", "confidence": 0.95}') | None |
 | `--volume PATH`              | Path    | Path to volume file to associate with the object                                    | None                         |
 | `--volume-format CHOICE`     | String  | Format of the volume file ('mrc' or 'zarr')                                         | Auto-detected                |
 | `--voxel-size FLOAT`         | Float   | Voxel size for the volume data. Required if volume is provided                      | None                         |
@@ -319,6 +320,9 @@ copick add object --config config.json --name proteasome --object-type particle 
 
 # Add object with EMDB reference and identifier
 copick add object --config config.json --name apoferritin --object-type particle --emdb-id EMD-1234 --identifier "GO:0006826" --radius 60
+
+# Add object with custom metadata
+copick add object --config config.json --name ribosome --object-type particle --radius 120 --metadata '{"source": "experimental_data", "confidence": 0.95, "notes": "High-resolution structure"}'
 ```
 
 #### :material-cube-outline: `copick add object-volume`

--- a/docs/datamodel.md
+++ b/docs/datamodel.md
@@ -47,7 +47,12 @@ label, color, radius, and other properties.
         "label": 1,
         "color": [255, 0, 0, 255],
         "radius": 60,
-        "map_threshold": 0.0418
+        "map_threshold": 0.0418,
+        "metadata": {
+            "source": "experimental_data",
+            "confidence": 0.95,
+            "notes": "High-resolution structure"
+        }
     }
     ```
 
@@ -67,6 +72,9 @@ label, color, radius, and other properties.
         object. This is used to determine the isosurface level to use when rendering the object as a mesh. Density maps are
         discovered by the copick API by looking for files with the same name as the object in the `Objects` directory of
         the project's root.
+    - `metadata`: An optional dictionary that can contain arbitrary key-value pairs for storing additional custom
+        information about the object. This field allows users to attach project-specific metadata such as confidence scores,
+        data sources, or processing notes.
 
 
 ### Run

--- a/src/copick/cli/add.py
+++ b/src/copick/cli/add.py
@@ -457,6 +457,12 @@ def segmentation(
     show_default=True,
 )
 @click.option(
+    "--metadata",
+    type=str,
+    default=None,
+    help="Additional metadata values to associate with the object, in JSON format.",
+)
+@click.option(
     "--volume",
     type=str,
     default=None,
@@ -497,6 +503,7 @@ def object(
     identifier: str,
     map_threshold: float,
     radius: float,
+    metadata: str,
     volume: str,
     volume_format: str,
     voxel_size: float,
@@ -529,6 +536,16 @@ def object(
             color_tuple = tuple(color_values)
         except ValueError:
             ctx.fail("Color values must be integers between 0 and 255.")
+
+    # Parse metadata if provided
+    metadata_dict = {}
+    if metadata:
+        try:
+            import json
+
+            metadata_dict = json.loads(metadata)
+        except json.JSONDecodeError:
+            ctx.fail("Metadata must be valid JSON format.")
 
     # Load volume if provided
     volume_data = None
@@ -564,6 +581,7 @@ def object(
             radius=radius,
             volume=volume_data,
             voxel_size=voxel_spacing,
+            metadata=metadata_dict,
             exist_ok=exist_ok,
             save_config=True,
             config_path=config,

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -1,5 +1,5 @@
 import json
-from typing import TYPE_CHECKING, Dict, Iterable, List, Literal, MutableMapping, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, MutableMapping, Optional, Tuple, Type, Union
 
 import numpy as np
 import zarr
@@ -37,6 +37,7 @@ class PickableObject(BaseModel):
     identifier: Optional[str] = Field(None, alias=AliasChoices("go_id", "identifier"))
     map_threshold: Optional[float] = None
     radius: Optional[float] = None
+    metadata: Optional[Dict[str, Any]] = Field(default_factory=dict)
 
     @property
     def go_id(self):
@@ -211,6 +212,7 @@ class CopickObject:
         pdb_id: PDB ID for the object.
         map_threshold: Threshold to apply to the map when rendering the isosurface.
         radius: Radius of the particle, when displaying as a sphere.
+        metadata: Additional metadata for the object (not part of the base PickableObject model).
     """
 
     def __init__(self, root: "CopickRoot", meta: PickableObject):
@@ -272,6 +274,10 @@ class CopickObject:
     @property
     def radius(self) -> Union[float, None]:
         return self.meta.radius
+
+    @property
+    def metadata(self) -> Dict[str, Any]:
+        return self.meta.metadata
 
     def zarr(self) -> Union[None, MutableMapping]:
         """Override this method to return a zarr store for this object. Should return None if
@@ -554,6 +560,7 @@ class CopickRoot:
         identifier: Optional[str] = None,
         map_threshold: Optional[float] = None,
         radius: Optional[float] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         exist_ok: bool = False,
     ) -> "CopickObject":
         """Create a new pickable object and add it to the configuration.
@@ -568,6 +575,7 @@ class CopickRoot:
             identifier: Identifier for the object (e.g. Gene Ontology ID or UniProtKB accession).
             map_threshold: Threshold to apply to the map when rendering the isosurface.
             radius: Radius of the particle, when displaying as a sphere.
+            metadata: Additional metadata for the object (not part of the base PickableObject model).
             exist_ok: Whether existing objects with the same name should be overwritten..
 
         Returns:
@@ -598,6 +606,7 @@ class CopickRoot:
             obj.meta.identifier = identifier if identifier else obj.identifier
             obj.meta.map_threshold = map_threshold if map_threshold else obj.map_threshold
             obj.meta.radius = radius if radius else obj.radius
+            obj.meta.metadata = metadata if metadata else obj.metadata
         else:
             # Check for duplicate label BEFORE auto-assignment
             if label is not None:
@@ -626,6 +635,7 @@ class CopickRoot:
                 identifier=identifier,
                 map_threshold=map_threshold,
                 radius=radius,
+                metadata=metadata if metadata else {},
             )
 
             # Add to configuration

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -26,6 +26,7 @@ class PickableObject(BaseModel):
         identifier: Identifier for the object (e.g. Gene Ontology ID or UniProtKB accession).
         map_threshold: Threshold to apply to the map when rendering the isosurface.
         radius: Radius of the particle, when displaying as a sphere.
+        metadata: Additional metadata for the object (not part of the base PickableObject model).
     """
 
     name: str

--- a/src/copick/ops/add.py
+++ b/src/copick/ops/add.py
@@ -427,6 +427,7 @@ def add_object(
     radius: Optional[float] = None,
     volume: Optional[np.ndarray] = None,
     voxel_size: Optional[float] = None,
+    metadata: Optional[Dict[str, Any]] = None,
     exist_ok: bool = False,
     save_config: bool = False,
     config_path: Optional[str] = None,
@@ -447,6 +448,7 @@ def add_object(
         radius: Radius of the particle, when displaying as a sphere.
         volume: Optional volume data to associate with the object.
         voxel_size: Voxel size for the volume data. Required if volume is provided.
+        metadata: Optional metadata dictionary to associate with the object.
         exist_ok: Whether existing objects with the same name should be overwritten..
         save_config: Whether to save the configuration to disk after adding the object.
         config_path: Path to save the configuration. Required if save_config is True.
@@ -481,6 +483,7 @@ def add_object(
         identifier=identifier,
         map_threshold=map_threshold,
         radius=radius,
+        metadata=metadata or {},
         exist_ok=exist_ok,
     )
 

--- a/tests/test_object_models.py
+++ b/tests/test_object_models.py
@@ -34,6 +34,8 @@ class TestCopickRootNewObject:
         """Test creating an object with all parameters specified."""
         root = test_payload["root"]
 
+        metadata_dict = {"key1": "value1", "key2": 42, "nested": {"inner": True}}
+
         obj = root.new_object(
             name="detailed-object",
             is_particle=False,
@@ -44,6 +46,7 @@ class TestCopickRootNewObject:
             identifier="GO:0005840",
             map_threshold=0.7,
             radius=150.0,
+            metadata=metadata_dict,
         )
 
         assert obj.name == "detailed-object"
@@ -55,6 +58,7 @@ class TestCopickRootNewObject:
         assert obj.identifier == "GO:0005840"
         assert obj.map_threshold == 0.7
         assert obj.radius == 150.0
+        assert obj.metadata == metadata_dict
 
     def test_new_object_auto_label_assignment(self, test_payload):
         """Test automatic label assignment for multiple objects."""
@@ -174,6 +178,50 @@ class TestCopickRootNewObject:
         with pytest.raises(ValidationError, match="Color values must be in the range"):
             root.new_object(name="bad-color2", is_particle=True, color=(256, 0, 0, 255))  # 256 > 255
 
+    def test_new_object_with_metadata(self, test_payload):
+        """Test creating object with metadata."""
+        root = test_payload["root"]
+
+        metadata_dict = {
+            "key1": "value1",
+            "key2": 42,
+            "key3": {"nested": {"inner": True}},
+            "array": [1, 2, 3],
+            "boolean": False,
+        }
+
+        obj = root.new_object(name="test-with-metadata", is_particle=True, metadata=metadata_dict)
+
+        assert obj.name == "test-with-metadata"
+        assert obj.metadata == metadata_dict
+
+    def test_new_object_without_metadata(self, test_payload):
+        """Test creating object without metadata (should default to empty dict)."""
+        root = test_payload["root"]
+
+        obj = root.new_object(name="test-no-metadata", is_particle=True)
+
+        assert obj.name == "test-no-metadata"
+        assert obj.metadata == {}
+
+    def test_new_object_with_none_metadata(self, test_payload):
+        """Test creating object with None metadata (should default to empty dict)."""
+        root = test_payload["root"]
+
+        obj = root.new_object(name="test-none-metadata", is_particle=True, metadata=None)
+
+        assert obj.name == "test-none-metadata"
+        assert obj.metadata == {}
+
+    def test_new_object_with_empty_metadata(self, test_payload):
+        """Test creating object with empty metadata dict."""
+        root = test_payload["root"]
+
+        obj = root.new_object(name="test-empty-metadata", is_particle=True, metadata={})
+
+        assert obj.name == "test-empty-metadata"
+        assert obj.metadata == {}
+
 
 class TestCopickRootSaveConfig:
     """Test cases for the CopickRoot.save_config method."""
@@ -232,6 +280,33 @@ class TestCopickRootSaveConfig:
         assert loaded_obj.identifier == original_obj.identifier
         assert loaded_obj.map_threshold == original_obj.map_threshold
         assert loaded_obj.radius == original_obj.radius
+
+    def test_save_config_preserves_metadata(self, test_payload, tmp_path):
+        """Test that saving config preserves object metadata."""
+        root = test_payload["root"]
+
+        # Add object with complex metadata
+        metadata_dict = {
+            "key1": "value1",
+            "key2": 42,
+            "key3": {"nested": {"inner": True, "list": [1, 2, 3]}},
+            "array": [1, 2, 3],
+            "boolean": False,
+            "null_value": None,
+        }
+
+        original_obj = root.new_object(name="metadata-object", is_particle=True, metadata=metadata_dict)
+
+        # Save config
+        config_path = tmp_path / "metadata-config.json"
+        root.save_config(str(config_path))
+
+        # Load and verify metadata is preserved
+        new_root = CopickRootFSSpec.from_file(str(config_path))
+        loaded_obj = new_root.get_object("metadata-object")
+
+        assert loaded_obj.name == original_obj.name
+        assert loaded_obj.metadata == metadata_dict
 
 
 class TestAddObjectFunction:
@@ -322,6 +397,81 @@ class TestAddObjectFunction:
                 save_config=True,
                 # Missing config_path
             )
+
+    def test_add_object_functional_api_with_metadata(self, test_payload):
+        """Test adding object with metadata via functional API."""
+        root = test_payload["root"]
+
+        metadata_dict = {"key1": "value1", "key2": 42, "key3": {"nested": True}, "array": [1, 2, 3]}
+
+        # Add object with metadata
+        obj = add_object(
+            root=root,
+            name="test-functional-metadata",
+            is_particle=True,
+            metadata=metadata_dict,
+        )
+
+        assert obj is not None, "Object should be created"
+        assert obj.metadata == metadata_dict, f"Metadata should match. Got: {obj.metadata}"
+
+        # Verify object is accessible from root with metadata
+        retrieved_obj = root.get_object("test-functional-metadata")
+        assert retrieved_obj is not None, "Object should exist"
+        assert retrieved_obj.metadata == metadata_dict, "Metadata should persist"
+
+    def test_add_object_functional_api_without_metadata(self, test_payload):
+        """Test adding object without metadata via functional API (should default to empty dict)."""
+        root = test_payload["root"]
+
+        # Add object without metadata
+        obj = add_object(
+            root=root,
+            name="test-functional-no-metadata",
+            is_particle=True,
+        )
+
+        assert obj is not None, "Object should be created"
+        assert obj.metadata == {}, "Metadata should default to empty dict"
+
+    def test_add_object_functional_api_with_none_metadata(self, test_payload):
+        """Test adding object with None metadata via functional API (should default to empty dict)."""
+        root = test_payload["root"]
+
+        # Add object with None metadata
+        obj = add_object(
+            root=root,
+            name="test-functional-none-metadata",
+            is_particle=True,
+            metadata=None,
+        )
+
+        assert obj is not None, "Object should be created"
+        assert obj.metadata == {}, "Metadata should default to empty dict when None"
+
+    def test_add_object_with_metadata_and_config_save(self, test_payload, tmp_path):
+        """Test adding object with metadata and saving config preserves metadata."""
+        root = test_payload["root"]
+        config_path = tmp_path / "metadata-saved-config.json"
+
+        metadata_dict = {"key1": "value1", "key2": 42, "nested": {"inner": True}}
+
+        obj = add_object(
+            root=root,
+            name="test-metadata-save",
+            is_particle=True,
+            metadata=metadata_dict,
+            save_config=True,
+            config_path=str(config_path),
+        )
+
+        assert obj.metadata == metadata_dict
+
+        # Verify metadata persists after reloading config
+        root_reloaded = CopickRootFSSpec.from_file(str(config_path))
+        obj_reloaded = root_reloaded.get_object("test-metadata-save")
+        assert obj_reloaded is not None, "Object should exist after reload"
+        assert obj_reloaded.metadata == metadata_dict, "Metadata should persist after reload"
 
 
 class TestAddObjectVolumeFunction:
@@ -419,3 +569,52 @@ class TestAddObjectVolumeFunction:
         else:
             # Skip test if no read-only objects available
             pytest.skip("No read-only particle objects available for testing")
+
+
+class TestPickableObjectModel:
+    """Test cases for the PickableObject model metadata functionality."""
+
+    def test_pickable_object_model_with_metadata(self):
+        """Test PickableObject model with metadata field."""
+        from copick.models import PickableObject
+
+        metadata_dict = {"key1": "value1", "key2": 42}
+
+        obj = PickableObject(name="test-object", is_particle=True, metadata=metadata_dict, identifier=None)
+
+        assert obj.metadata == metadata_dict, "Metadata should be preserved in model"
+
+    def test_pickable_object_model_without_metadata(self):
+        """Test PickableObject model without metadata field (should default to empty dict)."""
+        from copick.models import PickableObject
+
+        obj = PickableObject(name="test-object", is_particle=True)
+
+        assert obj.metadata == {}, "Metadata should default to empty dict"
+
+    def test_pickable_object_model_with_none_metadata(self):
+        """Test PickableObject model with None metadata."""
+        from copick.models import PickableObject
+
+        obj = PickableObject(name="test-object", is_particle=True, metadata=None)
+
+        assert obj.metadata == {}, "Metadata should default to empty dict when None"
+
+    def test_pickable_object_model_complex_metadata(self):
+        """Test PickableObject model with complex metadata structures."""
+        from copick.models import PickableObject
+
+        complex_metadata = {
+            "string": "value",
+            "number": 42,
+            "float": 3.14,
+            "boolean": True,
+            "null": None,
+            "nested": {"inner": "nested_value", "array": [1, 2, 3], "nested_object": {"deep": "value"}},
+            "array": ["a", "b", "c"],
+            "mixed_array": [1, "two", {"three": 3}],
+        }
+
+        obj = PickableObject(name="complex-object", is_particle=True, metadata=complex_metadata)
+
+        assert obj.metadata == complex_metadata, "Complex metadata should be preserved"


### PR DESCRIPTION
@zhuowenzhao pointed out that it might be useful to allow storing custom metadata on `PickableObject` to store parameters necessary for inference or training. This PR adds an optional dictionary to the `PickableObject`-Class that allows storing arbitrary JSON-serializable data. 

```python
class PickableObject(BaseModel):
    """Metadata for a pickable objects.

    Attributes:
        name: Name of the object.
        is_particle: Whether this object should be represented by points (True) or segmentation masks (False).
        label: Numeric label/id for the object, as used in multilabel segmentation masks. Must be unique.
        color: RGBA color for the object.
        emdb_id: EMDB ID for the object.
        pdb_id: PDB ID for the object.
        identifier: Identifier for the object (e.g. Gene Ontology ID or UniProtKB accession).
        map_threshold: Threshold to apply to the map when rendering the isosurface.
        radius: Radius of the particle, when displaying as a sphere.
        metadata: Additional metadata for the object (not part of the base PickableObject model).   # NEW
    """

    name: str
    is_particle: bool
    label: Optional[int] = 1
    color: Optional[Tuple[int, int, int, int]] = (100, 100, 100, 255)
    emdb_id: Optional[str] = None
    pdb_id: Optional[str] = None
    identifier: Optional[str] = Field(None, alias=AliasChoices("go_id", "identifier"))
    map_threshold: Optional[float] = None
    radius: Optional[float] = None
    metadata: Optional[Dict[str, Any]] = Field(default_factory=dict)      # NEW
```

The `add_object`-function, CLI and docs are also updated. Also adds tests for the new metadata and default values. 

