### PR TITLE
docs: Update docs to reflect fix in pip==25.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pip install "copick[all]"
 ```
 
 > [!NOTE]
-> `copick==1.2.0` will fail to install with `pip>=25`. We recommend using [`uv pip`](https://docs.astral.sh/uv/pip/) or `pip<=25` when installing copick.
+> `copick>=1.2.0` will fail to install with `pip~=25.1.0`. We recommend using `pip>=25.2` or  [`uv pip`](https://docs.astral.sh/uv/pip/) when installing copick.
 
 
 ## Example dataset

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,7 +21,7 @@ pip install "copick[all]"
 ```
 
 !!! note
-    `copick==1.2.0` will fail to install with `pip>=25`. We recommend using [`uv pip`](https://docs.astral.sh/uv/pip/) or `pip<=25` when installing copick.
+    `copick>=1.2.0` will fail to install with `pip~=25.1.0`. We recommend using `pip>=25.2` or  [`uv pip`](https://docs.astral.sh/uv/pip/) when installing copick.
 
 
 ## Example dataset


### PR DESCRIPTION
`pip==25.2` fixed the resolution errors, we can now recommend using pip for installation again. 