### PR TITLE
feat: Define a URI scheme for identifying copick entities. 

### DIFF
--- a/src/copick/util/uri.py
+++ b/src/copick/util/uri.py
@@ -1,0 +1,694 @@
+import fnmatch
+import re
+from typing import Any, Dict, List, Optional, Union
+from urllib.parse import parse_qs
+
+from copick.models import (
+    CopickFeatures,
+    CopickMesh,
+    CopickPicks,
+    CopickRoot,
+    CopickRun,
+    CopickSegmentation,
+    CopickTomogram,
+)
+
+# ============================================================================
+# URI Parsing
+# ============================================================================
+
+
+def parse_copick_uri(uri: str, object_type: str) -> Dict[str, Any]:
+    """Parse a copick object URI according to the copick URI schemes.
+
+    URI Schemes:
+    - Picks: object_name:user_id/session_id
+    - Meshes: object_name:user_id/session_id
+    - Segmentations: name:user_id/session_id@voxel_spacing?multilabel=true
+    - Tomogram: tomo_type@voxel_spacing
+    - Feature: tomo_type@voxel_spacing:feature_type
+
+    Pattern Support:
+    - Glob patterns by default (e.g., 'mt*:user*/session*')
+    - Use 're:' prefix for regex patterns (e.g., 're:mt.*:user_\\d+/session_\\d+')
+    - Incomplete patterns match everything (e.g., 'mt:user' → 'mt:user/*')
+    - Missing components become wildcards (e.g., 'mt' for picks → 'mt:*/*')
+
+    Args:
+        uri (str): The copick URI to parse.
+        object_type (str): Type of object ('pick', 'mesh', 'segmentation', 'tomogram', 'feature').
+
+    Returns:
+        Dict[str, Any]: A dictionary containing the parsed components.
+                       Includes 'pattern_type' field ('glob' or 'regex').
+
+    Raises:
+        ValueError: If the URI format is invalid or object_type is unknown.
+    """
+    # Remove any leading/trailing whitespace
+    uri = uri.strip()
+
+    # Check for regex prefix
+    pattern_type = "glob"
+    if uri.startswith("re:"):
+        pattern_type = "regex"
+        uri = uri[3:]  # Remove 're:' prefix
+
+    # Handle query parameters (for segmentations)
+    query_params = {}
+    if "?" in uri:
+        uri, query_string = uri.split("?", 1)
+        query_params = parse_qs(query_string)
+        # Flatten single-value lists
+        query_params = {k: v[0] if len(v) == 1 else v for k, v in query_params.items()}
+
+    if object_type in ("pick", "mesh"):
+        # Pattern: object_name:user_id/session_id
+        # Support incomplete patterns: 'obj' → 'obj:*/*', 'obj:user' → 'obj:user/*'
+        parts = uri.split(":")
+        if len(parts) == 1:
+            # Just object_name
+            object_name = parts[0]
+            user_id = "*"
+            session_id = "*"
+        elif len(parts) == 2:
+            object_name = parts[0]
+            session_part = parts[1]
+            if "/" in session_part:
+                user_id, session_id = session_part.split("/", 1)
+            else:
+                user_id = session_part
+                session_id = "*"
+        else:
+            raise ValueError(f"Invalid {object_type} URI format: '{uri}'")
+
+        return {
+            "object_type": object_type,
+            "pattern_type": pattern_type,
+            "object_name": object_name,
+            "user_id": user_id,
+            "session_id": session_id,
+        }
+
+    elif object_type == "segmentation":
+        # Pattern: name:user_id/session_id@voxel_spacing
+        # Support incomplete: 'name' → 'name:*/*@*', 'name:user' → 'name:user/*@*', etc.
+
+        # Split by @ first to get voxel_spacing
+        if "@" in uri:
+            main_part, voxel_spacing = uri.split("@", 1)
+        else:
+            main_part = uri
+            voxel_spacing = "*"
+
+        # Now parse the main part
+        parts = main_part.split(":")
+        if len(parts) == 1:
+            name = parts[0]
+            user_id = "*"
+            session_id = "*"
+        elif len(parts) == 2:
+            name = parts[0]
+            session_part = parts[1]
+            if "/" in session_part:
+                user_id, session_id = session_part.split("/", 1)
+            else:
+                user_id = session_part
+                session_id = "*"
+        else:
+            raise ValueError(f"Invalid segmentation URI format: '{uri}'")
+
+        result = {
+            "object_type": "segmentation",
+            "pattern_type": pattern_type,
+            "name": name,
+            "user_id": user_id,
+            "session_id": session_id,
+            "voxel_spacing": voxel_spacing,
+            "multilabel": None,  # Default value (matches both multilabel and non-multilabel)
+        }
+
+        # Check for multilabel parameter
+        if "multilabel" in query_params:
+            multilabel_val = query_params["multilabel"].lower()
+            result["multilabel"] = multilabel_val in ("true", "1", "yes")
+
+        return result
+
+    elif object_type == "tomogram":
+        # Pattern: tomo_type@voxel_spacing
+        # Support incomplete: 'tomo' → 'tomo@*'
+        if "@" in uri:
+            tomo_type, voxel_spacing = uri.split("@", 1)
+        else:
+            tomo_type = uri
+            voxel_spacing = "*"
+
+        return {
+            "object_type": "tomogram",
+            "pattern_type": pattern_type,
+            "tomo_type": tomo_type,
+            "voxel_spacing": voxel_spacing,
+        }
+
+    elif object_type == "feature":
+        # Pattern: tomo_type@voxel_spacing:feature_type
+        # Support incomplete: 'tomo' → 'tomo@*:*', 'tomo@10' → 'tomo@10:*'
+
+        # Split by @ first
+        if "@" in uri:
+            tomo_type, rest = uri.split("@", 1)
+            # Now check if we have feature_type
+            if ":" in rest:
+                voxel_spacing, feature_type = rest.split(":", 1)
+            else:
+                voxel_spacing = rest
+                feature_type = "*"
+        else:
+            tomo_type = uri
+            voxel_spacing = "*"
+            feature_type = "*"
+
+        return {
+            "object_type": "feature",
+            "pattern_type": pattern_type,
+            "tomo_type": tomo_type,
+            "voxel_spacing": voxel_spacing,
+            "feature_type": feature_type,
+        }
+
+    else:
+        raise ValueError(
+            f"Unknown object type: {object_type}. Must be one of: pick, mesh, segmentation, tomogram, feature",
+        )
+
+
+# ============================================================================
+# URI Serialization
+# ============================================================================
+
+
+def serialize_copick_uri(
+    obj: Union[CopickPicks, CopickMesh, CopickSegmentation, CopickTomogram, CopickFeatures],
+) -> str:
+    """Serialize a copick object to its URI representation.
+
+    Args:
+        obj: A copick object (CopickPicks, CopickMesh, CopickSegmentation, CopickTomogram, or CopickFeatures).
+
+    Returns:
+        str: The URI representation of the object.
+
+    Raises:
+        ValueError: If the object type is not recognized.
+    """
+    if isinstance(obj, (CopickPicks, CopickMesh)):
+        return f"{obj.pickable_object_name}:{obj.user_id}/{obj.session_id}"
+
+    elif isinstance(obj, CopickSegmentation):
+        uri = f"{obj.name}:{obj.user_id}/{obj.session_id}@{obj.voxel_size}"
+        if obj.is_multilabel:
+            uri += "?multilabel=true"
+        return uri
+
+    elif isinstance(obj, CopickTomogram):
+        return f"{obj.tomo_type}@{obj.voxel_spacing.voxel_size}"
+
+    elif isinstance(obj, CopickFeatures):
+        return f"{obj.tomo_type}@{obj.tomogram.voxel_spacing.voxel_size}:{obj.feature_type}"
+
+    else:
+        raise ValueError(f"Unknown copick object type: {type(obj).__name__}")
+
+
+def serialize_copick_uri_from_dict(
+    object_type: str,
+    object_name: Optional[str] = None,
+    name: Optional[str] = None,
+    user_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    tomo_type: Optional[str] = None,
+    voxel_spacing: Optional[float] = None,
+    feature_type: Optional[str] = None,
+    multilabel: Optional[bool] = None,
+) -> str:
+    """Serialize copick object parameters into a URI according to copick URI schemes.
+
+    Args:
+        object_type (str): Type of copick object ('pick', 'mesh', 'segmentation', 'tomogram', 'feature')
+        object_name (str, optional): Object name for picks/meshes
+        name (str, optional): Name for segmentations
+        user_id (str, optional): User ID for picks/meshes/segmentations
+        session_id (str, optional): Session ID for picks/meshes/segmentations
+        tomo_type (str, optional): Tomogram type for tomograms/features
+        voxel_spacing (float, optional): Voxel spacing for segmentations/tomograms/features
+        feature_type (str, optional): Feature type for features
+        multilabel (bool, optional): Whether segmentation is multilabel
+
+    Returns:
+        str: The serialized copick URI
+
+    Raises:
+        ValueError: If required parameters are missing for the given object type
+    """
+    if object_type == "pick":
+        if not all([object_name, user_id, session_id]):
+            raise ValueError("Picks require object_name, user_id, and session_id")
+        return f"{object_name}:{user_id}/{session_id}"
+
+    elif object_type == "mesh":
+        if not all([object_name, user_id, session_id]):
+            raise ValueError("Meshes require object_name, user_id, and session_id")
+        return f"{object_name}:{user_id}/{session_id}"
+
+    elif object_type == "segmentation":
+        if not all([name, user_id, session_id, voxel_spacing is not None]):
+            raise ValueError("Segmentations require name, user_id, session_id, and voxel_spacing")
+        uri = f"{name}:{user_id}/{session_id}@{voxel_spacing}"
+        if multilabel is True:
+            uri += "?multilabel=true"
+        return uri
+
+    elif object_type == "tomogram":
+        if not all([tomo_type, voxel_spacing is not None]):
+            raise ValueError("Tomograms require tomo_type and voxel_spacing")
+        return f"{tomo_type}@{voxel_spacing}"
+
+    elif object_type == "feature":
+        if not all([tomo_type, voxel_spacing is not None, feature_type]):
+            raise ValueError("Features require tomo_type, voxel_spacing, and feature_type")
+        return f"{tomo_type}@{voxel_spacing}:{feature_type}"
+
+    else:
+        raise ValueError(f"Unknown object type: {object_type}")
+
+
+# ============================================================================
+# Object Resolution (Public API)
+# ============================================================================
+
+
+def resolve_copick_objects(
+    uri: str,
+    root: "CopickRoot",
+    object_type: str,
+    run_name: Optional[str] = None,
+) -> List[Union["CopickPicks", "CopickMesh", "CopickSegmentation", "CopickTomogram", "CopickFeatures"]]:
+    """Resolve a copick URI to actual copick objects.
+
+    This function parses a URI string and delegates to get_copick_objects_by_type()
+    for the actual filtering logic.
+
+    Args:
+        uri (str): The copick URI to resolve.
+        root (CopickRoot): The copick root to search in.
+        object_type (str): Type of object ('pick', 'mesh', 'segmentation', 'tomogram', 'feature').
+        run_name (str, optional): Specific run name to search in. If None, searches all runs.
+
+    Returns:
+        List: List of matching copick objects.
+
+    Raises:
+        ValueError: If the URI is invalid or object_type is invalid.
+    """
+    # Parse the URI to extract filter parameters
+    parsed = parse_copick_uri(uri, object_type)
+
+    # Remove object_type and pattern_type from parsed dict as they're not needed by get_copick_objects_by_type
+    parsed.pop("object_type", None)
+
+    # Delegate to get_copick_objects_by_type with the parsed filters
+    return get_copick_objects_by_type(root, object_type, run_name, **parsed)
+
+
+def get_copick_objects_by_type(
+    root: "CopickRoot",
+    object_type: str,
+    run_name: Optional[str] = None,
+    **filters,
+) -> List[Union["CopickPicks", "CopickMesh", "CopickSegmentation", "CopickTomogram", "CopickFeatures"]]:
+    """Get copick objects by type with optional filters.
+
+    This is a convenience function that provides a more direct way to query objects
+    without needing to construct URIs. Uses CopickRun's built-in get_* methods when
+    possible for exact matches, falls back to pattern matching only when needed.
+
+    Args:
+        root (CopickRoot): The copick root to search in.
+        object_type (str): The type of objects to retrieve ('pick', 'mesh', 'segmentation', 'tomogram', 'feature').
+        run_name (str, optional): Specific run name to search in.
+        **filters: Additional filters based on object type.
+                  For picks/meshes: object_name, user_id, session_id
+                  For segmentations: name, user_id, session_id, voxel_spacing, multilabel
+                  For tomograms: tomo_type, voxel_spacing
+                  For features: tomo_type, voxel_spacing, feature_type
+
+    Returns:
+        List: List of matching copick objects.
+
+    Raises:
+        ValueError: If the object_type is invalid or required filters are missing.
+    """
+    # Get runs to search
+    runs_to_search = []
+    if run_name:
+        run = root.get_run(run_name)
+        if run is None:
+            raise ValueError(f"Run '{run_name}' not found")
+        runs_to_search = [run]
+    else:
+        runs_to_search = root.runs
+
+    # Dispatch to type-specific handler
+    handlers = {
+        "pick": _get_picks_from_runs,
+        "mesh": _get_meshes_from_runs,
+        "segmentation": _get_segmentations_from_runs,
+        "tomogram": _get_tomograms_from_runs,
+        "feature": _get_features_from_runs,
+    }
+
+    if object_type not in handlers:
+        raise ValueError(
+            f"Unknown object type: {object_type}. Must be one of: pick, mesh, segmentation, tomogram, feature",
+        )
+
+    return handlers[object_type](runs_to_search, filters)
+
+
+# ============================================================================
+# Pattern Matching Helpers (Private)
+# ============================================================================
+
+
+def _is_pattern(value: str, pattern_type: str) -> bool:
+    """Check if a value is actually a pattern (not just a literal string).
+
+    Args:
+        value: The value to check.
+        pattern_type: Either "glob" or "regex".
+
+    Returns:
+        bool: True if the value is a pattern that requires matching.
+    """
+    if value == "*":
+        return True
+    if pattern_type == "regex":
+        return True  # Regex is always treated as a pattern
+    # Check for glob wildcards
+    return "*" in value or "?" in value or "[" in value
+
+
+def _matches_pattern(value: str, pattern: str, pattern_type: str) -> bool:
+    """Check if a value matches a pattern based on pattern type."""
+    # Wildcard matches everything
+    if pattern == "*":
+        return True
+
+    if pattern_type == "glob":
+        return fnmatch.fnmatch(value, pattern)
+    elif pattern_type == "regex":
+        try:
+            return re.match(pattern, value) is not None
+        except re.error as e:
+            raise ValueError(f"Invalid regex pattern '{pattern}': {e}") from e
+    else:
+        raise ValueError(f"Unknown pattern type: {pattern_type}")
+
+
+def _matches_numeric_pattern(value: Union[str, float], pattern: str, pattern_type: str) -> bool:
+    """Check if a numeric value matches a pattern."""
+    # Wildcard matches everything
+    if pattern == "*":
+        return True
+
+    if pattern_type == "glob":
+        # For exact numeric comparison, try to match as numbers
+        try:
+            return float(value) == float(pattern)
+        except (ValueError, TypeError):
+            # Fall back to string matching for non-numeric patterns
+            return _matches_pattern(str(value), pattern, pattern_type)
+    else:
+        # For regex, convert value to string for matching
+        return _matches_pattern(str(value), pattern, pattern_type)
+
+
+# ============================================================================
+# Type-Specific Object Handlers (Private)
+# ============================================================================
+
+
+def _get_picks_from_runs(
+    runs: List["CopickRun"],
+    filters: Dict[str, Any],
+) -> List["CopickPicks"]:
+    """Get picks using CopickRun.get_picks when possible for exact matches.
+
+    Args:
+        runs: List of runs to search.
+        filters: Filter dictionary with optional keys: object_name, user_id, session_id, pattern_type.
+
+    Returns:
+        List of matching picks.
+    """
+    results = []
+    pattern_type = filters.get("pattern_type", "glob")
+    object_name = filters.get("object_name")
+    user_id = filters.get("user_id")
+    session_id = filters.get("session_id")
+
+    # Check if we can use the built-in get_picks method (no patterns)
+    use_builtin = (
+        not (object_name and _is_pattern(object_name, pattern_type))
+        and not (user_id and _is_pattern(user_id, pattern_type))
+        and not (session_id and _is_pattern(session_id, pattern_type))
+    )
+
+    if use_builtin:
+        # Use the built-in filtering - much cleaner!
+        for run in runs:
+            picks = run.get_picks(
+                object_name=None if object_name == "*" else object_name,
+                user_id=None if user_id == "*" else user_id,
+                session_id=None if session_id == "*" else session_id,
+            )
+            results.extend(picks)
+    else:
+        # Need pattern matching
+        for run in runs:
+            for pick in run.picks:
+                if (
+                    (not object_name or _matches_pattern(pick.pickable_object_name, object_name, pattern_type))
+                    and (not user_id or _matches_pattern(pick.user_id, user_id, pattern_type))
+                    and (not session_id or _matches_pattern(pick.session_id, session_id, pattern_type))
+                ):
+                    results.append(pick)
+
+    return results
+
+
+def _get_meshes_from_runs(
+    runs: List["CopickRun"],
+    filters: Dict[str, Any],
+) -> List["CopickMesh"]:
+    """Get meshes using CopickRun.get_meshes when possible for exact matches.
+
+    Args:
+        runs: List of runs to search.
+        filters: Filter dictionary with optional keys: object_name, user_id, session_id, pattern_type.
+
+    Returns:
+        List of matching meshes.
+    """
+    results = []
+    pattern_type = filters.get("pattern_type", "glob")
+    object_name = filters.get("object_name")
+    user_id = filters.get("user_id")
+    session_id = filters.get("session_id")
+
+    # Check if we can use the built-in get_meshes method (no patterns)
+    use_builtin = (
+        not (object_name and _is_pattern(object_name, pattern_type))
+        and not (user_id and _is_pattern(user_id, pattern_type))
+        and not (session_id and _is_pattern(session_id, pattern_type))
+    )
+
+    if use_builtin:
+        # Use the built-in filtering
+        for run in runs:
+            meshes = run.get_meshes(
+                object_name=None if object_name == "*" else object_name,
+                user_id=None if user_id == "*" else user_id,
+                session_id=None if session_id == "*" else session_id,
+            )
+            results.extend(meshes)
+    else:
+        # Need pattern matching
+        for run in runs:
+            for mesh in run.meshes:
+                if (
+                    (not object_name or _matches_pattern(mesh.pickable_object_name, object_name, pattern_type))
+                    and (not user_id or _matches_pattern(mesh.user_id, user_id, pattern_type))
+                    and (not session_id or _matches_pattern(mesh.session_id, session_id, pattern_type))
+                ):
+                    results.append(mesh)
+
+    return results
+
+
+def _get_segmentations_from_runs(
+    runs: List["CopickRun"],
+    filters: Dict[str, Any],
+) -> List["CopickSegmentation"]:
+    """Get segmentations using CopickRun.get_segmentations when possible for exact matches.
+
+    Args:
+        runs: List of runs to search.
+        filters: Filter dictionary with optional keys: name, user_id, session_id, voxel_spacing, multilabel, pattern_type.
+
+    Returns:
+        List of matching segmentations.
+    """
+    results = []
+    pattern_type = filters.get("pattern_type", "glob")
+    name = filters.get("name")
+    user_id = filters.get("user_id")
+    session_id = filters.get("session_id")
+    voxel_spacing = filters.get("voxel_spacing")
+    multilabel = filters.get("multilabel")
+
+    # Check if we need pattern matching
+    use_builtin = (
+        not (name and _is_pattern(name, pattern_type))
+        and not (user_id and _is_pattern(user_id, pattern_type))
+        and not (session_id and _is_pattern(session_id, pattern_type))
+        and not (voxel_spacing and isinstance(voxel_spacing, str) and _is_pattern(voxel_spacing, pattern_type))
+    )
+
+    if use_builtin:
+        # Use built-in filtering
+        for run in runs:
+            # Convert voxel_spacing to float if it's not a wildcard
+            vs_value = None
+            if voxel_spacing and voxel_spacing != "*":
+                try:
+                    vs_value = float(voxel_spacing)
+                except (ValueError, TypeError):
+                    vs_value = None
+
+            segs = run.get_segmentations(
+                name=None if name == "*" else name,
+                user_id=None if user_id == "*" else user_id,
+                session_id=None if session_id == "*" else session_id,
+                is_multilabel=multilabel,
+                voxel_size=vs_value,
+            )
+            results.extend(segs)
+    else:
+        # Pattern matching needed
+        for run in runs:
+            for seg in run.segmentations:
+                if (
+                    (not name or _matches_pattern(seg.name, name, pattern_type))
+                    and (not user_id or _matches_pattern(seg.user_id, user_id, pattern_type))
+                    and (not session_id or _matches_pattern(seg.session_id, session_id, pattern_type))
+                    and (not voxel_spacing or _matches_numeric_pattern(seg.voxel_size, voxel_spacing, pattern_type))
+                    and (multilabel is None or seg.is_multilabel == multilabel)
+                ):
+                    results.append(seg)
+
+    return results
+
+
+def _get_tomograms_from_runs(
+    runs: List["CopickRun"],
+    filters: Dict[str, Any],
+) -> List["CopickTomogram"]:
+    """Get tomograms with optional filtering.
+
+    Args:
+        runs: List of runs to search.
+        filters: Filter dictionary with optional keys: tomo_type, voxel_spacing, pattern_type.
+
+    Returns:
+        List of matching tomograms.
+    """
+    results = []
+    pattern_type = filters.get("pattern_type", "glob")
+    tomo_type = filters.get("tomo_type")
+    voxel_spacing = filters.get("voxel_spacing")
+
+    for run in runs:
+        for vs in run.voxel_spacings:
+            # Skip if voxel_spacing filter doesn't match
+            if voxel_spacing and not _matches_numeric_pattern(vs.voxel_size, voxel_spacing, pattern_type):
+                continue
+
+            # Get tomograms (use built-in method if not a pattern)
+            if tomo_type and not _is_pattern(tomo_type, pattern_type):
+                # Exact match - use built-in get_tomograms
+                tomos = vs.get_tomograms(tomo_type)
+            else:
+                # Need pattern matching or get all
+                tomos = [
+                    t for t in vs.tomograms if not tomo_type or _matches_pattern(t.tomo_type, tomo_type, pattern_type)
+                ]
+
+            results.extend(tomos)
+
+    return results
+
+
+def _get_features_from_runs(
+    runs: List["CopickRun"],
+    filters: Dict[str, Any],
+) -> List["CopickFeatures"]:
+    """Get features with simplified nesting and use of built-in methods.
+
+    Args:
+        runs: List of runs to search.
+        filters: Filter dictionary with optional keys: tomo_type, voxel_spacing, feature_type, pattern_type.
+
+    Returns:
+        List of matching features.
+    """
+    results = []
+    pattern_type = filters.get("pattern_type", "glob")
+    tomo_type = filters.get("tomo_type")
+    voxel_spacing = filters.get("voxel_spacing")
+    feature_type = filters.get("feature_type")
+
+    for run in runs:
+        for vs in run.voxel_spacings:
+            # Skip if voxel_spacing filter doesn't match
+            if voxel_spacing and not _matches_numeric_pattern(vs.voxel_size, voxel_spacing, pattern_type):
+                continue
+
+            # Get tomograms (use built-in method if not a pattern)
+            if tomo_type and not _is_pattern(tomo_type, pattern_type):
+                # Exact match - use built-in get_tomograms
+                tomos = vs.get_tomograms(tomo_type)
+            else:
+                # Need pattern matching or get all
+                tomos = [
+                    t for t in vs.tomograms if not tomo_type or _matches_pattern(t.tomo_type, tomo_type, pattern_type)
+                ]
+
+            for tomo in tomos:
+                # Get features (use built-in method if not a pattern)
+                if feature_type and not _is_pattern(feature_type, pattern_type):
+                    # Exact match
+                    feat = tomo.get_features(feature_type)
+                    if feat:
+                        results.append(feat)
+                else:
+                    # Pattern matching or get all
+                    features = [
+                        f
+                        for f in tomo.features
+                        if not feature_type or _matches_pattern(f.feature_type, feature_type, pattern_type)
+                    ]
+                    results.extend(features)
+
+    return results

--- a/src/copick/util/uri.py
+++ b/src/copick/util/uri.py
@@ -36,7 +36,7 @@ def parse_copick_uri(uri: str, object_type: str) -> Dict[str, Any]:
 
     Args:
         uri (str): The copick URI to parse.
-        object_type (str): Type of object ('pick', 'mesh', 'segmentation', 'tomogram', 'feature').
+        object_type (str): Type of object ('picks', 'mesh', 'segmentation', 'tomogram', 'feature').
 
     Returns:
         Dict[str, Any]: A dictionary containing the parsed components.
@@ -62,7 +62,7 @@ def parse_copick_uri(uri: str, object_type: str) -> Dict[str, Any]:
         # Flatten single-value lists
         query_params = {k: v[0] if len(v) == 1 else v for k, v in query_params.items()}
 
-    if object_type in ("pick", "mesh"):
+    if object_type in ("picks", "mesh"):
         # Pattern: object_name:user_id/session_id
         # Support incomplete patterns: 'obj' → 'obj:*/*', 'obj:user' → 'obj:user/*'
         parts = uri.split(":")
@@ -179,7 +179,7 @@ def parse_copick_uri(uri: str, object_type: str) -> Dict[str, Any]:
 
     else:
         raise ValueError(
-            f"Unknown object type: {object_type}. Must be one of: pick, mesh, segmentation, tomogram, feature",
+            f"Unknown object type: {object_type}. Must be one of: picks, mesh, segmentation, tomogram, feature",
         )
 
 
@@ -235,7 +235,7 @@ def serialize_copick_uri_from_dict(
     """Serialize copick object parameters into a URI according to copick URI schemes.
 
     Args:
-        object_type (str): Type of copick object ('pick', 'mesh', 'segmentation', 'tomogram', 'feature')
+        object_type (str): Type of copick object ('picks', 'mesh', 'segmentation', 'tomogram', 'feature')
         object_name (str, optional): Object name for picks/meshes
         name (str, optional): Name for segmentations
         user_id (str, optional): User ID for picks/meshes/segmentations
@@ -251,7 +251,7 @@ def serialize_copick_uri_from_dict(
     Raises:
         ValueError: If required parameters are missing for the given object type
     """
-    if object_type == "pick":
+    if object_type == "picks":
         if not all([object_name, user_id, session_id]):
             raise ValueError("Picks require object_name, user_id, and session_id")
         return f"{object_name}:{user_id}/{session_id}"
@@ -302,7 +302,7 @@ def resolve_copick_objects(
     Args:
         uri (str): The copick URI to resolve.
         root (CopickRoot): The copick root to search in.
-        object_type (str): Type of object ('pick', 'mesh', 'segmentation', 'tomogram', 'feature').
+        object_type (str): Type of object ('picks', 'mesh', 'segmentation', 'tomogram', 'feature').
         run_name (str, optional): Specific run name to search in. If None, searches all runs.
 
     Returns:
@@ -335,7 +335,7 @@ def get_copick_objects_by_type(
 
     Args:
         root (CopickRoot): The copick root to search in.
-        object_type (str): The type of objects to retrieve ('pick', 'mesh', 'segmentation', 'tomogram', 'feature').
+        object_type (str): The type of objects to retrieve ('picks', 'mesh', 'segmentation', 'tomogram', 'feature').
         run_name (str, optional): Specific run name to search in.
         **filters: Additional filters based on object type.
                   For picks/meshes: object_name, user_id, session_id
@@ -361,7 +361,7 @@ def get_copick_objects_by_type(
 
     # Dispatch to type-specific handler
     handlers = {
-        "pick": _get_picks_from_runs,
+        "picks": _get_picks_from_runs,
         "mesh": _get_meshes_from_runs,
         "segmentation": _get_segmentations_from_runs,
         "tomogram": _get_tomograms_from_runs,
@@ -370,7 +370,7 @@ def get_copick_objects_by_type(
 
     if object_type not in handlers:
         raise ValueError(
-            f"Unknown object type: {object_type}. Must be one of: pick, mesh, segmentation, tomogram, feature",
+            f"Unknown object type: {object_type}. Must be one of: picks, mesh, segmentation, tomogram, feature",
         )
 
     return handlers[object_type](runs_to_search, filters)

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -14,8 +14,8 @@ class TestParseURI:
 
     def test_parse_pick_uri_complete(self):
         """Test parsing a complete pick URI."""
-        result = parse_copick_uri("ribosome:gapstop/0", "pick")
-        assert result["object_type"] == "pick"
+        result = parse_copick_uri("ribosome:gapstop/0", "picks")
+        assert result["object_type"] == "picks"
         assert result["pattern_type"] == "glob"
         assert result["object_name"] == "ribosome"
         assert result["user_id"] == "gapstop"
@@ -24,27 +24,27 @@ class TestParseURI:
     def test_parse_pick_uri_incomplete(self):
         """Test parsing incomplete pick URIs with wildcard defaults."""
         # Just object name
-        result = parse_copick_uri("ribosome", "pick")
+        result = parse_copick_uri("ribosome", "picks")
         assert result["object_name"] == "ribosome"
         assert result["user_id"] == "*"
         assert result["session_id"] == "*"
 
         # Object name and user ID
-        result = parse_copick_uri("ribosome:gapstop", "pick")
+        result = parse_copick_uri("ribosome:gapstop", "picks")
         assert result["object_name"] == "ribosome"
         assert result["user_id"] == "gapstop"
         assert result["session_id"] == "*"
 
     def test_parse_pick_uri_glob_patterns(self):
         """Test parsing pick URIs with glob patterns."""
-        result = parse_copick_uri("ribo*:gapstop/*", "pick")
+        result = parse_copick_uri("ribo*:gapstop/*", "picks")
         assert result["object_name"] == "ribo*"
         assert result["user_id"] == "gapstop"
         assert result["session_id"] == "*"
 
     def test_parse_pick_uri_regex(self):
         """Test parsing pick URIs with regex patterns."""
-        result = parse_copick_uri("re:ribo.*:gapstop/\\d+", "pick")
+        result = parse_copick_uri("re:ribo.*:gapstop/\\d+", "picks")
         assert result["pattern_type"] == "regex"
         assert result["object_name"] == "ribo.*"
         assert result["user_id"] == "gapstop"
@@ -162,7 +162,7 @@ class TestSerializeURI:
             assert "/" in uri
 
             # Parse it back
-            parsed = parse_copick_uri(uri, "pick")
+            parsed = parse_copick_uri(uri, "picks")
             assert parsed["object_name"] == pick.pickable_object_name
             assert parsed["user_id"] == pick.user_id
             assert parsed["session_id"] == pick.session_id
@@ -258,7 +258,7 @@ class TestSerializeURI:
     def test_serialize_from_dict_picks(self):
         """Test serializing picks from dict parameters."""
         uri = serialize_copick_uri_from_dict(
-            object_type="pick",
+            object_type="picks",
             object_name="ribosome",
             user_id="gapstop",
             session_id="0",
@@ -299,7 +299,7 @@ class TestSerializeURI:
     def test_serialize_from_dict_missing_params(self):
         """Test that missing required parameters raise errors."""
         with pytest.raises(ValueError, match="require"):
-            serialize_copick_uri_from_dict(object_type="pick", object_name="ribosome")
+            serialize_copick_uri_from_dict(object_type="picks", object_name="ribosome")
 
 
 class TestResolveObjects:
@@ -317,7 +317,7 @@ class TestResolveObjects:
             pick = run.picks[0]
             uri = f"{pick.pickable_object_name}:{pick.user_id}/{pick.session_id}"
 
-            resolved = resolve_copick_objects(uri, root, "pick", run.name)
+            resolved = resolve_copick_objects(uri, root, "picks", run.name)
             assert len(resolved) == 1
             assert resolved[0].pickable_object_name == pick.pickable_object_name
             assert resolved[0].user_id == pick.user_id
@@ -330,7 +330,7 @@ class TestResolveObjects:
         root = copick.from_file(str(fixture["cfg_file"]))
 
         # Get all picks for ribosome
-        resolved = resolve_copick_objects("ribosome", root, "pick")
+        resolved = resolve_copick_objects("ribosome", root, "picks")
         ribosome_picks = [p for p in resolved if p.pickable_object_name == "ribosome"]
         assert len(ribosome_picks) > 0
 
@@ -345,7 +345,7 @@ class TestResolveObjects:
         root = copick.from_file(str(fixture["cfg_file"]))
 
         # Match all picks with user_id starting with 'gap'
-        resolved = resolve_copick_objects("*:gap*/*", root, "pick")
+        resolved = resolve_copick_objects("*:gap*/*", root, "picks")
         assert len(resolved) > 0
 
         for pick in resolved:
@@ -488,7 +488,7 @@ class TestGetObjectsByType:
         fixture = request.getfixturevalue(case)
         root = copick.from_file(str(fixture["cfg_file"]))
 
-        picks = get_copick_objects_by_type(root, "pick")
+        picks = get_copick_objects_by_type(root, "picks")
         assert len(picks) > 0
         assert all(hasattr(p, "pickable_object_name") for p in picks)
 
@@ -499,7 +499,7 @@ class TestGetObjectsByType:
         root = copick.from_file(str(fixture["cfg_file"]))
 
         # Get all ribosome picks
-        picks = get_copick_objects_by_type(root, "pick", object_name="ribosome")
+        picks = get_copick_objects_by_type(root, "picks", object_name="ribosome")
         assert all(p.pickable_object_name == "ribosome" for p in picks)
 
     @pytest.mark.parametrize("case", pytest.common_cases)
@@ -509,7 +509,7 @@ class TestGetObjectsByType:
         root = copick.from_file(str(fixture["cfg_file"]))
 
         run = root.runs[0]
-        picks = get_copick_objects_by_type(root, "pick", run_name=run.name)
+        picks = get_copick_objects_by_type(root, "picks", run_name=run.name)
 
         # All picks should belong to the specified run
         for pick in picks:
@@ -558,7 +558,7 @@ class TestGetObjectsByType:
         root = copick.from_file(str(local["cfg_file"]))
 
         with pytest.raises(ValueError, match="not found"):
-            get_copick_objects_by_type(root, "pick", run_name="nonexistent_run")
+            get_copick_objects_by_type(root, "picks", run_name="nonexistent_run")
 
 
 class TestPatternMatching:
@@ -571,7 +571,7 @@ class TestPatternMatching:
         root = copick.from_file(str(fixture["cfg_file"]))
 
         # Match picks with numeric session IDs
-        resolved = resolve_copick_objects("re:.*:.*/(\\d+)", root, "pick")
+        resolved = resolve_copick_objects("re:.*:.*/(\\d+)", root, "picks")
 
         if resolved:
             for pick in resolved:

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -1,0 +1,613 @@
+import copick
+import pytest
+from copick.util.uri import (
+    get_copick_objects_by_type,
+    parse_copick_uri,
+    resolve_copick_objects,
+    serialize_copick_uri,
+    serialize_copick_uri_from_dict,
+)
+
+
+class TestParseURI:
+    """Test URI parsing functionality."""
+
+    def test_parse_pick_uri_complete(self):
+        """Test parsing a complete pick URI."""
+        result = parse_copick_uri("ribosome:gapstop/0", "pick")
+        assert result["object_type"] == "pick"
+        assert result["pattern_type"] == "glob"
+        assert result["object_name"] == "ribosome"
+        assert result["user_id"] == "gapstop"
+        assert result["session_id"] == "0"
+
+    def test_parse_pick_uri_incomplete(self):
+        """Test parsing incomplete pick URIs with wildcard defaults."""
+        # Just object name
+        result = parse_copick_uri("ribosome", "pick")
+        assert result["object_name"] == "ribosome"
+        assert result["user_id"] == "*"
+        assert result["session_id"] == "*"
+
+        # Object name and user ID
+        result = parse_copick_uri("ribosome:gapstop", "pick")
+        assert result["object_name"] == "ribosome"
+        assert result["user_id"] == "gapstop"
+        assert result["session_id"] == "*"
+
+    def test_parse_pick_uri_glob_patterns(self):
+        """Test parsing pick URIs with glob patterns."""
+        result = parse_copick_uri("ribo*:gapstop/*", "pick")
+        assert result["object_name"] == "ribo*"
+        assert result["user_id"] == "gapstop"
+        assert result["session_id"] == "*"
+
+    def test_parse_pick_uri_regex(self):
+        """Test parsing pick URIs with regex patterns."""
+        result = parse_copick_uri("re:ribo.*:gapstop/\\d+", "pick")
+        assert result["pattern_type"] == "regex"
+        assert result["object_name"] == "ribo.*"
+        assert result["user_id"] == "gapstop"
+        assert result["session_id"] == "\\d+"
+
+    def test_parse_mesh_uri(self):
+        """Test parsing mesh URIs (same format as picks)."""
+        result = parse_copick_uri("membrane:membrain/0", "mesh")
+        assert result["object_type"] == "mesh"
+        assert result["object_name"] == "membrane"
+        assert result["user_id"] == "membrain"
+        assert result["session_id"] == "0"
+
+    def test_parse_segmentation_uri_complete(self):
+        """Test parsing a complete segmentation URI."""
+        result = parse_copick_uri("painting:test.user/123@10.0?multilabel=true", "segmentation")
+        assert result["object_type"] == "segmentation"
+        assert result["name"] == "painting"
+        assert result["user_id"] == "test.user"
+        assert result["session_id"] == "123"
+        assert result["voxel_spacing"] == "10.0"
+        assert result["multilabel"] is True
+
+    def test_parse_segmentation_uri_no_multilabel(self):
+        """Test parsing segmentation URI without multilabel parameter."""
+        result = parse_copick_uri("membrane:membrain/0@20.0", "segmentation")
+        assert result["name"] == "membrane"
+        assert result["user_id"] == "membrain"
+        assert result["session_id"] == "0"
+        assert result["voxel_spacing"] == "20.0"
+        assert result["multilabel"] is None  # Default: match both
+
+    def test_parse_segmentation_uri_incomplete(self):
+        """Test parsing incomplete segmentation URIs."""
+        # Just name
+        result = parse_copick_uri("painting", "segmentation")
+        assert result["name"] == "painting"
+        assert result["user_id"] == "*"
+        assert result["session_id"] == "*"
+        assert result["voxel_spacing"] == "*"
+
+        # Name and user
+        result = parse_copick_uri("painting:test.user", "segmentation")
+        assert result["name"] == "painting"
+        assert result["user_id"] == "test.user"
+        assert result["session_id"] == "*"
+        assert result["voxel_spacing"] == "*"
+
+        # Name, user, session
+        result = parse_copick_uri("painting:test.user/123", "segmentation")
+        assert result["name"] == "painting"
+        assert result["user_id"] == "test.user"
+        assert result["session_id"] == "123"
+        assert result["voxel_spacing"] == "*"
+
+    def test_parse_tomogram_uri_complete(self):
+        """Test parsing a complete tomogram URI."""
+        result = parse_copick_uri("wbp@10.0", "tomogram")
+        assert result["object_type"] == "tomogram"
+        assert result["tomo_type"] == "wbp"
+        assert result["voxel_spacing"] == "10.0"
+
+    def test_parse_tomogram_uri_incomplete(self):
+        """Test parsing incomplete tomogram URI."""
+        result = parse_copick_uri("wbp", "tomogram")
+        assert result["tomo_type"] == "wbp"
+        assert result["voxel_spacing"] == "*"
+
+    def test_parse_feature_uri_complete(self):
+        """Test parsing a complete feature URI."""
+        result = parse_copick_uri("wbp@10.0:sobel", "feature")
+        assert result["object_type"] == "feature"
+        assert result["tomo_type"] == "wbp"
+        assert result["voxel_spacing"] == "10.0"
+        assert result["feature_type"] == "sobel"
+
+    def test_parse_feature_uri_incomplete(self):
+        """Test parsing incomplete feature URIs."""
+        # Just tomo type
+        result = parse_copick_uri("wbp", "feature")
+        assert result["tomo_type"] == "wbp"
+        assert result["voxel_spacing"] == "*"
+        assert result["feature_type"] == "*"
+
+        # Tomo type and voxel spacing
+        result = parse_copick_uri("wbp@10.0", "feature")
+        assert result["tomo_type"] == "wbp"
+        assert result["voxel_spacing"] == "10.0"
+        assert result["feature_type"] == "*"
+
+    def test_parse_uri_invalid_object_type(self):
+        """Test parsing with invalid object type."""
+        with pytest.raises(ValueError, match="Unknown object type"):
+            parse_copick_uri("test:user/session", "invalid_type")
+
+
+class TestSerializeURI:
+    """Test URI serialization functionality."""
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_serialize_picks_roundtrip(self, case, request):
+        """Test that picks can be serialized and parsed back."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get a pick and serialize it
+        run = root.runs[0]
+        picks = run.picks
+        if picks:
+            pick = picks[0]
+            uri = serialize_copick_uri(pick)
+
+            # URI should match expected format
+            assert ":" in uri
+            assert "/" in uri
+
+            # Parse it back
+            parsed = parse_copick_uri(uri, "pick")
+            assert parsed["object_name"] == pick.pickable_object_name
+            assert parsed["user_id"] == pick.user_id
+            assert parsed["session_id"] == pick.session_id
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_serialize_meshes_roundtrip(self, case, request):
+        """Test that meshes can be serialized and parsed back."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        meshes = run.meshes
+        if meshes:
+            mesh = meshes[0]
+            uri = serialize_copick_uri(mesh)
+
+            parsed = parse_copick_uri(uri, "mesh")
+            assert parsed["object_name"] == mesh.pickable_object_name
+            assert parsed["user_id"] == mesh.user_id
+            assert parsed["session_id"] == mesh.session_id
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_serialize_segmentations_roundtrip(self, case, request):
+        """Test that segmentations can be serialized and parsed back."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        segs = run.segmentations
+        if segs:
+            seg = segs[0]
+            uri = serialize_copick_uri(seg)
+
+            # URI should contain @ for voxel spacing
+            assert "@" in uri
+
+            parsed = parse_copick_uri(uri, "segmentation")
+            assert parsed["name"] == seg.name
+            assert parsed["user_id"] == seg.user_id
+            assert parsed["session_id"] == seg.session_id
+            assert float(parsed["voxel_spacing"]) == seg.voxel_size
+
+            # Check multilabel flag
+            if seg.is_multilabel:
+                assert "?multilabel=true" in uri
+                assert parsed["multilabel"] is True
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_serialize_tomograms_roundtrip(self, case, request):
+        """Test that tomograms can be serialized and parsed back."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        if run.voxel_spacings:
+            vs = run.voxel_spacings[0]
+            tomos = vs.tomograms
+            if tomos:
+                tomo = tomos[0]
+                uri = serialize_copick_uri(tomo)
+
+                assert "@" in uri
+
+                parsed = parse_copick_uri(uri, "tomogram")
+                assert parsed["tomo_type"] == tomo.tomo_type
+                assert float(parsed["voxel_spacing"]) == tomo.voxel_spacing.voxel_size
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_serialize_features_roundtrip(self, case, request):
+        """Test that features can be serialized and parsed back."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        if run.voxel_spacings:
+            vs = run.voxel_spacings[0]
+            tomos = vs.tomograms
+            for tomo in tomos:
+                features = tomo.features
+                if features:
+                    feat = features[0]
+                    uri = serialize_copick_uri(feat)
+
+                    assert "@" in uri
+                    assert ":" in uri
+
+                    parsed = parse_copick_uri(uri, "feature")
+                    assert parsed["tomo_type"] == feat.tomo_type
+                    assert float(parsed["voxel_spacing"]) == feat.tomogram.voxel_spacing.voxel_size
+                    assert parsed["feature_type"] == feat.feature_type
+                    return
+
+    def test_serialize_from_dict_picks(self):
+        """Test serializing picks from dict parameters."""
+        uri = serialize_copick_uri_from_dict(
+            object_type="pick",
+            object_name="ribosome",
+            user_id="gapstop",
+            session_id="0",
+        )
+        assert uri == "ribosome:gapstop/0"
+
+    def test_serialize_from_dict_segmentations(self):
+        """Test serializing segmentations from dict parameters."""
+        uri = serialize_copick_uri_from_dict(
+            object_type="segmentation",
+            name="painting",
+            user_id="test.user",
+            session_id="123",
+            voxel_spacing=10.0,
+            multilabel=True,
+        )
+        assert uri == "painting:test.user/123@10.0?multilabel=true"
+
+    def test_serialize_from_dict_tomograms(self):
+        """Test serializing tomograms from dict parameters."""
+        uri = serialize_copick_uri_from_dict(
+            object_type="tomogram",
+            tomo_type="wbp",
+            voxel_spacing=10.0,
+        )
+        assert uri == "wbp@10.0"
+
+    def test_serialize_from_dict_features(self):
+        """Test serializing features from dict parameters."""
+        uri = serialize_copick_uri_from_dict(
+            object_type="feature",
+            tomo_type="wbp",
+            voxel_spacing=10.0,
+            feature_type="sobel",
+        )
+        assert uri == "wbp@10.0:sobel"
+
+    def test_serialize_from_dict_missing_params(self):
+        """Test that missing required parameters raise errors."""
+        with pytest.raises(ValueError, match="require"):
+            serialize_copick_uri_from_dict(object_type="pick", object_name="ribosome")
+
+
+class TestResolveObjects:
+    """Test object resolution from URIs."""
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_picks_exact(self, case, request):
+        """Test resolving picks with exact match."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Find a specific pick to test
+        run = root.runs[0]
+        if run.picks:
+            pick = run.picks[0]
+            uri = f"{pick.pickable_object_name}:{pick.user_id}/{pick.session_id}"
+
+            resolved = resolve_copick_objects(uri, root, "pick", run.name)
+            assert len(resolved) == 1
+            assert resolved[0].pickable_object_name == pick.pickable_object_name
+            assert resolved[0].user_id == pick.user_id
+            assert resolved[0].session_id == pick.session_id
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_picks_wildcard(self, case, request):
+        """Test resolving picks with wildcards."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get all picks for ribosome
+        resolved = resolve_copick_objects("ribosome", root, "pick")
+        ribosome_picks = [p for p in resolved if p.pickable_object_name == "ribosome"]
+        assert len(ribosome_picks) > 0
+
+        # All should be ribosome picks
+        for pick in ribosome_picks:
+            assert pick.pickable_object_name == "ribosome"
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_picks_glob_pattern(self, case, request):
+        """Test resolving picks with glob patterns."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Match all picks with user_id starting with 'gap'
+        resolved = resolve_copick_objects("*:gap*/*", root, "pick")
+        assert len(resolved) > 0
+
+        for pick in resolved:
+            assert pick.user_id.startswith("gap")
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_meshes_exact(self, case, request):
+        """Test resolving meshes with exact match."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        if run.meshes:
+            mesh = run.meshes[0]
+            uri = f"{mesh.pickable_object_name}:{mesh.user_id}/{mesh.session_id}"
+
+            resolved = resolve_copick_objects(uri, root, "mesh", run.name)
+            assert len(resolved) == 1
+            assert resolved[0].pickable_object_name == mesh.pickable_object_name
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_segmentations_exact(self, case, request):
+        """Test resolving segmentations with exact match."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        if run.segmentations:
+            seg = run.segmentations[0]
+            uri = f"{seg.name}:{seg.user_id}/{seg.session_id}@{seg.voxel_size}"
+
+            resolved = resolve_copick_objects(uri, root, "segmentation", run.name)
+            assert len(resolved) == 1
+            assert resolved[0].name == seg.name
+            assert resolved[0].voxel_size == seg.voxel_size
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_segmentations_multilabel_default(self, case, request):
+        """Test that segmentations match both multilabel and non-multilabel by default."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get all segmentations without specifying multilabel
+        resolved = resolve_copick_objects("*:*/*@*", root, "segmentation")
+
+        # Should include both multilabel and non-multilabel segmentations
+        has_multilabel = any(seg.is_multilabel for seg in resolved)
+        has_non_multilabel = any(not seg.is_multilabel for seg in resolved)
+
+        # At least one type should exist (depends on test data)
+        assert has_multilabel or has_non_multilabel
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_segmentations_multilabel_filter(self, case, request):
+        """Test filtering segmentations by multilabel flag."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get multilabel segmentations only
+        resolved = resolve_copick_objects("*:*/*@*?multilabel=true", root, "segmentation")
+
+        if resolved:
+            # All should be multilabel
+            for seg in resolved:
+                assert seg.is_multilabel
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_tomograms_exact(self, case, request):
+        """Test resolving tomograms with exact match."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        if run.voxel_spacings:
+            vs = run.voxel_spacings[0]
+            tomos = vs.tomograms
+            if tomos:
+                tomo = tomos[0]
+                uri = f"{tomo.tomo_type}@{vs.voxel_size}"
+
+                resolved = resolve_copick_objects(uri, root, "tomogram", run.name)
+                assert len(resolved) >= 1
+
+                # Find our specific tomogram
+                found = [t for t in resolved if t.tomo_type == tomo.tomo_type]
+                assert len(found) >= 1
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_tomograms_wildcard(self, case, request):
+        """Test resolving all tomograms with wildcards."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get all tomograms
+        resolved = resolve_copick_objects("*@*", root, "tomogram")
+        assert len(resolved) > 0
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_features_exact(self, case, request):
+        """Test resolving features with exact match."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        if run.voxel_spacings:
+            vs = run.voxel_spacings[0]
+            for tomo in vs.tomograms:
+                if tomo.features:
+                    feat = tomo.features[0]
+                    uri = f"{feat.tomo_type}@{vs.voxel_size}:{feat.feature_type}"
+
+                    resolved = resolve_copick_objects(uri, root, "feature", run.name)
+                    assert len(resolved) >= 1
+
+                    found = [f for f in resolved if f.feature_type == feat.feature_type]
+                    assert len(found) >= 1
+                    return
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_features_wildcard(self, case, request):
+        """Test resolving all features with wildcards."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get all features
+        resolved = resolve_copick_objects("*@*:*", root, "feature")
+
+        # Should have at least some features
+        if resolved:
+            for feat in resolved:
+                assert feat.feature_type is not None
+
+
+class TestGetObjectsByType:
+    """Test direct object retrieval by type."""
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_get_picks_all(self, case, request):
+        """Test getting all picks."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        picks = get_copick_objects_by_type(root, "pick")
+        assert len(picks) > 0
+        assert all(hasattr(p, "pickable_object_name") for p in picks)
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_get_picks_filtered(self, case, request):
+        """Test getting filtered picks."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get all ribosome picks
+        picks = get_copick_objects_by_type(root, "pick", object_name="ribosome")
+        assert all(p.pickable_object_name == "ribosome" for p in picks)
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_get_picks_by_run(self, case, request):
+        """Test getting picks for specific run."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        picks = get_copick_objects_by_type(root, "pick", run_name=run.name)
+
+        # All picks should belong to the specified run
+        for pick in picks:
+            assert pick.run.name == run.name
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_get_segmentations_all(self, case, request):
+        """Test getting all segmentations."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        segs = get_copick_objects_by_type(root, "segmentation")
+        if segs:
+            assert all(hasattr(s, "name") for s in segs)
+            assert all(hasattr(s, "voxel_size") for s in segs)
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_get_tomograms_all(self, case, request):
+        """Test getting all tomograms."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        tomos = get_copick_objects_by_type(root, "tomogram")
+        assert len(tomos) > 0
+        assert all(hasattr(t, "tomo_type") for t in tomos)
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_get_features_all(self, case, request):
+        """Test getting all features."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        features = get_copick_objects_by_type(root, "feature")
+        if features:
+            assert all(hasattr(f, "feature_type") for f in features)
+
+    def test_get_objects_invalid_type(self, local):
+        """Test getting objects with invalid type."""
+        root = copick.from_file(str(local["cfg_file"]))
+
+        with pytest.raises(ValueError, match="Unknown object type"):
+            get_copick_objects_by_type(root, "invalid_type")
+
+    def test_get_objects_invalid_run(self, local):
+        """Test getting objects with non-existent run."""
+        root = copick.from_file(str(local["cfg_file"]))
+
+        with pytest.raises(ValueError, match="not found"):
+            get_copick_objects_by_type(root, "pick", run_name="nonexistent_run")
+
+
+class TestPatternMatching:
+    """Test advanced pattern matching with regex."""
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_regex_picks_pattern(self, case, request):
+        """Test regex pattern matching for picks."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Match picks with numeric session IDs
+        resolved = resolve_copick_objects("re:.*:.*/(\\d+)", root, "pick")
+
+        if resolved:
+            for pick in resolved:
+                assert pick.session_id.isdigit()
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_glob_voxel_spacing_pattern(self, case, request):
+        """Test glob pattern for voxel spacings."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get tomograms at voxel spacing 10.0
+        resolved = resolve_copick_objects("*@10.0", root, "tomogram")
+
+        if resolved:
+            for tomo in resolved:
+                assert tomo.voxel_spacing.voxel_size == 10.0
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_combined_filters(self, case, request):
+        """Test combining multiple filters."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get specific object with specific user at specific voxel spacing
+        run = root.runs[0]
+        resolved = get_copick_objects_by_type(
+            root,
+            "segmentation",
+            run_name=run.name,
+            name="painting",
+            voxel_spacing="10.0",
+            pattern_type="glob",
+        )
+
+        # All results should match all filters
+        for seg in resolved:
+            assert seg.name == "painting"
+            assert seg.voxel_size == 10.0


### PR DESCRIPTION
# Add URI-based Object Resolution System for Copick

## Summary

Implements a URI-based system for querying and resolving copick objects (picks, meshes, segmentations, tomograms, and features) with glob/regex pattern matching support. Provides a concise, string-based interface for filtering copick data objects.

## URI Schemes

**Picks & Meshes:** `object_name:user_id/session_id`
```python
ribosome:gapstop/0          # Exact match
ribosome                     # Expands to ribosome:*/*
ribo*:gap*/0                 # Glob patterns
re:ribo.*:gap.*/\d+          # Regex patterns
```

**Segmentations:** `name:user_id/session_id@voxel_spacing?multilabel=true`
```python
painting:test.user/123@10.0
membrane:*/*@20.0?multilabel=true
```

**Tomograms:** `tomo_type@voxel_spacing`
```python
wbp@10.0
```

**Features:** `tomo_type@voxel_spacing:feature_type`
```python
wbp@10.0:sobel
```

## API

```python
from copick.util.uri import resolve_copick_objects, serialize_copick_uri

# Resolve URI to objects
picks = resolve_copick_objects("ribosome:gapstop/0", root, "pick")

# Serialize object to URI
uri = serialize_copick_uri(pick_object)  # → "ribosome:gapstop/0"

# Pattern matching
picks = resolve_copick_objects("*:gap*/*", root, "pick")

# Regex patterns
picks = resolve_copick_objects(r"re:.*:.*\/\d+", root, "pick")

# Filter by run
picks = resolve_copick_objects("ribosome", root, "pick", run_name="TS_001")
```