### PR TITLE
feat: Functional API and CLI commands for gathering statistics.

### DIFF
--- a/docs/api_reference/functional/stats.md
+++ b/docs/api_reference/functional/stats.md
@@ -1,0 +1,185 @@
+# Stats Operations
+
+The `copick.ops.stats` module provides statistical analysis functions for Copick projects. These functions generate comprehensive statistics about picks, meshes, and segmentations including counts, distributions, and frequency analysis.
+
+## Functions
+
+::: copick.ops.stats.picks_stats
+    options:
+        show_root_heading: true
+        show_root_full_path: true
+
+::: copick.ops.stats.meshes_stats
+    options:
+        show_root_heading: true
+        show_root_full_path: true
+
+::: copick.ops.stats.segmentations_stats
+    options:
+        show_root_heading: true
+        show_root_full_path: true
+
+## Usage Examples
+
+### Picks Statistics
+
+```python
+from copick.ops.stats import picks_stats
+from copick.impl.filesystem import CopickRootFSSpec
+
+# Open a project
+root = CopickRootFSSpec.from_file("config.json")
+
+# Get comprehensive picks statistics
+all_picks_stats = picks_stats(root)
+print(f"Total picks: {all_picks_stats['total_picks']}")
+print(f"Distribution by run: {all_picks_stats['distribution_by_run']}")
+
+# Get statistics for specific runs and objects
+filtered_stats = picks_stats(
+    root=root,
+    runs=["experiment_001", "experiment_002"],
+    object_name=["ribosome", "proteasome"],
+    user_id=["annotator_1"]
+)
+
+# Enable parallel processing for large projects
+parallel_stats = picks_stats(
+    root=root,
+    parallel=True,
+    workers=12,
+    show_progress=True
+)
+```
+
+### Meshes Statistics
+
+```python
+from copick.ops.stats import meshes_stats
+
+# Get mesh statistics with filtering
+mesh_stats = meshes_stats(
+    root=root,
+    runs=["experiment_001"],
+    user_id=["modeler_1", "modeler_2"],
+    object_name=["ribosome"]
+)
+
+print(f"Total meshes: {mesh_stats['total_meshes']}")
+print(f"Distribution by user: {mesh_stats['distribution_by_user']}")
+print(f"Frequent combinations: {mesh_stats['session_user_object_combinations']}")
+
+# Get statistics for all meshes with parallel processing
+all_mesh_stats = meshes_stats(root, parallel=True)
+```
+
+### Segmentations Statistics
+
+```python
+from copick.ops.stats import segmentations_stats
+
+# Get segmentation statistics with comprehensive filtering
+seg_stats = segmentations_stats(
+    root=root,
+    runs=["experiment_001"],
+    user_id=["segmentation_model"],
+    name=["membrane", "organelle"],
+    voxel_size=[10.0, 20.0],
+    is_multilabel=True
+)
+
+print(f"Total segmentations: {seg_stats['total_segmentations']}")
+print(f"Distribution by name: {seg_stats['distribution_by_name']}")
+print(f"Distribution by voxel size: {seg_stats['distribution_by_voxel_size']}")
+print(f"Distribution by multilabel: {seg_stats['distribution_by_multilabel']}")
+
+# Analyze combination frequencies
+combinations = seg_stats['session_user_voxelspacing_multilabel_combinations']
+most_frequent = max(combinations.items(), key=lambda x: x[1])
+print(f"Most frequent combination: {most_frequent[0]} ({most_frequent[1]} occurrences)")
+```
+
+## Return Value Structure
+
+### Picks Statistics
+
+```python
+{
+    "total_picks": int,                    # Total number of individual pick points
+    "total_pick_files": int,               # Total number of pick files
+    "distribution_by_run": {               # Pick count per run
+        "run_name": pick_count
+    },
+    "distribution_by_user": {              # Pick count per user
+        "user_id": pick_count
+    },
+    "distribution_by_session": {           # Pick count per session
+        "session_id": pick_count
+    },
+    "distribution_by_object": {            # Pick count per object
+        "object_name": pick_count
+    }
+}
+```
+
+### Meshes Statistics
+
+```python
+{
+    "total_meshes": int,                   # Total number of mesh files
+    "distribution_by_user": {              # Mesh count per user
+        "user_id": mesh_count
+    },
+    "distribution_by_session": {           # Mesh count per session
+        "session_id": mesh_count
+    },
+    "distribution_by_object": {            # Mesh count per object
+        "object_name": mesh_count
+    },
+    "session_user_object_combinations": {  # Frequency of specific combinations
+        "session_user_object": frequency
+    }
+}
+```
+
+### Segmentations Statistics
+
+```python
+{
+    "total_segmentations": int,            # Total number of segmentation files
+    "distribution_by_user": {              # Segmentation count per user
+        "user_id": segmentation_count
+    },
+    "distribution_by_session": {           # Segmentation count per session
+        "session_id": segmentation_count
+    },
+    "distribution_by_name": {              # Segmentation count per name
+        "name": segmentation_count
+    },
+    "distribution_by_voxel_size": {        # Segmentation count per voxel size
+        "voxel_size": segmentation_count
+    },
+    "distribution_by_multilabel": {        # Segmentation count by multilabel status
+        "True/False": segmentation_count
+    },
+    "session_user_voxelspacing_multilabel_combinations": {  # Frequency of specific combinations
+        "session_user_name_voxelsize_multilabel": frequency
+    }
+}
+```
+
+## Performance Considerations
+
+### Parallel Processing
+
+All stats functions support parallel processing for improved performance with large projects:
+
+```python
+# Enable parallel processing with custom worker count
+stats = picks_stats(
+    root=root,
+    parallel=True,
+    workers=16,  # Adjust based on your system
+    show_progress=True
+)
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -685,6 +685,134 @@ copick sync tomograms -c source_config.json --target-config target_config.json \
 
 ---
 
+### :material-chart-bar: `copick stats`
+
+Gather statistics about a Copick project's entities including picks, meshes, and segmentations.
+
+**Subcommands:**
+
+- [`copick stats picks`](#copick-stats-picks) - Generate statistics for picks in the project
+- [`copick stats meshes`](#copick-stats-meshes) - Generate statistics for meshes in the project
+- [`copick stats segmentations`](#copick-stats-segmentations) - Generate statistics for segmentations in the project
+
+#### :material-target: `copick stats picks`
+
+Generate comprehensive statistics for picks including total counts and distribution analysis.
+
+**Usage:**
+```bash
+copick stats picks [OPTIONS]
+```
+
+**Options:**
+
+| Option                  | Type    | Description                                           | Default                      |
+|-------------------------|---------|-------------------------------------------------------|------------------------------|
+| `-c, --config PATH`     | Path    | Path to the configuration file                        | Uses `COPICK_CONFIG` env var |
+| `--runs`                | String  | Specific run names to analyze (multiple allowed)     | All runs                     |
+| `--user-id`             | String  | Filter by user ID (multiple allowed)                 | All users                    |
+| `--session-id`          | String  | Filter by session ID (multiple allowed)              | All sessions                 |
+| `--object-name`         | String  | Filter by pickable object name (multiple allowed)    | All objects                  |
+| `--parallel/--no-parallel` | Boolean | Enable parallel processing                           | `no-parallel`               |
+| `--workers`             | Integer | Number of workers for parallel processing            | `8`                          |
+| `--output`              | Choice  | Output format ('json' or 'table')                    | `table`                      |
+| `--debug/--no-debug`    | Boolean | Enable debug logging                                  | `no-debug`                   |
+
+**Examples:**
+
+```bash
+# Get statistics for all picks
+copick stats picks --config config.json
+
+# Get statistics for specific runs
+copick stats picks --config config.json --runs run1 --runs run2
+
+# Get statistics for specific objects and users
+copick stats picks --config config.json --object-name ribosome --user-id alice
+
+# Output in JSON format with parallel processing
+copick stats picks --config config.json --output json --parallel --workers 12
+```
+
+#### :material-vector-triangle: `copick stats meshes`
+
+Generate statistics for meshes including counts and frequency analysis of user/session/object combinations.
+
+**Usage:**
+```bash
+copick stats meshes [OPTIONS]
+```
+
+**Options:**
+
+| Option                  | Type    | Description                                           | Default                      |
+|-------------------------|---------|-------------------------------------------------------|------------------------------|
+| `-c, --config PATH`     | Path    | Path to the configuration file                        | Uses `COPICK_CONFIG` env var |
+| `--runs`                | String  | Specific run names to analyze (multiple allowed)     | All runs                     |
+| `--user-id`             | String  | Filter by user ID (multiple allowed)                 | All users                    |
+| `--session-id`          | String  | Filter by session ID (multiple allowed)              | All sessions                 |
+| `--object-name`         | String  | Filter by pickable object name (multiple allowed)    | All objects                  |
+| `--parallel/--no-parallel` | Boolean | Enable parallel processing                           | `no-parallel`               |
+| `--workers`             | Integer | Number of workers for parallel processing            | `8`                          |
+| `--output`              | Choice  | Output format ('json' or 'table')                    | `table`                      |
+| `--debug/--no-debug`    | Boolean | Enable debug logging                                  | `no-debug`                   |
+
+**Examples:**
+
+```bash
+# Get statistics for all meshes
+copick stats meshes --config config.json
+
+# Get statistics for specific users and sessions
+copick stats meshes --config config.json --user-id analyst --session-id session1
+
+# JSON output for integration with other tools
+copick stats meshes --config config.json --output json
+```
+
+#### :material-layers: `copick stats segmentations`
+
+Generate statistics for segmentations including counts and frequency analysis by various properties.
+
+**Usage:**
+```bash
+copick stats segmentations [OPTIONS]
+```
+
+**Options:**
+
+| Option                      | Type    | Description                                           | Default                      |
+|-----------------------------|---------|-------------------------------------------------------|------------------------------|
+| `-c, --config PATH`         | Path    | Path to the configuration file                        | Uses `COPICK_CONFIG` env var |
+| `--runs`                    | String  | Specific run names to analyze (multiple allowed)     | All runs                     |
+| `--user-id`                 | String  | Filter by user ID (multiple allowed)                 | All users                    |
+| `--session-id`              | String  | Filter by session ID (multiple allowed)              | All sessions                 |
+| `--name`                    | String  | Filter by segmentation name (multiple allowed)       | All segmentations            |
+| `--voxel-size`              | Float   | Filter by voxel size (multiple allowed)              | All voxel sizes              |
+| `--multilabel/--no-multilabel` | Boolean | Filter by multilabel status                          | All types                    |
+| `--parallel/--no-parallel`  | Boolean | Enable parallel processing                            | `no-parallel`               |
+| `--workers`                 | Integer | Number of workers for parallel processing            | `8`                          |
+| `--output`                  | Choice  | Output format ('json' or 'table')                    | `table`                      |
+| `--debug/--no-debug`        | Boolean | Enable debug logging                                  | `no-debug`                   |
+
+**Examples:**
+
+```bash
+# Get statistics for all segmentations
+copick stats segmentations --config config.json
+
+# Get statistics for specific segmentation types and voxel sizes
+copick stats segmentations --config config.json --name membrane --voxel-size 10.0
+
+# Filter by multilabel segmentations only
+copick stats segmentations --config config.json --multilabel
+
+# Comprehensive analysis with parallel processing
+copick stats segmentations --config config.json --parallel --output json
+```
+
+---
+
 ### :material-information: `copick info`
 
 Display information about the Copick CLI and available plugins.

--- a/src/copick/cli/cli.py
+++ b/src/copick/cli/cli.py
@@ -7,6 +7,7 @@ from copick.cli.config import config
 from copick.cli.ext import load_plugin_commands
 from copick.cli.info import info
 from copick.cli.new import new
+from copick.cli.stats import stats
 from copick.cli.sync import sync
 from copick.util.log import get_logger
 
@@ -93,6 +94,7 @@ def add_core_commands(cmd: click.group) -> click.group:
     cmd.add_command(config)
     cmd.add_command(info)
     cmd.add_command(new)
+    cmd.add_command(stats)
     cmd.add_command(sync)
 
     return cmd

--- a/src/copick/cli/stats.py
+++ b/src/copick/cli/stats.py
@@ -1,0 +1,398 @@
+import json
+
+import click
+
+from copick.cli.util import add_config_option, add_debug_option
+from copick.ops.open import from_file
+from copick.ops.stats import meshes_stats, picks_stats, segmentations_stats
+from copick.util.log import get_logger
+
+
+@click.group(short_help="Gather statistics about a copick project.")
+@click.pass_context
+def stats(ctx):
+    """
+    Statistics commands for Copick.
+
+    This group contains commands for gathering statistics about Copick project entities.
+    """
+    pass
+
+
+@stats.command()
+@add_config_option
+@add_debug_option
+@click.option(
+    "--runs",
+    type=str,
+    multiple=True,
+    help="Specific run names to analyze. Can be specified multiple times.",
+)
+@click.option(
+    "--user-id",
+    type=str,
+    multiple=True,
+    help="Filter by user ID. Can be specified multiple times.",
+)
+@click.option(
+    "--session-id", 
+    type=str,
+    multiple=True,
+    help="Filter by session ID. Can be specified multiple times.",
+)
+@click.option(
+    "--object-name",
+    type=str,
+    multiple=True,
+    help="Filter by pickable object name. Can be specified multiple times.",
+)
+@click.option(
+    "--parallel/--no-parallel",
+    default=False,
+    help="Enable parallel processing.",
+)
+@click.option(
+    "--workers",
+    type=int,
+    default=8,
+    help="Number of workers for parallel processing.",
+)
+@click.option(
+    "--output",
+    type=click.Choice(["json", "table"]),
+    default="table",
+    help="Output format.",
+)
+@click.pass_context
+def picks(
+    ctx,
+    config,
+    debug,
+    runs,
+    user_id,
+    session_id,
+    object_name,
+    parallel,
+    workers,
+    output,
+):
+    """Generate statistics for picks in the project."""
+    logger = get_logger(__name__, debug)
+    
+    if config is None:
+        raise click.ClickException("Configuration file path is required. Use -c/--config option.")
+        
+    root = from_file(config)
+    
+    # Convert tuples to lists or None
+    runs_param = list(runs) if runs else None
+    user_id_param = list(user_id) if user_id else None
+    session_id_param = list(session_id) if session_id else None
+    object_name_param = list(object_name) if object_name else None
+    
+    stats_data = picks_stats(
+        root=root,
+        runs=runs_param,
+        user_id=user_id_param,
+        session_id=session_id_param,
+        object_name=object_name_param,
+        parallel=parallel,
+        workers=workers,
+        show_progress=True,
+    )
+    
+    if output == "json":
+        click.echo(json.dumps(stats_data, indent=2))
+    else:
+        _print_picks_table(stats_data)
+
+
+@stats.command()
+@add_config_option
+@add_debug_option
+@click.option(
+    "--runs",
+    type=str,
+    multiple=True,
+    help="Specific run names to analyze. Can be specified multiple times.",
+)
+@click.option(
+    "--user-id",
+    type=str,
+    multiple=True,
+    help="Filter by user ID. Can be specified multiple times.",
+)
+@click.option(
+    "--session-id",
+    type=str,
+    multiple=True,
+    help="Filter by session ID. Can be specified multiple times.",
+)
+@click.option(
+    "--object-name",
+    type=str,
+    multiple=True,
+    help="Filter by pickable object name. Can be specified multiple times.",
+)
+@click.option(
+    "--parallel/--no-parallel",
+    default=False,
+    help="Enable parallel processing.",
+)
+@click.option(
+    "--workers",
+    type=int,
+    default=8,
+    help="Number of workers for parallel processing.",
+)
+@click.option(
+    "--output",
+    type=click.Choice(["json", "table"]),
+    default="table",
+    help="Output format.",
+)
+@click.pass_context
+def meshes(
+    ctx,
+    config,
+    debug,
+    runs,
+    user_id,
+    session_id,
+    object_name,
+    parallel,
+    workers,
+    output,
+):
+    """Generate statistics for meshes in the project."""
+    logger = get_logger(__name__, debug)
+    
+    if config is None:
+        raise click.ClickException("Configuration file path is required. Use -c/--config option.")
+        
+    root = from_file(config)
+    
+    # Convert tuples to lists or None
+    runs_param = list(runs) if runs else None
+    user_id_param = list(user_id) if user_id else None
+    session_id_param = list(session_id) if session_id else None
+    object_name_param = list(object_name) if object_name else None
+    
+    stats_data = meshes_stats(
+        root=root,
+        runs=runs_param,
+        user_id=user_id_param,
+        session_id=session_id_param,
+        object_name=object_name_param,
+        parallel=parallel,
+        workers=workers,
+        show_progress=True,
+    )
+    
+    if output == "json":
+        click.echo(json.dumps(stats_data, indent=2))
+    else:
+        _print_meshes_table(stats_data)
+
+
+@stats.command()
+@add_config_option
+@add_debug_option
+@click.option(
+    "--runs",
+    type=str,
+    multiple=True,
+    help="Specific run names to analyze. Can be specified multiple times.",
+)
+@click.option(
+    "--user-id",
+    type=str,
+    multiple=True,
+    help="Filter by user ID. Can be specified multiple times.",
+)
+@click.option(
+    "--session-id",
+    type=str,
+    multiple=True,
+    help="Filter by session ID. Can be specified multiple times.",
+)
+@click.option(
+    "--name",
+    type=str,
+    multiple=True,
+    help="Filter by segmentation name. Can be specified multiple times.",
+)
+@click.option(
+    "--voxel-size",
+    type=float,
+    multiple=True,
+    help="Filter by voxel size. Can be specified multiple times.",
+)
+@click.option(
+    "--multilabel/--no-multilabel",
+    default=None,
+    help="Filter by multilabel status.",
+)
+@click.option(
+    "--parallel/--no-parallel",
+    default=False,
+    help="Enable parallel processing.",
+)
+@click.option(
+    "--workers",
+    type=int,
+    default=8,
+    help="Number of workers for parallel processing.",
+)
+@click.option(
+    "--output",
+    type=click.Choice(["json", "table"]),
+    default="table",
+    help="Output format.",
+)
+@click.pass_context
+def segmentations(
+    ctx,
+    config,
+    debug,
+    runs,
+    user_id,
+    session_id,
+    name,
+    voxel_size,
+    multilabel,
+    parallel,
+    workers,
+    output,
+):
+    """Generate statistics for segmentations in the project."""
+    logger = get_logger(__name__, debug)
+    
+    if config is None:
+        raise click.ClickException("Configuration file path is required. Use -c/--config option.")
+        
+    root = from_file(config)
+    
+    # Convert tuples to lists or None
+    runs_param = list(runs) if runs else None
+    user_id_param = list(user_id) if user_id else None
+    session_id_param = list(session_id) if session_id else None
+    name_param = list(name) if name else None
+    voxel_size_param = list(voxel_size) if voxel_size else None
+    
+    stats_data = segmentations_stats(
+        root=root,
+        runs=runs_param,
+        user_id=user_id_param,
+        session_id=session_id_param,
+        is_multilabel=multilabel,
+        name=name_param,
+        voxel_size=voxel_size_param,
+        parallel=parallel,
+        workers=workers,
+        show_progress=True,
+    )
+    
+    if output == "json":
+        click.echo(json.dumps(stats_data, indent=2))
+    else:
+        _print_segmentations_table(stats_data)
+
+
+def _print_picks_table(stats_data: dict):
+    """Print picks statistics in table format."""
+    click.echo("=== Picks Statistics ===")
+    click.echo(f"Total individual picks: {stats_data['total_picks']}")
+    click.echo(f"Total pick files: {stats_data['total_pick_files']}")
+    
+    if stats_data["distribution_by_run"]:
+        click.echo("\nDistribution by run:")
+        for run, count in stats_data["distribution_by_run"].items():
+            click.echo(f"  {run}: {count}")
+    
+    if stats_data["distribution_by_user"]:
+        click.echo("\nDistribution by user:")
+        for user, count in stats_data["distribution_by_user"].items():
+            click.echo(f"  {user}: {count}")
+    
+    if stats_data["distribution_by_session"]:
+        click.echo("\nDistribution by session:")
+        for session, count in stats_data["distribution_by_session"].items():
+            click.echo(f"  {session}: {count}")
+    
+    if stats_data["distribution_by_object"]:
+        click.echo("\nDistribution by object:")
+        for obj, count in stats_data["distribution_by_object"].items():
+            click.echo(f"  {obj}: {count}")
+
+
+def _print_meshes_table(stats_data: dict):
+    """Print meshes statistics in table format."""
+    click.echo("=== Meshes Statistics ===")
+    click.echo(f"Total meshes: {stats_data['total_meshes']}")
+    
+    if stats_data["distribution_by_user"]:
+        click.echo("\nDistribution by user:")
+        for user, count in stats_data["distribution_by_user"].items():
+            click.echo(f"  {user}: {count}")
+    
+    if stats_data["distribution_by_session"]:
+        click.echo("\nDistribution by session:")
+        for session, count in stats_data["distribution_by_session"].items():
+            click.echo(f"  {session}: {count}")
+    
+    if stats_data["distribution_by_object"]:
+        click.echo("\nDistribution by object:")
+        for obj, count in stats_data["distribution_by_object"].items():
+            click.echo(f"  {obj}: {count}")
+    
+    if stats_data["session_user_object_combinations"]:
+        click.echo("\nFrequent session_user_object combinations:")
+        sorted_combos = sorted(
+            stats_data["session_user_object_combinations"].items(),
+            key=lambda x: x[1],
+            reverse=True
+        )
+        for combo, count in sorted_combos[:10]:  # Top 10
+            click.echo(f"  {combo}: {count}")
+
+
+def _print_segmentations_table(stats_data: dict):
+    """Print segmentations statistics in table format."""
+    click.echo("=== Segmentations Statistics ===")
+    click.echo(f"Total segmentations: {stats_data['total_segmentations']}")
+    
+    if stats_data["distribution_by_user"]:
+        click.echo("\nDistribution by user:")
+        for user, count in stats_data["distribution_by_user"].items():
+            click.echo(f"  {user}: {count}")
+    
+    if stats_data["distribution_by_session"]:
+        click.echo("\nDistribution by session:")
+        for session, count in stats_data["distribution_by_session"].items():
+            click.echo(f"  {session}: {count}")
+    
+    if stats_data["distribution_by_name"]:
+        click.echo("\nDistribution by name:")
+        for name, count in stats_data["distribution_by_name"].items():
+            click.echo(f"  {name}: {count}")
+    
+    if stats_data["distribution_by_voxel_size"]:
+        click.echo("\nDistribution by voxel size:")
+        for voxel_size, count in stats_data["distribution_by_voxel_size"].items():
+            click.echo(f"  {voxel_size}: {count}")
+    
+    if stats_data["distribution_by_multilabel"]:
+        click.echo("\nDistribution by multilabel:")
+        for multilabel, count in stats_data["distribution_by_multilabel"].items():
+            click.echo(f"  {multilabel}: {count}")
+    
+    if stats_data["session_user_voxelspacing_multilabel_combinations"]:
+        click.echo("\nFrequent session_user_voxelspacing_multilabel combinations:")
+        sorted_combos = sorted(
+            stats_data["session_user_voxelspacing_multilabel_combinations"].items(),
+            key=lambda x: x[1],
+            reverse=True
+        )
+        for combo, count in sorted_combos[:10]:  # Top 10
+            click.echo(f"  {combo}: {count}")

--- a/src/copick/cli/stats.py
+++ b/src/copick/cli/stats.py
@@ -35,7 +35,7 @@ def stats(ctx):
     help="Filter by user ID. Can be specified multiple times.",
 )
 @click.option(
-    "--session-id", 
+    "--session-id",
     type=str,
     multiple=True,
     help="Filter by session ID. Can be specified multiple times.",
@@ -48,7 +48,7 @@ def stats(ctx):
 )
 @click.option(
     "--parallel/--no-parallel",
-    default=False,
+    default=True,
     help="Enable parallel processing.",
 )
 @click.option(
@@ -77,19 +77,19 @@ def picks(
     output,
 ):
     """Generate statistics for picks in the project."""
-    logger = get_logger(__name__, debug)
-    
+    get_logger(__name__, debug)
+
     if config is None:
         raise click.ClickException("Configuration file path is required. Use -c/--config option.")
-        
+
     root = from_file(config)
-    
+
     # Convert tuples to lists or None
     runs_param = list(runs) if runs else None
     user_id_param = list(user_id) if user_id else None
     session_id_param = list(session_id) if session_id else None
     object_name_param = list(object_name) if object_name else None
-    
+
     stats_data = picks_stats(
         root=root,
         runs=runs_param,
@@ -100,7 +100,7 @@ def picks(
         workers=workers,
         show_progress=True,
     )
-    
+
     if output == "json":
         click.echo(json.dumps(stats_data, indent=2))
     else:
@@ -136,7 +136,7 @@ def picks(
 )
 @click.option(
     "--parallel/--no-parallel",
-    default=False,
+    default=True,
     help="Enable parallel processing.",
 )
 @click.option(
@@ -165,19 +165,19 @@ def meshes(
     output,
 ):
     """Generate statistics for meshes in the project."""
-    logger = get_logger(__name__, debug)
-    
+    get_logger(__name__, debug)
+
     if config is None:
         raise click.ClickException("Configuration file path is required. Use -c/--config option.")
-        
+
     root = from_file(config)
-    
+
     # Convert tuples to lists or None
     runs_param = list(runs) if runs else None
     user_id_param = list(user_id) if user_id else None
     session_id_param = list(session_id) if session_id else None
     object_name_param = list(object_name) if object_name else None
-    
+
     stats_data = meshes_stats(
         root=root,
         runs=runs_param,
@@ -188,7 +188,7 @@ def meshes(
         workers=workers,
         show_progress=True,
     )
-    
+
     if output == "json":
         click.echo(json.dumps(stats_data, indent=2))
     else:
@@ -235,7 +235,7 @@ def meshes(
 )
 @click.option(
     "--parallel/--no-parallel",
-    default=False,
+    default=True,
     help="Enable parallel processing.",
 )
 @click.option(
@@ -266,20 +266,20 @@ def segmentations(
     output,
 ):
     """Generate statistics for segmentations in the project."""
-    logger = get_logger(__name__, debug)
-    
+    get_logger(__name__, debug)
+
     if config is None:
         raise click.ClickException("Configuration file path is required. Use -c/--config option.")
-        
+
     root = from_file(config)
-    
+
     # Convert tuples to lists or None
     runs_param = list(runs) if runs else None
     user_id_param = list(user_id) if user_id else None
     session_id_param = list(session_id) if session_id else None
     name_param = list(name) if name else None
     voxel_size_param = list(voxel_size) if voxel_size else None
-    
+
     stats_data = segmentations_stats(
         root=root,
         runs=runs_param,
@@ -292,7 +292,7 @@ def segmentations(
         workers=workers,
         show_progress=True,
     )
-    
+
     if output == "json":
         click.echo(json.dumps(stats_data, indent=2))
     else:
@@ -304,22 +304,22 @@ def _print_picks_table(stats_data: dict):
     click.echo("=== Picks Statistics ===")
     click.echo(f"Total individual picks: {stats_data['total_picks']}")
     click.echo(f"Total pick files: {stats_data['total_pick_files']}")
-    
+
     if stats_data["distribution_by_run"]:
         click.echo("\nDistribution by run:")
         for run, count in stats_data["distribution_by_run"].items():
             click.echo(f"  {run}: {count}")
-    
+
     if stats_data["distribution_by_user"]:
         click.echo("\nDistribution by user:")
         for user, count in stats_data["distribution_by_user"].items():
             click.echo(f"  {user}: {count}")
-    
+
     if stats_data["distribution_by_session"]:
         click.echo("\nDistribution by session:")
         for session, count in stats_data["distribution_by_session"].items():
             click.echo(f"  {session}: {count}")
-    
+
     if stats_data["distribution_by_object"]:
         click.echo("\nDistribution by object:")
         for obj, count in stats_data["distribution_by_object"].items():
@@ -330,28 +330,28 @@ def _print_meshes_table(stats_data: dict):
     """Print meshes statistics in table format."""
     click.echo("=== Meshes Statistics ===")
     click.echo(f"Total meshes: {stats_data['total_meshes']}")
-    
+
     if stats_data["distribution_by_user"]:
         click.echo("\nDistribution by user:")
         for user, count in stats_data["distribution_by_user"].items():
             click.echo(f"  {user}: {count}")
-    
+
     if stats_data["distribution_by_session"]:
         click.echo("\nDistribution by session:")
         for session, count in stats_data["distribution_by_session"].items():
             click.echo(f"  {session}: {count}")
-    
+
     if stats_data["distribution_by_object"]:
         click.echo("\nDistribution by object:")
         for obj, count in stats_data["distribution_by_object"].items():
             click.echo(f"  {obj}: {count}")
-    
+
     if stats_data["session_user_object_combinations"]:
         click.echo("\nFrequent session_user_object combinations:")
         sorted_combos = sorted(
             stats_data["session_user_object_combinations"].items(),
             key=lambda x: x[1],
-            reverse=True
+            reverse=True,
         )
         for combo, count in sorted_combos[:10]:  # Top 10
             click.echo(f"  {combo}: {count}")
@@ -361,38 +361,38 @@ def _print_segmentations_table(stats_data: dict):
     """Print segmentations statistics in table format."""
     click.echo("=== Segmentations Statistics ===")
     click.echo(f"Total segmentations: {stats_data['total_segmentations']}")
-    
+
     if stats_data["distribution_by_user"]:
         click.echo("\nDistribution by user:")
         for user, count in stats_data["distribution_by_user"].items():
             click.echo(f"  {user}: {count}")
-    
+
     if stats_data["distribution_by_session"]:
         click.echo("\nDistribution by session:")
         for session, count in stats_data["distribution_by_session"].items():
             click.echo(f"  {session}: {count}")
-    
+
     if stats_data["distribution_by_name"]:
         click.echo("\nDistribution by name:")
         for name, count in stats_data["distribution_by_name"].items():
             click.echo(f"  {name}: {count}")
-    
+
     if stats_data["distribution_by_voxel_size"]:
         click.echo("\nDistribution by voxel size:")
         for voxel_size, count in stats_data["distribution_by_voxel_size"].items():
             click.echo(f"  {voxel_size}: {count}")
-    
+
     if stats_data["distribution_by_multilabel"]:
         click.echo("\nDistribution by multilabel:")
         for multilabel, count in stats_data["distribution_by_multilabel"].items():
             click.echo(f"  {multilabel}: {count}")
-    
+
     if stats_data["session_user_voxelspacing_multilabel_combinations"]:
         click.echo("\nFrequent session_user_voxelspacing_multilabel combinations:")
         sorted_combos = sorted(
             stats_data["session_user_voxelspacing_multilabel_combinations"].items(),
             key=lambda x: x[1],
-            reverse=True
+            reverse=True,
         )
         for combo, count in sorted_combos[:10]:  # Top 10
             click.echo(f"  {combo}: {count}")

--- a/src/copick/ops/stats.py
+++ b/src/copick/ops/stats.py
@@ -1,0 +1,228 @@
+from collections import defaultdict
+from typing import Dict, Iterable, Optional, Union
+
+from copick.models import CopickRoot, CopickRun
+from copick.ops.get import get_meshes, get_picks, get_segmentations
+
+
+def picks_stats(
+    root: Union[str, CopickRoot],
+    runs: Union[str, CopickRun, Iterable[str], Iterable[CopickRun], None] = None,
+    user_id: Union[str, Iterable[str], None] = None,
+    session_id: Union[str, Iterable[str], None] = None,
+    object_name: Union[str, Iterable[str], None] = None,
+    parallel: bool = False,
+    workers: Optional[int] = 8,
+    show_progress: bool = True,
+) -> Dict[str, Union[int, Dict[str, int]]]:
+    """Generate statistics for picks in a Copick project.
+
+    Args:
+        root: The Copick project root.
+        runs: The runs to query picks from. If `None`, query all runs.
+        user_id: The user ID of the picks. If `None`, query all users.
+        session_id: The session ID of the picks. If `None`, query all sessions.
+        object_name: The pickable object of the picks. If `None`, query all picks.
+        parallel: Whether to query picks in parallel. Default is `False`.
+        workers: The number of workers to use. Default is `8`.
+        show_progress: Whether to show progress. Default is `True`.
+
+    Returns:
+        A dictionary containing total pick count and distribution statistics.
+    """
+    picks_list = get_picks(
+        root=root,
+        runs=runs,
+        user_id=user_id,
+        session_id=session_id,
+        object_name=object_name,
+        parallel=parallel,
+        workers=workers,
+        show_progress=show_progress,
+    )
+
+    if not picks_list:
+        return {
+            "total_picks": 0,
+            "total_pick_files": 0,
+            "distribution_by_run": {},
+            "distribution_by_user": {},
+            "distribution_by_session": {},
+            "distribution_by_object": {},
+        }
+
+    # Count individual picks
+    total_individual_picks = 0
+    distribution_by_run = defaultdict(int)
+    distribution_by_user = defaultdict(int)
+    distribution_by_session = defaultdict(int)
+    distribution_by_object = defaultdict(int)
+
+    for picks_file in picks_list:
+        pick_count = len(picks_file.points) if picks_file.points else 0
+        total_individual_picks += pick_count
+        
+        run_name = picks_file.run.name
+        distribution_by_run[run_name] += pick_count
+        distribution_by_user[picks_file.user_id] += pick_count
+        distribution_by_session[picks_file.session_id] += pick_count
+        distribution_by_object[picks_file.pickable_object_name] += pick_count
+
+    return {
+        "total_picks": total_individual_picks,
+        "total_pick_files": len(picks_list),
+        "distribution_by_run": dict(distribution_by_run),
+        "distribution_by_user": dict(distribution_by_user),
+        "distribution_by_session": dict(distribution_by_session),
+        "distribution_by_object": dict(distribution_by_object),
+    }
+
+
+def meshes_stats(
+    root: Union[str, CopickRoot],
+    runs: Union[str, CopickRun, Iterable[str], Iterable[CopickRun], None] = None,
+    user_id: Union[str, Iterable[str], None] = None,
+    session_id: Union[str, Iterable[str], None] = None,
+    object_name: Union[str, Iterable[str], None] = None,
+    parallel: bool = False,
+    workers: Optional[int] = 8,
+    show_progress: bool = True,
+) -> Dict[str, Union[int, Dict[str, int]]]:
+    """Generate statistics for meshes in a Copick project.
+
+    Args:
+        root: The Copick project root.
+        runs: The runs to query meshes from. If `None`, query all runs.
+        user_id: The user ID of the meshes. If `None`, query all users.
+        session_id: The session ID of the meshes. If `None`, query all sessions.
+        object_name: The pickable object of the meshes. If `None`, query all meshes.
+        parallel: Whether to query meshes in parallel. Default is `False`.
+        workers: The number of workers to use. Default is `8`.
+        show_progress: Whether to show progress. Default is `True`.
+
+    Returns:
+        A dictionary containing mesh count and frequency statistics.
+    """
+    meshes_list = get_meshes(
+        root=root,
+        runs=runs,
+        user_id=user_id,
+        session_id=session_id,
+        object_name=object_name,
+        parallel=parallel,
+        workers=workers,
+        show_progress=show_progress,
+    )
+
+    if not meshes_list:
+        return {
+            "total_meshes": 0,
+            "distribution_by_user": {},
+            "distribution_by_session": {},
+            "distribution_by_object": {},
+            "session_user_object_combinations": {},
+        }
+
+    # Track distributions and combinations
+    distribution_by_user = defaultdict(int)
+    distribution_by_session = defaultdict(int)
+    distribution_by_object = defaultdict(int)
+    session_user_object_freq = defaultdict(int)
+
+    for mesh in meshes_list:
+        distribution_by_user[mesh.user_id] += 1
+        distribution_by_session[mesh.session_id] += 1
+        distribution_by_object[mesh.pickable_object_name] += 1
+        
+        combo_key = f"{mesh.session_id}_{mesh.user_id}_{mesh.pickable_object_name}"
+        session_user_object_freq[combo_key] += 1
+
+    return {
+        "total_meshes": len(meshes_list),
+        "distribution_by_user": dict(distribution_by_user),
+        "distribution_by_session": dict(distribution_by_session),
+        "distribution_by_object": dict(distribution_by_object),
+        "session_user_object_combinations": dict(session_user_object_freq),
+    }
+
+
+def segmentations_stats(
+    root: Union[str, CopickRoot],
+    runs: Union[str, CopickRun, Iterable[str], Iterable[CopickRun], None] = None,
+    user_id: Union[str, Iterable[str], None] = None,
+    session_id: Union[str, Iterable[str], None] = None,
+    is_multilabel: bool = None,
+    name: Union[str, Iterable[str], None] = None,
+    voxel_size: Union[float, Iterable[float], None] = None,
+    parallel: bool = False,
+    workers: Optional[int] = 8,
+    show_progress: bool = False,
+) -> Dict[str, Union[int, Dict[str, int]]]:
+    """Generate statistics for segmentations in a Copick project.
+
+    Args:
+        root: The Copick project root.
+        runs: The runs to query segmentations from. If `None`, query all runs.
+        user_id: The user ID of the segmentations. If `None`, query all users.
+        session_id: The session ID of the segmentations. If `None`, query all sessions.
+        is_multilabel: Whether the segmentations are multilabel. If `None`, query all segmentations.
+        name: The name of the segmentation. If `None`, query all segmentations.
+        voxel_size: The voxel size of the segmentation. If `None`, query all segmentations.
+        parallel: Whether to query segmentations in parallel. Default is `False`.
+        workers: The number of workers to use. Default is `8`.
+        show_progress: Whether to show progress. Default is `True`.
+
+    Returns:
+        A dictionary containing segmentation count and frequency statistics.
+    """
+    segmentations_list = get_segmentations(
+        root=root,
+        runs=runs,
+        user_id=user_id,
+        session_id=session_id,
+        is_multilabel=is_multilabel,
+        name=name,
+        voxel_size=voxel_size,
+        parallel=parallel,
+        workers=workers,
+        show_progress=show_progress,
+    )
+
+    if not segmentations_list:
+        return {
+            "total_segmentations": 0,
+            "distribution_by_user": {},
+            "distribution_by_session": {},
+            "distribution_by_name": {},
+            "distribution_by_voxel_size": {},
+            "distribution_by_multilabel": {},
+            "session_user_voxelspacing_multilabel_combinations": {},
+        }
+
+    # Track distributions and combinations
+    distribution_by_user = defaultdict(int)
+    distribution_by_session = defaultdict(int)
+    distribution_by_name = defaultdict(int)
+    distribution_by_voxel_size = defaultdict(int)
+    distribution_by_multilabel = defaultdict(int)
+    combo_freq = defaultdict(int)
+
+    for seg in segmentations_list:
+        distribution_by_user[seg.user_id] += 1
+        distribution_by_session[seg.session_id] += 1
+        distribution_by_name[seg.name] += 1
+        distribution_by_voxel_size[seg.voxel_size] += 1
+        distribution_by_multilabel[str(seg.is_multilabel)] += 1
+        
+        combo_key = f"{seg.session_id}_{seg.user_id}_{seg.name}_{seg.voxel_size}_{seg.is_multilabel}"
+        combo_freq[combo_key] += 1
+
+    return {
+        "total_segmentations": len(segmentations_list),
+        "distribution_by_user": dict(distribution_by_user),
+        "distribution_by_session": dict(distribution_by_session),
+        "distribution_by_name": dict(distribution_by_name),
+        "distribution_by_voxel_size": dict(distribution_by_voxel_size),
+        "distribution_by_multilabel": dict(distribution_by_multilabel),
+        "session_user_voxelspacing_multilabel_combinations": dict(combo_freq),
+    }

--- a/src/copick/ops/stats.py
+++ b/src/copick/ops/stats.py
@@ -61,7 +61,7 @@ def picks_stats(
     for picks_file in picks_list:
         pick_count = len(picks_file.points) if picks_file.points else 0
         total_individual_picks += pick_count
-        
+
         run_name = picks_file.run.name
         distribution_by_run[run_name] += pick_count
         distribution_by_user[picks_file.user_id] += pick_count
@@ -133,7 +133,7 @@ def meshes_stats(
         distribution_by_user[mesh.user_id] += 1
         distribution_by_session[mesh.session_id] += 1
         distribution_by_object[mesh.pickable_object_name] += 1
-        
+
         combo_key = f"{mesh.session_id}_{mesh.user_id}_{mesh.pickable_object_name}"
         session_user_object_freq[combo_key] += 1
 
@@ -156,7 +156,7 @@ def segmentations_stats(
     voxel_size: Union[float, Iterable[float], None] = None,
     parallel: bool = False,
     workers: Optional[int] = 8,
-    show_progress: bool = False,
+    show_progress: bool = True,
 ) -> Dict[str, Union[int, Dict[str, int]]]:
     """Generate statistics for segmentations in a Copick project.
 
@@ -213,7 +213,7 @@ def segmentations_stats(
         distribution_by_name[seg.name] += 1
         distribution_by_voxel_size[seg.voxel_size] += 1
         distribution_by_multilabel[str(seg.is_multilabel)] += 1
-        
+
         combo_key = f"{seg.session_id}_{seg.user_id}_{seg.name}_{seg.voxel_size}_{seg.is_multilabel}"
         combo_freq[combo_key] += 1
 


### PR DESCRIPTION
Adds `cli/stats.py` and `ops/stats.py` to compute basic statistics across annotation types . 

  Functional API (src/copick/ops/stats.py)

  - picks_stats(): Analyzes pick distributions across runs, users, sessions, and objects with individual pick counting
  - meshes_stats(): Generates mesh statistics with individual property distributions and combination frequency analysis
  - segmentations_stats(): Comprehensive segmentation analysis including voxel size, multilabel status, and combinations
  - All functions support parallel processing and leverage existing get_* functions from copick.ops.get

  CLI Interface (src/copick/cli/stats.py)

  - New top-level copick stats command group with three subcommands:
    - copick stats picks: Pick statistics with filtering by runs, users, sessions, objects
    - copick stats meshes: Mesh statistics with user/session/object filtering
    - copick stats segmentations: Segmentation statistics with name, voxel size, multilabel filtering
