### PR TITLE
feat: More output for copick info, include versioned plugins in copick CLI logs. 

### DIFF
--- a/src/copick/cli/cli.py
+++ b/src/copick/cli/cli.py
@@ -30,6 +30,7 @@ def _cli(ctx):
     logger.info(text)
     logger.info(f"{'-'*len(text)}")
 
+
 @click.group(
     short_help="Run inference on copick tomograms.",
     no_args_is_help=True,

--- a/src/copick/cli/info.py
+++ b/src/copick/cli/info.py
@@ -1,6 +1,7 @@
-import click
 from importlib import metadata
 from typing import Set
+
+import click
 
 from copick.cli.ext import load_plugin_commands
 from copick.util.log import get_logger
@@ -8,22 +9,22 @@ from copick.util.log import get_logger
 
 def get_installed_plugin_packages() -> Set[str]:
     """Get a set of installed plugin packages with their versions.
-    
+
     Returns:
         Set of strings in format "package-name version"
     """
     command_groups = ["main", "inference", "training", "evaluation", "process", "convert", "logical"]
     plugin_packages = set()
-    
+
     for group in command_groups:
         commands = load_plugin_commands(group)
-        for command, package_name in commands:
+        for _command, package_name in commands:
             try:
                 version = metadata.version(package_name)
                 plugin_packages.add(f"{package_name} {version}")
             except metadata.PackageNotFoundError:
                 plugin_packages.add(f"{package_name} (version unknown)")
-    
+
     return plugin_packages
 
 


### PR DESCRIPTION
Add a section for the logical subcommand to `copick info`. 

Also adds plugins and plugin versions to the default copick CLI logs. 