### PR TITLE
fix: Consistently show help when no args provided.

### DIFF
--- a/src/copick/cli/add.py
+++ b/src/copick/cli/add.py
@@ -16,7 +16,10 @@ def add(ctx):
     pass
 
 
-@add.command(short_help="Add a tomogram to the project.")
+@add.command(
+    short_help="Add a tomogram to the project.",
+    no_args_is_help=True,
+)
 @add_config_option
 @click.option(
     "--run",
@@ -232,7 +235,10 @@ def tomogram(
     report_results(results, len(paths), logger)
 
 
-@add.command(short_help="Add a segmentation to the project.")
+@add.command(
+    short_help="Add a segmentation to the project.",
+    no_args_is_help=True,
+)
 @add_config_option
 @click.option(
     "--run",
@@ -396,7 +402,10 @@ def segmentation(
     report_results(results, len(paths), logger)
 
 
-@add.command(short_help="Add a pickable object to the project configuration.")
+@add.command(
+    short_help="Add a pickable object to the project configuration.",
+    no_args_is_help=True,
+)
 @add_config_option
 @click.option(
     "--name",
@@ -595,7 +604,10 @@ def object(
         ctx.fail(f"Error adding object: {e}")
 
 
-@add.command(short_help="Add volume data to an existing pickable object.")
+@add.command(
+    short_help="Add volume data to an existing pickable object.",
+    no_args_is_help=True,
+)
 @add_config_option
 @click.option(
     "--object-name",

--- a/src/copick/cli/browse.py
+++ b/src/copick/cli/browse.py
@@ -4,7 +4,10 @@ from copick.cli.util import add_config_option, add_debug_option
 from copick.util.log import get_logger
 
 
-@click.command(context_settings={"show_default": True}, short_help="Browse Copick projects.")
+@click.command(
+    context_settings={"show_default": True},
+    short_help="Browse Copick projects.",
+)
 @add_config_option
 @click.option(
     "-ds",

--- a/src/copick/cli/config.py
+++ b/src/copick/cli/config.py
@@ -43,6 +43,7 @@ def parse_object(ctx, param, value):
 @config.command(
     context_settings={"show_default": True},
     short_help="Set up a configuration file from CZDP dataset IDs.",
+    no_args_is_help=True,
 )
 @click.option(
     "-ds",
@@ -99,7 +100,11 @@ def dataportal(
     logger.info(f"Generated configuration file at {output}.")
 
 
-@config.command(context_settings={"show_default": True}, short_help="Set up a configuration file for a local project.")
+@config.command(
+    context_settings={"show_default": True},
+    short_help="Set up a configuration file for a local project.",
+    no_args_is_help=True,
+)
 @click.pass_context
 @click.option("--overlay-root", type=str, required=True, help="Overlay root path.")
 @click.option(

--- a/src/copick/cli/new.py
+++ b/src/copick/cli/new.py
@@ -14,7 +14,11 @@ def new(ctx):
     pass
 
 
-@new.command(context_settings={"show_default": True}, short_help="Create empty picks for a given particle name.")
+@new.command(
+    context_settings={"show_default": True},
+    short_help="Create empty picks for a given particle name.",
+    no_args_is_help=True,
+)
 @add_config_option
 @click.option("--particle-name", type=str, required=True, help="Name of the particle to create picks for")
 @click.option("--out-user", type=str, required=False, default="copick", help="User ID to write picks to")
@@ -74,7 +78,11 @@ def picks(
         picks.store()
 
 
-@new.command(short_help="Create an empty run with the given name.", context_settings={"show_default": True})
+@new.command(
+    short_help="Create an empty run with the given name.",
+    context_settings={"show_default": True},
+    no_args_is_help=True,
+)
 @add_config_option
 @add_create_overwrite_options
 @add_debug_option
@@ -105,7 +113,11 @@ def run(
     return 0
 
 
-@new.command(short_help="Create an empty voxelspacing with the given name.", context_settings={"show_default": True})
+@new.command(
+    short_help="Create an empty voxelspacing with the given name.",
+    context_settings={"show_default": True},
+    no_args_is_help=True,
+)
 @add_config_option
 @click.option("--run", required=True, type=str, help="Name of the run to add voxel spacing to.", metavar="RUN")
 @add_create_overwrite_options

--- a/src/copick/cli/stats.py
+++ b/src/copick/cli/stats.py
@@ -19,7 +19,11 @@ def stats(ctx):
     pass
 
 
-@stats.command()
+@stats.command(
+    short_help="Display statistics about picks.",
+    context_settings={"show_default": True},
+    no_args_is_help=True,
+)
 @add_config_option
 @click.option(
     "--runs",
@@ -107,7 +111,11 @@ def picks(
         _print_picks_table(stats_data)
 
 
-@stats.command()
+@stats.command(
+    short_help="Display statistics about meshes.",
+    context_settings={"show_default": True},
+    no_args_is_help=True,
+)
 @add_config_option
 @click.option(
     "--runs",
@@ -195,7 +203,11 @@ def meshes(
         _print_meshes_table(stats_data)
 
 
-@stats.command()
+@stats.command(
+    short_help="Display statistics about segmentations.",
+    context_settings={"show_default": True},
+    no_args_is_help=True,
+)
 @add_config_option
 @click.option(
     "--runs",

--- a/src/copick/cli/sync.py
+++ b/src/copick/cli/sync.py
@@ -21,7 +21,11 @@ def sync(ctx):
     pass
 
 
-@sync.command(short_help="Synchronize picks between two Copick projects.")
+@sync.command(
+    short_help="Synchronize picks between two Copick projects.",
+    context_settings={"show_default": True},
+    no_args_is_help=True,
+)
 @add_config_option
 @click.option(
     "--source-dataset-ids",


### PR DESCRIPTION
This PR updates the main CLI to show the help message when no arguments are provided, consistent with the copick-utils commands. 