### PR TITLE
feat: Add command that prepares copick data for deposition on the cryoET data portal.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -698,65 +698,65 @@ copick deposit [OPTIONS]
 
 **Options:**
 
-| Option                     | Type    | Description                                                                                                                                                      | Default                      |
-|----------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|
-| `-c, --config PATH`        | Path    | Path to the configuration file                                                                                                                                   | Uses `COPICK_CONFIG` env var |
-| `--target-dir PATH`        | Path    | Target directory for the deposited view (required)                                                                                                               | None                         |
-| `--run-names TEXT`         | String  | Comma-separated list of specific run names to process. If not specified, processes all runs                                                                      | `""` (all runs)              |
-| `--run-name-prefix TEXT`   | String  | Prefix to prepend to all run names. For data portal projects, if not provided, automatically constructs `{dataset_id}_{portal_run_name}_` for each run          | `""`                         |
-| `--run-name-regex TEXT`    | String  | Optional regex to define how to extract run names from copick run names. Run names will be extracted from the first group defined using parentheses             | None                         |
-| `--picks-uris TEXT`        | String  | URIs to filter picks (e.g., `proteasome:*/*` or `ribosome:user1/*`). Can be specified multiple times. If not specified, skips picks entirely                    | None                         |
-| `--meshes-uris TEXT`       | String  | URIs to filter meshes. Can be specified multiple times. If not specified, skips meshes entirely                                                                 | None                         |
-| `--segmentations-uris TEXT`| String  | URIs to filter segmentations (e.g., `membrane:*/*@10.0`). Can be specified multiple times. If not specified, skips segmentations entirely                       | None                         |
-| `--tomograms-uris TEXT`    | String  | URIs to filter tomograms (e.g., `wbp@10.0`). Can be specified multiple times. If not specified, skips tomograms entirely                                        | None                         |
-| `--features-uris TEXT`     | String  | URIs to filter features (e.g., `wbp@10.0:cellcanvas`). Can be specified multiple times. If not specified, skips features entirely                               | None                         |
-| `--n-workers INTEGER`      | Integer | Number of parallel workers for processing runs                                                                                                                   | `8`                          |
-| `--debug / --no-debug`     | Boolean | Enable debug logging                                                                                                                                             | `no-debug`                   |
+| Option                  | Type    | Description                                                                                                                                                      | Default                      |
+|-------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|
+| `-c, --config PATH`     | Path    | Path to the configuration file                                                                                                                                   | Uses `COPICK_CONFIG` env var |
+| `--target-dir PATH`     | Path    | Target directory for the deposited view (required)                                                                                                               | None                         |
+| `--run-names TEXT`      | String  | Comma-separated list of specific run names to process. If not specified, processes all runs                                                                      | `""` (all runs)              |
+| `--run-name-prefix TEXT`| String  | Prefix to prepend to all run names. For data portal projects, if not provided, automatically constructs `{dataset_id}_{portal_run_name}_` for each run          | `""`                         |
+| `--run-name-regex TEXT` | String  | Optional regex to define how to extract run names from copick run names. Run names will be extracted from the first group defined using parentheses             | None                         |
+| `--picks TEXT`          | String  | URIs to filter picks (e.g., `proteasome:*/*` or `ribosome:user1/*`). Can be specified multiple times. If not specified, skips picks entirely                    | None                         |
+| `--meshes TEXT`         | String  | URIs to filter meshes. Can be specified multiple times. If not specified, skips meshes entirely                                                                 | None                         |
+| `--segmentations TEXT`  | String  | URIs to filter segmentations (e.g., `membrane:*/*@10.0`). Can be specified multiple times. If not specified, skips segmentations entirely                       | None                         |
+| `--tomograms TEXT`      | String  | URIs to filter tomograms (e.g., `wbp@10.0`). Can be specified multiple times. If not specified, skips tomograms entirely                                        | None                         |
+| `--features TEXT`       | String  | URIs to filter features (e.g., `wbp@10.0:cellcanvas`). Can be specified multiple times. If not specified, skips features entirely                               | None                         |
+| `--max-workers INTEGER` | Integer | Number of parallel workers for processing runs                                                                                                                   | `8`                          |
+| `--debug / --no-debug`  | Boolean | Enable debug logging                                                                                                                                             | `no-debug`                   |
 
 **Examples:**
 
 ```bash
 # Deposit all runs from a filesystem project with all picks and meshes
 copick deposit -c filesystem_config.json --target-dir /path/to/deposit \
-    --picks-uris "*:*/*" --meshes-uris "*:*/*"
+    --picks "*:*/*" --meshes "*:*/*"
 
 # Deposit from a data portal project (automatic run name transformation)
 # Runs will be named like: 10301_TS_001_<portal_run_id>
 copick deposit -c portal_config.json --target-dir /path/to/deposit \
-    --picks-uris "proteasome:*/*" --picks-uris "ribosome:*/*" \
-    --segmentations-uris "membrane:*/*@10.0"
+    --picks "proteasome:*/*" --picks "ribosome:*/*" \
+    --segmentations "membrane:*/*@10.0"
 
 # Deposit specific runs with explicit prefix override
 copick deposit -c config.json --target-dir /path/to/deposit \
     --run-names "TS_001,TS_002" --run-name-prefix "custom_prefix_" \
-    --picks-uris "*:*/*"
+    --picks "*:*/*"
 
 # Deposit with regex to extract run names
 # For runs named "TS_001_processed", this extracts "TS_001"
 copick deposit -c config.json --target-dir /path/to/deposit \
-    --run-name-regex "^(TS_\d+).*" --tomograms-uris "wbp@10.0"
+    --run-name-regex "^(TS_\d+).*" --tomograms "wbp@10.0"
 
 # Deposit specific data types with filters
 copick deposit -c config.json --target-dir /path/to/deposit \
-    --picks-uris "proteasome:*/*" --picks-uris "ribosome:analyst1/*" \
-    --segmentations-uris "membrane:*/*@10.0" --segmentations-uris "organelle:*/*@10.0" \
-    --tomograms-uris "wbp@10.0" --tomograms-uris "denoised@10.0"
+    --picks "proteasome:*/*" --picks "ribosome:analyst1/*" \
+    --segmentations "membrane:*/*@10.0" --segmentations "organelle:*/*@10.0" \
+    --tomograms "wbp@10.0" --tomograms "denoised@10.0"
 
 # Multiple projects to same target (successive executions)
 copick deposit -c project1.json --target-dir /deposit --run-name-prefix "proj1_" \
-    --picks-uris "*:*/*"
+    --picks "*:*/*"
 copick deposit -c project2.json --target-dir /deposit --run-name-prefix "proj2_" \
-    --picks-uris "*:*/*"
+    --picks "*:*/*"
 
 # Complex deposit with multiple filters and settings
 copick deposit -c config.json --target-dir /path/to/deposit \
     --run-names "TS_001,TS_002,TS_003" \
-    --picks-uris "proteasome:*/*" --picks-uris "ribosome:*/*" \
-    --meshes-uris "membrane:*/*" \
-    --segmentations-uris "membrane:*/*@10.0" \
-    --tomograms-uris "wbp@10.0" \
-    --features-uris "wbp@10.0:cellcanvas" \
-    --n-workers 16
+    --picks "proteasome:*/*" --picks "ribosome:*/*" \
+    --meshes "membrane:*/*" \
+    --segmentations "membrane:*/*@10.0" \
+    --tomograms "wbp@10.0" \
+    --features "wbp@10.0:cellcanvas" \
+    --max-workers 16
 ```
 
 !!! info "URI Syntax"
@@ -1151,36 +1151,36 @@ Prepare your copick project for upload to the CryoET Data Portal:
 ```bash
 # Basic deposit with all picks and meshes from a filesystem project
 copick deposit -c project.json --target-dir /path/to/deposit \
-    --picks-uris "*:*/*" --meshes-uris "*:*/*"
+    --picks "*:*/*" --meshes "*:*/*"
 
 # Deposit specific data types with filters
 copick deposit -c project.json --target-dir /path/to/deposit \
-    --picks-uris "ribosome:*/*" --picks-uris "proteasome:*/*" \
-    --segmentations-uris "membrane:*/*@10.0" \
-    --tomograms-uris "wbp@10.0"
+    --picks "ribosome:*/*" --picks "proteasome:*/*" \
+    --segmentations "membrane:*/*@10.0" \
+    --tomograms "wbp@10.0"
 
 # Deposit from data portal project (automatic run naming)
 # Runs will be transformed to: {dataset_id}_{portal_run_name}_{portal_run_id}
 copick deposit -c portal_config.json --target-dir /path/to/deposit \
-    --picks-uris "proteasome:*/*" --meshes-uris "membrane:*/*"
+    --picks "proteasome:*/*" --meshes "membrane:*/*"
 
 # Deposit specific runs with custom prefix
 copick deposit -c project.json --target-dir /path/to/deposit \
     --run-names "TS_001,TS_002,TS_003" \
     --run-name-prefix "experiment_A_" \
-    --picks-uris "*:*/*" --n-workers 16
+    --picks "*:*/*" --max-workers 16
 
 # Use regex to extract run names
 # For runs like "Position_60_7_Vol_CTF", extracts "Position_60_7"
 copick deposit -c project.json --target-dir /path/to/deposit \
     --run-name-regex "^(Position_.*)_Vol_CTF" \
-    --tomograms-uris "wbp@10.0" --tomograms-uris "denoised@10.0"
+    --tomograms "wbp@10.0" --tomograms "denoised@10.0"
 
 # Deposit multiple projects to same target directory (successive executions)
 copick deposit -c project1.json --target-dir /deposit --run-name-prefix "proj1_" \
-    --picks-uris "*:*/*"
+    --picks "*:*/*"
 copick deposit -c project2.json --target-dir /deposit --run-name-prefix "proj2_" \
-    --picks-uris "*:*/*"
+    --picks "*:*/*"
 
 # Verify the deposited structure
 ls -la /deposit/ExperimentRuns/
@@ -1208,5 +1208,5 @@ copick sync picks -c source_config.json --target-config target_config.json --deb
 
 # Test deposit with debug logging
 copick deposit -c project.json --target-dir /tmp/test_deposit \
-    --picks-uris "*:*/*" --debug
+    --picks "*:*/*" --debug
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -685,6 +685,101 @@ copick sync tomograms -c source_config.json --target-config target_config.json \
 
 ---
 
+### :material-folder-arrow-right: `copick deposit`
+
+Create a depositable view of a copick project using symlinks.
+
+This command creates a hierarchical directory structure suitable for uploading to the cryoET data portal. It operates on a single copick config and creates symlinks to the actual data files, allowing multiple projects to be deposited into the same target directory through successive executions.
+
+**Usage:**
+```bash
+copick deposit [OPTIONS]
+```
+
+**Options:**
+
+| Option                     | Type    | Description                                                                                                                                                      | Default                      |
+|----------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|
+| `-c, --config PATH`        | Path    | Path to the configuration file                                                                                                                                   | Uses `COPICK_CONFIG` env var |
+| `--target-dir PATH`        | Path    | Target directory for the deposited view (required)                                                                                                               | None                         |
+| `--run-names TEXT`         | String  | Comma-separated list of specific run names to process. If not specified, processes all runs                                                                      | `""` (all runs)              |
+| `--run-name-prefix TEXT`   | String  | Prefix to prepend to all run names. For data portal projects, if not provided, automatically constructs `{dataset_id}_{portal_run_name}_` for each run          | `""`                         |
+| `--run-name-regex TEXT`    | String  | Optional regex to define how to extract run names from copick run names. Run names will be extracted from the first group defined using parentheses             | None                         |
+| `--picks-uris TEXT`        | String  | URIs to filter picks (e.g., `proteasome:*/*` or `ribosome:user1/*`). Can be specified multiple times. If not specified, skips picks entirely                    | None                         |
+| `--meshes-uris TEXT`       | String  | URIs to filter meshes. Can be specified multiple times. If not specified, skips meshes entirely                                                                 | None                         |
+| `--segmentations-uris TEXT`| String  | URIs to filter segmentations (e.g., `membrane:*/*@10.0`). Can be specified multiple times. If not specified, skips segmentations entirely                       | None                         |
+| `--tomograms-uris TEXT`    | String  | URIs to filter tomograms (e.g., `wbp@10.0`). Can be specified multiple times. If not specified, skips tomograms entirely                                        | None                         |
+| `--features-uris TEXT`     | String  | URIs to filter features (e.g., `wbp@10.0:cellcanvas`). Can be specified multiple times. If not specified, skips features entirely                               | None                         |
+| `--n-workers INTEGER`      | Integer | Number of parallel workers for processing runs                                                                                                                   | `8`                          |
+| `--debug / --no-debug`     | Boolean | Enable debug logging                                                                                                                                             | `no-debug`                   |
+
+**Examples:**
+
+```bash
+# Deposit all runs from a filesystem project with all picks and meshes
+copick deposit -c filesystem_config.json --target-dir /path/to/deposit \
+    --picks-uris "*:*/*" --meshes-uris "*:*/*"
+
+# Deposit from a data portal project (automatic run name transformation)
+# Runs will be named like: 10301_TS_001_<portal_run_id>
+copick deposit -c portal_config.json --target-dir /path/to/deposit \
+    --picks-uris "proteasome:*/*" --picks-uris "ribosome:*/*" \
+    --segmentations-uris "membrane:*/*@10.0"
+
+# Deposit specific runs with explicit prefix override
+copick deposit -c config.json --target-dir /path/to/deposit \
+    --run-names "TS_001,TS_002" --run-name-prefix "custom_prefix_" \
+    --picks-uris "*:*/*"
+
+# Deposit with regex to extract run names
+# For runs named "TS_001_processed", this extracts "TS_001"
+copick deposit -c config.json --target-dir /path/to/deposit \
+    --run-name-regex "^(TS_\d+).*" --tomograms-uris "wbp@10.0"
+
+# Deposit specific data types with filters
+copick deposit -c config.json --target-dir /path/to/deposit \
+    --picks-uris "proteasome:*/*" --picks-uris "ribosome:analyst1/*" \
+    --segmentations-uris "membrane:*/*@10.0" --segmentations-uris "organelle:*/*@10.0" \
+    --tomograms-uris "wbp@10.0" --tomograms-uris "denoised@10.0"
+
+# Multiple projects to same target (successive executions)
+copick deposit -c project1.json --target-dir /deposit --run-name-prefix "proj1_" \
+    --picks-uris "*:*/*"
+copick deposit -c project2.json --target-dir /deposit --run-name-prefix "proj2_" \
+    --picks-uris "*:*/*"
+
+# Complex deposit with multiple filters and settings
+copick deposit -c config.json --target-dir /path/to/deposit \
+    --run-names "TS_001,TS_002,TS_003" \
+    --picks-uris "proteasome:*/*" --picks-uris "ribosome:*/*" \
+    --meshes-uris "membrane:*/*" \
+    --segmentations-uris "membrane:*/*@10.0" \
+    --tomograms-uris "wbp@10.0" \
+    --features-uris "wbp@10.0:cellcanvas" \
+    --n-workers 16
+```
+
+!!! info "URI Syntax"
+    The deposit command uses URI patterns to filter which data to include:
+
+    - **Picks/Meshes**: `object_name:user_id/session_id` (e.g., `ribosome:user1/*` or `*:*/*` for all)
+    - **Segmentations**: `name:user_id/session_id@voxel_size` (e.g., `membrane:*/*@10.0`)
+    - **Tomograms**: `tomo_type@voxel_size` (e.g., `wbp@10.0`)
+    - **Features**: `tomo_type@voxel_size:feature_type` (e.g., `wbp@10.0:cellcanvas`)
+
+    Use `*` as a wildcard to match all values in that position.
+
+!!! tip "Data Portal Projects"
+    For data portal projects, run names are automatically transformed from portal run IDs to `{dataset_id}_{portal_run_name}_{portal_run_id}` unless `--run-name-prefix` is explicitly provided. This ensures unique run names when depositing multiple datasets.
+
+!!! warning "Important Notes"
+    - Multiple executions to the same `target-dir` are safe and idempotent
+    - Symlinks that already exist and point to the correct source are skipped
+    - Read-only data from the portal cannot be symlinked and will raise an error
+    - Data must be in the overlay (writable) to be deposited
+
+---
+
 ### :material-chart-bar: `copick stats`
 
 Gather statistics about a Copick project's entities including picks, meshes, and segmentations.
@@ -1049,6 +1144,48 @@ copick sync tomograms -c source_config.json --target-config target_config.json \
     --log
 ```
 
+### Create Depositable View for Data Portal
+
+Prepare your copick project for upload to the CryoET Data Portal:
+
+```bash
+# Basic deposit with all picks and meshes from a filesystem project
+copick deposit -c project.json --target-dir /path/to/deposit \
+    --picks-uris "*:*/*" --meshes-uris "*:*/*"
+
+# Deposit specific data types with filters
+copick deposit -c project.json --target-dir /path/to/deposit \
+    --picks-uris "ribosome:*/*" --picks-uris "proteasome:*/*" \
+    --segmentations-uris "membrane:*/*@10.0" \
+    --tomograms-uris "wbp@10.0"
+
+# Deposit from data portal project (automatic run naming)
+# Runs will be transformed to: {dataset_id}_{portal_run_name}_{portal_run_id}
+copick deposit -c portal_config.json --target-dir /path/to/deposit \
+    --picks-uris "proteasome:*/*" --meshes-uris "membrane:*/*"
+
+# Deposit specific runs with custom prefix
+copick deposit -c project.json --target-dir /path/to/deposit \
+    --run-names "TS_001,TS_002,TS_003" \
+    --run-name-prefix "experiment_A_" \
+    --picks-uris "*:*/*" --n-workers 16
+
+# Use regex to extract run names
+# For runs like "Position_60_7_Vol_CTF", extracts "Position_60_7"
+copick deposit -c project.json --target-dir /path/to/deposit \
+    --run-name-regex "^(Position_.*)_Vol_CTF" \
+    --tomograms-uris "wbp@10.0" --tomograms-uris "denoised@10.0"
+
+# Deposit multiple projects to same target directory (successive executions)
+copick deposit -c project1.json --target-dir /deposit --run-name-prefix "proj1_" \
+    --picks-uris "*:*/*"
+copick deposit -c project2.json --target-dir /deposit --run-name-prefix "proj2_" \
+    --picks-uris "*:*/*"
+
+# Verify the deposited structure
+ls -la /deposit/ExperimentRuns/
+```
+
 ### Development and Debugging
 
 Debug and test your Copick workflows:
@@ -1068,4 +1205,8 @@ copick add tomogram --config project.json --run TEST_RUN --debug data/test_tomog
 
 # Test synchronization with debug logging
 copick sync picks -c source_config.json --target-config target_config.json --debug --log
+
+# Test deposit with debug logging
+copick deposit -c project.json --target-dir /tmp/test_deposit \
+    --picks-uris "*:*/*" --debug
 ```

--- a/src/copick/cli/cli.py
+++ b/src/copick/cli/cli.py
@@ -4,6 +4,7 @@ from copick import __version__ as version
 from copick.cli.add import add
 from copick.cli.browse import browse
 from copick.cli.config import config
+from copick.cli.deposit import deposit
 from copick.cli.ext import load_plugin_commands
 from copick.cli.info import get_installed_plugin_packages, info
 from copick.cli.new import new
@@ -130,6 +131,7 @@ def add_core_commands(cmd: click.group) -> click.group:
     cmd.add_command(add)
     cmd.add_command(browse)
     cmd.add_command(config)
+    cmd.add_command(deposit)
     cmd.add_command(info)
     cmd.add_command(new)
     cmd.add_command(stats)

--- a/src/copick/cli/deposit.py
+++ b/src/copick/cli/deposit.py
@@ -1,7 +1,6 @@
 import click
 
 from copick.cli.util import add_config_option, add_debug_option
-from copick.ops.deposit import deposit as deposit_op
 from copick.util.log import get_logger
 
 
@@ -134,6 +133,8 @@ def deposit(
     - Symlinks that already exist and point to the correct source are skipped.
     - Read-only data from the portal cannot be symlinked and will raise an error.
     """
+    from copick.ops.deposit import deposit as deposit_op
+
     logger = get_logger(__name__, debug=debug)
 
     # Parse run_names from comma-separated string to list

--- a/src/copick/cli/deposit.py
+++ b/src/copick/cli/deposit.py
@@ -1,0 +1,166 @@
+import click
+
+from copick.cli.util import add_config_option, add_debug_option
+from copick.ops.deposit import deposit as deposit_op
+from copick.util.log import get_logger
+
+
+@click.command(short_help="Create a depositable view of a copick project using symlinks.")
+@add_config_option
+@click.option(
+    "--target-dir",
+    type=str,
+    help="Target directory for the deposited view (required).",
+    required=True,
+    metavar="PATH",
+)
+@click.option(
+    "--run-names",
+    type=str,
+    help="Comma-separated list of specific run names to process. If not specified, processes all runs.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--run-name-prefix",
+    type=str,
+    help="Prefix to prepend to all run names. For data portal projects, if not provided, automatically constructs '{dataset_id}_{portal_run_name}_' for each run.",
+    default="",
+    show_default=True,
+)
+@click.option(
+    "--run-name-regex",
+    type=str,
+    help="Optional regex to define how to extract run names from copick run names. Run names will be extracted from the first group defined using parentheses in the pattern.",
+    default=None,
+)
+@click.option(
+    "--picks-uris",
+    type=str,
+    multiple=True,
+    help="URIs to filter picks (e.g., 'proteasome:*/*' or 'ribosome:user1/*'). Can be specified multiple times. If not specified, skips picks entirely.",
+)
+@click.option(
+    "--meshes-uris",
+    type=str,
+    multiple=True,
+    help="URIs to filter meshes. Can be specified multiple times. If not specified, skips meshes entirely.",
+)
+@click.option(
+    "--segmentations-uris",
+    type=str,
+    multiple=True,
+    help="URIs to filter segmentations (e.g., 'membrane:*/*@10.0'). Can be specified multiple times. If not specified, skips segmentations entirely.",
+)
+@click.option(
+    "--tomograms-uris",
+    type=str,
+    multiple=True,
+    help="URIs to filter tomograms (e.g., 'wbp@10.0'). Can be specified multiple times. If not specified, skips tomograms entirely.",
+)
+@click.option(
+    "--features-uris",
+    type=str,
+    multiple=True,
+    help="URIs to filter features (e.g., 'wbp@10.0:cellcanvas'). Can be specified multiple times. If not specified, skips features entirely.",
+)
+@click.option(
+    "--n-workers",
+    type=int,
+    help="Number of parallel workers for processing runs.",
+    default=8,
+    show_default=True,
+)
+@add_debug_option
+def deposit(
+    config,
+    target_dir,
+    run_names,
+    run_name_prefix,
+    run_name_regex,
+    picks_uris,
+    meshes_uris,
+    segmentations_uris,
+    tomograms_uris,
+    features_uris,
+    n_workers,
+    debug,
+):
+    """Create a depositable view of a copick project using symlinks.
+
+    This command creates a hierarchical directory structure suitable for uploading to the
+    cryoET data portal. It operates on a single copick config and creates symlinks to the
+    actual data files, allowing multiple projects to be deposited into the same target
+    directory through successive executions.
+
+    The directory structure created conforms to the standard copick filesystem layout.
+
+    Examples:
+
+    \b
+    # Deposit all runs from a filesystem project
+    copick deposit -c filesystem_config.json --target-dir /path/to/deposit \\
+        --picks-uris "*:*/*" --meshes-uris "*:*/*"
+
+    \b
+    # Deposit from a data portal project (automatic run name transformation)
+    # Runs will be named like: 10301_TS_001_<portal_run_id>
+    copick deposit -c portal_config.json --target-dir /path/to/deposit \\
+        --picks-uris "proteasome:*/*" --picks-uris "ribosome:*/*" \\
+        --segmentations-uris "membrane:*/*@10.0"
+
+    \b
+    # Deposit with explicit prefix override
+    copick deposit -c config.json --target-dir /path/to/deposit \\
+        --run-names "TS_001,TS_002" --run-name-prefix "custom_prefix_" \\
+        --picks-uris "*:*/*"
+
+    \b
+    # Deposit with regex to extract run names
+    copick deposit -c config.json --target-dir /path/to/deposit \\
+        --run-name-regex "^(TS_\\d+).*" --tomograms-uris "wbp@10.0"
+
+    \b
+    # Multiple projects to same target (successive executions)
+    copick deposit -c project1.json --target-dir /deposit --run-name-prefix "proj1_" \\
+        --picks-uris "*:*/*"
+    copick deposit -c project2.json --target-dir /deposit --run-name-prefix "proj2_" \\
+        --picks-uris "*:*/*"
+
+    Notes:
+    - For data portal projects, run names are automatically transformed from portal run IDs
+      to "{dataset_id}_{portal_run_name}_{portal_run_id}" unless run_name_prefix is provided.
+    - Multiple executions to the same target_dir are safe and idempotent.
+    - Symlinks that already exist and point to the correct source are skipped.
+    - Read-only data from the portal cannot be symlinked and will raise an error.
+    """
+    logger = get_logger(__name__, debug=debug)
+
+    # Parse run_names from comma-separated string to list
+    run_names_list = None
+    if run_names:
+        run_names_list = [name.strip() for name in run_names.split(",") if name.strip()]
+
+    # Convert tuple to list or None
+    picks_uris_list = list(picks_uris) if picks_uris else None
+    meshes_uris_list = list(meshes_uris) if meshes_uris else None
+    segmentations_uris_list = list(segmentations_uris) if segmentations_uris else None
+    tomograms_uris_list = list(tomograms_uris) if tomograms_uris else None
+    features_uris_list = list(features_uris) if features_uris else None
+
+    # Call the deposit operation
+    deposit_op(
+        config=config,
+        target_dir=target_dir,
+        run_names=run_names_list,
+        run_name_prefix=run_name_prefix,
+        run_name_regex=run_name_regex,
+        picks_uris=picks_uris_list,
+        meshes_uris=meshes_uris_list,
+        segmentations_uris=segmentations_uris_list,
+        tomograms_uris=tomograms_uris_list,
+        features_uris=features_uris_list,
+        n_workers=n_workers,
+    )
+
+    logger.info("Deposit operation completed successfully.")

--- a/src/copick/cli/deposit.py
+++ b/src/copick/cli/deposit.py
@@ -34,37 +34,37 @@ from copick.util.log import get_logger
     default=None,
 )
 @click.option(
-    "--picks-uris",
+    "--picks",
     type=str,
     multiple=True,
     help="URIs to filter picks (e.g., 'proteasome:*/*' or 'ribosome:user1/*'). Can be specified multiple times. If not specified, skips picks entirely.",
 )
 @click.option(
-    "--meshes-uris",
+    "--meshes",
     type=str,
     multiple=True,
     help="URIs to filter meshes. Can be specified multiple times. If not specified, skips meshes entirely.",
 )
 @click.option(
-    "--segmentations-uris",
+    "--segmentations",
     type=str,
     multiple=True,
     help="URIs to filter segmentations (e.g., 'membrane:*/*@10.0'). Can be specified multiple times. If not specified, skips segmentations entirely.",
 )
 @click.option(
-    "--tomograms-uris",
+    "--tomograms",
     type=str,
     multiple=True,
     help="URIs to filter tomograms (e.g., 'wbp@10.0'). Can be specified multiple times. If not specified, skips tomograms entirely.",
 )
 @click.option(
-    "--features-uris",
+    "--features",
     type=str,
     multiple=True,
     help="URIs to filter features (e.g., 'wbp@10.0:cellcanvas'). Can be specified multiple times. If not specified, skips features entirely.",
 )
 @click.option(
-    "--n-workers",
+    "--max-workers",
     type=int,
     help="Number of parallel workers for processing runs.",
     default=8,
@@ -77,12 +77,12 @@ def deposit(
     run_names,
     run_name_prefix,
     run_name_regex,
-    picks_uris,
-    meshes_uris,
-    segmentations_uris,
-    tomograms_uris,
-    features_uris,
-    n_workers,
+    picks,
+    meshes,
+    segmentations,
+    tomograms,
+    features,
+    max_workers,
     debug,
 ):
     """Create a depositable view of a copick project using symlinks.
@@ -99,32 +99,32 @@ def deposit(
     \b
     # Deposit all runs from a filesystem project
     copick deposit -c filesystem_config.json --target-dir /path/to/deposit \\
-        --picks-uris "*:*/*" --meshes-uris "*:*/*"
+        --picks "*:*/*" --meshes "*:*/*"
 
     \b
     # Deposit from a data portal project (automatic run name transformation)
     # Runs will be named like: 10301_TS_001_<portal_run_id>
     copick deposit -c portal_config.json --target-dir /path/to/deposit \\
-        --picks-uris "proteasome:*/*" --picks-uris "ribosome:*/*" \\
-        --segmentations-uris "membrane:*/*@10.0"
+        --picks "proteasome:*/*" --picks "ribosome:*/*" \\
+        --segmentations "membrane:*/*@10.0"
 
     \b
     # Deposit with explicit prefix override
     copick deposit -c config.json --target-dir /path/to/deposit \\
         --run-names "TS_001,TS_002" --run-name-prefix "custom_prefix_" \\
-        --picks-uris "*:*/*"
+        --picks "*:*/*"
 
     \b
     # Deposit with regex to extract run names
     copick deposit -c config.json --target-dir /path/to/deposit \\
-        --run-name-regex "^(TS_\\d+).*" --tomograms-uris "wbp@10.0"
+        --run-name-regex "^(TS_\\d+).*" --tomograms "wbp@10.0"
 
     \b
     # Multiple projects to same target (successive executions)
     copick deposit -c project1.json --target-dir /deposit --run-name-prefix "proj1_" \\
-        --picks-uris "*:*/*"
+        --picks "*:*/*"
     copick deposit -c project2.json --target-dir /deposit --run-name-prefix "proj2_" \\
-        --picks-uris "*:*/*"
+        --picks "*:*/*"
 
     Notes:
     - For data portal projects, run names are automatically transformed from portal run IDs
@@ -143,11 +143,11 @@ def deposit(
         run_names_list = [name.strip() for name in run_names.split(",") if name.strip()]
 
     # Convert tuple to list or None
-    picks_uris_list = list(picks_uris) if picks_uris else None
-    meshes_uris_list = list(meshes_uris) if meshes_uris else None
-    segmentations_uris_list = list(segmentations_uris) if segmentations_uris else None
-    tomograms_uris_list = list(tomograms_uris) if tomograms_uris else None
-    features_uris_list = list(features_uris) if features_uris else None
+    picks_uris_list = list(picks) if picks else None
+    meshes_uris_list = list(meshes) if meshes else None
+    segmentations_uris_list = list(segmentations) if segmentations else None
+    tomograms_uris_list = list(tomograms) if tomograms else None
+    features_uris_list = list(features) if features else None
 
     # Call the deposit operation
     deposit_op(
@@ -161,7 +161,7 @@ def deposit(
         segmentations_uris=segmentations_uris_list,
         tomograms_uris=tomograms_uris_list,
         features_uris=features_uris_list,
-        n_workers=n_workers,
+        n_workers=max_workers,
     )
 
     logger.info("Deposit operation completed successfully.")

--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -751,10 +751,16 @@ class CopickVoxelSpacingCDP(CopickVoxelSpacingOverlay):
 class CopickRunMetaCDP(CopickRunMeta):
     portal_run_id: Optional[int] = None
     portal_run_name: Optional[str] = None
+    portal_dataset_id: Optional[int] = None
 
     @classmethod
     def from_portal(cls, source: cdp.Run):
-        return cls(name=f"{source.id}", portal_run_id=source.id, portal_run_name=source.name)
+        return cls(
+            name=f"{source.id}",
+            portal_run_id=source.id,
+            portal_run_name=source.name,
+            portal_dataset_id=source.dataset_id,
+        )
 
 
 class CopickRunCDP(CopickRunOverlay):
@@ -788,6 +794,10 @@ class CopickRunCDP(CopickRunOverlay):
     @property
     def portal_run_name(self) -> str:
         return self.meta.name
+
+    @property
+    def portal_dataset_id(self) -> int:
+        return self.meta.portal_dataset_id
 
     def _query_static_voxel_spacings(self) -> List[CopickVoxelSpacingCDP]:
         # VoxelSpacings only added on overlay

--- a/src/copick/ops/deposit.py
+++ b/src/copick/ops/deposit.py
@@ -167,7 +167,7 @@ def deposit_run(
     if picks_uris is not None:
         for uri in picks_uris:
             try:
-                picks_list = resolve_copick_objects(uri, run.root, "pick", run.name)
+                picks_list = resolve_copick_objects(uri, run.root, "picks", run.name)
                 for pick in picks_list:
                     source = _get_file_path(pick)
                     filename = f"{pick.user_id}_{pick.session_id}_{pick.pickable_object_name}.json"

--- a/src/copick/ops/deposit.py
+++ b/src/copick/ops/deposit.py
@@ -157,7 +157,7 @@ def deposit_run(
             output_run_name = match.group(1)
         else:
             if logger:
-                logger.exception(f"Run name {run.name} does not match regex {run_name_regex}.")
+                logger.error(f"Run name {run.name} does not match regex {run_name_regex}.")
             raise ValueError(f"Run name {run.name} does not match regex {run_name_regex}.")
 
     # Construct the prefixed run name

--- a/src/copick/ops/deposit.py
+++ b/src/copick/ops/deposit.py
@@ -1,0 +1,364 @@
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import copick
+from copick.impl.cryoet_data_portal import (
+    CopickFeaturesCDP,
+    CopickMeshCDP,
+    CopickPicksCDP,
+    CopickRootCDP,
+    CopickSegmentationCDP,
+    CopickTomogramCDP,
+)
+from copick.impl.filesystem import (
+    CopickFeaturesFSSpec,
+    CopickMeshFSSpec,
+    CopickPicksFSSpec,
+    CopickSegmentationFSSpec,
+    CopickTomogramFSSpec,
+)
+from copick.models import CopickFeatures, CopickMesh, CopickPicks, CopickRun, CopickSegmentation, CopickTomogram
+from copick.ops.run import map_runs, report_results
+from copick.util.log import get_logger
+from copick.util.uri import resolve_copick_objects
+
+logger = get_logger(__name__)
+
+
+def _get_file_path(obj: Union[CopickPicks, CopickMesh, CopickSegmentation, CopickTomogram, CopickFeatures]) -> str:
+    """Extract the filesystem path from a copick object.
+
+    For FSSpec objects, returns the path property.
+    For CDP objects, returns the overlay path if writable, or raises an error if read-only
+    (since data on the portal cannot be symlinked).
+
+    Args:
+        obj: A copick object (picks, mesh, segmentation, tomogram, or features).
+
+    Returns:
+        str: The filesystem path to the object's data file.
+
+    Raises:
+        ValueError: If the object is read-only from the data portal and cannot be symlinked.
+    """
+    # FSSpec objects - straightforward path access
+    if isinstance(obj, (CopickPicksFSSpec, CopickMeshFSSpec, CopickSegmentationFSSpec)):
+        return obj.path
+    elif isinstance(obj, CopickTomogramFSSpec):
+        # For FSSpec tomograms, use static_path if read-only, overlay_path otherwise
+        return obj.static_path if obj.read_only else obj.overlay_path
+    elif isinstance(obj, CopickFeaturesFSSpec):
+        return obj.path
+
+    # CDP objects - need to check if they're writable
+    elif isinstance(obj, (CopickPicksCDP, CopickSegmentationCDP)):
+        if obj.read_only:
+            raise ValueError(
+                f"Cannot symlink read-only data portal object: {obj}. "
+                "Data portal objects must be in the overlay to be deposited.",
+            )
+        return obj.path
+    elif isinstance(obj, CopickMeshCDP):
+        if obj.read_only:
+            raise ValueError(
+                "Cannot symlink read-only data portal mesh. "
+                "Data portal does not store meshes on the portal; they must be in the overlay.",
+            )
+        return obj.path
+    elif isinstance(obj, CopickTomogramCDP):
+        if obj.read_only:
+            raise ValueError(
+                f"Cannot symlink read-only data portal tomogram: {obj}. "
+                "Portal tomograms must be downloaded to overlay first to be deposited.",
+            )
+        return obj.overlay_path
+    elif isinstance(obj, CopickFeaturesCDP):
+        if obj.read_only:
+            raise ValueError(
+                "Cannot symlink read-only data portal features. Data portal does not support features yet.",
+            )
+        return obj.path
+
+    else:
+        raise TypeError(f"Unknown copick object type: {type(obj).__name__}")
+
+
+def _create_symlink(source: str, target: str) -> None:
+    """Safely create a symlink, creating parent directories as needed.
+
+    Args:
+        source: The source path to link to.
+        target: The target path for the symlink.
+    """
+    target_path = Path(target)
+
+    # Create parent directories if they don't exist
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Skip if symlink already exists and points to the same source
+    if target_path.is_symlink():
+        if os.readlink(target_path) == source:
+            return
+        else:
+            logger.warning(f"Symlink {target} already exists pointing to {os.readlink(target_path)}, skipping")
+            return
+
+    # Skip if a file/directory already exists at target
+    if target_path.exists():
+        logger.warning(f"File or directory {target} already exists, skipping")
+        return
+
+    # Create the symlink
+    os.symlink(source, target)
+
+
+def deposit_run(
+    run: CopickRun,
+    target_dir: str,
+    run_name_prefix: str = "",
+    picks_uris: Optional[List[str]] = None,
+    meshes_uris: Optional[List[str]] = None,
+    segmentations_uris: Optional[List[str]] = None,
+    tomograms_uris: Optional[List[str]] = None,
+    features_uris: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Process a single run and create symlinks for specified objects in the target directory.
+
+    Args:
+        run: The copick run to process.
+        target_dir: The target directory for the deposited view.
+        run_name_prefix: Prefix to prepend to the run name (e.g., "ds123_rn001_").
+        picks_uris: List of URIs to filter picks. If None, skip picks entirely.
+        meshes_uris: List of URIs to filter meshes. If None, skip meshes entirely.
+        segmentations_uris: List of URIs to filter segmentations. If None, skip segmentations entirely.
+        tomograms_uris: List of URIs to filter tomograms. If None, skip tomograms entirely.
+        features_uris: List of URIs to filter features. If None, skip features entirely.
+
+    Returns:
+        Dict with keys:
+            - "processed": Number of objects successfully symlinked
+            - "errors": List of error messages
+    """
+    processed = 0
+    errors = []
+
+    # Construct the prefixed run name
+    prefixed_run_name = f"{run_name_prefix}{run.name}"
+    run_dir = Path(target_dir) / "ExperimentRuns" / prefixed_run_name
+
+    # Process picks
+    if picks_uris is not None:
+        for uri in picks_uris:
+            try:
+                picks_list = resolve_copick_objects(uri, run.root, "pick", run.name)
+                for pick in picks_list:
+                    source = _get_file_path(pick)
+                    filename = f"{pick.user_id}_{pick.session_id}_{pick.pickable_object_name}.json"
+                    target = run_dir / "Picks" / filename
+                    _create_symlink(source, str(target))
+                    processed += 1
+            except Exception as e:
+                errors.append(f"Error processing picks URI '{uri}': {e}")
+                logger.error(f"Error processing picks URI '{uri}'", exc_info=e)
+
+    # Process meshes
+    if meshes_uris is not None:
+        for uri in meshes_uris:
+            try:
+                meshes_list = resolve_copick_objects(uri, run.root, "mesh", run.name)
+                for mesh in meshes_list:
+                    source = _get_file_path(mesh)
+                    filename = f"{mesh.user_id}_{mesh.session_id}_{mesh.pickable_object_name}.glb"
+                    target = run_dir / "Meshes" / filename
+                    _create_symlink(source, str(target))
+                    processed += 1
+            except Exception as e:
+                errors.append(f"Error processing meshes URI '{uri}': {e}")
+                logger.error(f"Error processing meshes URI '{uri}'", exc_info=e)
+
+    # Process segmentations
+    if segmentations_uris is not None:
+        for uri in segmentations_uris:
+            try:
+                segs_list = resolve_copick_objects(uri, run.root, "segmentation", run.name)
+                for seg in segs_list:
+                    source = _get_file_path(seg)
+                    if seg.is_multilabel:
+                        filename = f"{seg.voxel_size:.3f}_{seg.user_id}_{seg.session_id}_{seg.name}-multilabel.zarr"
+                    else:
+                        filename = f"{seg.voxel_size:.3f}_{seg.user_id}_{seg.session_id}_{seg.name}.zarr"
+                    target = run_dir / "Segmentations" / filename
+                    _create_symlink(source, str(target))
+                    processed += 1
+            except Exception as e:
+                errors.append(f"Error processing segmentations URI '{uri}': {e}")
+                logger.error(f"Error processing segmentations URI '{uri}'", exc_info=e)
+
+    # Process tomograms
+    if tomograms_uris is not None:
+        for uri in tomograms_uris:
+            try:
+                tomos_list = resolve_copick_objects(uri, run.root, "tomogram", run.name)
+                for tomo in tomos_list:
+                    source = _get_file_path(tomo)
+                    voxel_dir = f"VoxelSpacing{tomo.voxel_spacing.voxel_size:.3f}"
+                    filename = f"{tomo.tomo_type}.zarr"
+                    target = run_dir / voxel_dir / filename
+                    _create_symlink(source, str(target))
+                    processed += 1
+            except Exception as e:
+                errors.append(f"Error processing tomograms URI '{uri}': {e}")
+                logger.error(f"Error processing tomograms URI '{uri}'", exc_info=e)
+
+    # Process features
+    if features_uris is not None:
+        for uri in features_uris:
+            try:
+                features_list = resolve_copick_objects(uri, run.root, "feature", run.name)
+                for feature in features_list:
+                    source = _get_file_path(feature)
+                    voxel_dir = f"VoxelSpacing{feature.tomogram.voxel_spacing.voxel_size:.3f}"
+                    filename = f"{feature.tomo_type}_{feature.feature_type}_features.zarr"
+                    target = run_dir / voxel_dir / filename
+                    _create_symlink(source, str(target))
+                    processed += 1
+            except Exception as e:
+                errors.append(f"Error processing features URI '{uri}': {e}")
+                logger.error(f"Error processing features URI '{uri}'", exc_info=e)
+
+    return {"processed": processed, "errors": errors}
+
+
+def deposit(
+    config: str,
+    target_dir: str,
+    run_names: Optional[List[str]] = None,
+    run_name_prefix: str = "",
+    picks_uris: Optional[List[str]] = None,
+    meshes_uris: Optional[List[str]] = None,
+    segmentations_uris: Optional[List[str]] = None,
+    tomograms_uris: Optional[List[str]] = None,
+    features_uris: Optional[List[str]] = None,
+    n_workers: int = 8,
+) -> None:
+    """Create a depositable view of a copick project using symlinks.
+
+    This function creates a hierarchical directory structure suitable for uploading to the
+    cryoET data portal. It operates on a single copick config and creates symlinks to the
+    actual data files, allowing multiple projects to be deposited into the same target
+    directory through successive executions.
+
+    Directory Structure Created:
+        <target_dir>/ExperimentRuns/<prefixed_run_name>/
+            Picks/{user_id}_{session_id}_{object_name}.json
+            Meshes/{user_id}_{session_id}_{object_name}.glb
+            Segmentations/{voxel_size:.3f}_{user_id}_{session_id}_{name}[-multilabel].zarr
+            VoxelSpacing{voxel_size:.3f}/
+                {tomo_type}.zarr
+                {tomo_type}_{feature_type}_features.zarr
+
+    Args:
+        config: Path to the copick configuration file.
+        target_dir: Target directory for the deposited view.
+        run_names: List of specific run names to process. If None, processes all runs.
+        run_name_prefix: Prefix to prepend to all run names. For data portal projects, if not
+            provided, automatically constructs "{dataset_id}_{portal_run_name}_" for each run.
+            For filesystem projects or when explicitly provided, uses the same prefix for all runs.
+        picks_uris: List of URIs to filter picks (e.g., ["proteasome:*/*", "ribosome:user1/*"]).
+            If None, skips picks entirely.
+        meshes_uris: List of URIs to filter meshes. If None, skips meshes entirely.
+        segmentations_uris: List of URIs to filter segmentations (e.g., ["membrane:*/*@10.0"]).
+            If None, skips segmentations entirely.
+        tomograms_uris: List of URIs to filter tomograms (e.g., ["wbp@10.0"]).
+            If None, skips tomograms entirely.
+        features_uris: List of URIs to filter features (e.g., ["wbp@10.0:cellcanvas"]).
+            If None, skips features entirely.
+        n_workers: Number of parallel workers for processing runs.
+
+    Examples:
+        # Deposit all runs from a filesystem project
+        deposit(
+            config="filesystem_config.json",
+            target_dir="/path/to/deposit",
+            picks_uris=["*:*/*"],  # All picks
+            meshes_uris=["*:*/*"],  # All meshes
+        )
+
+        # Deposit from a data portal project (automatic run name transformation)
+        # Runs will be named like: 10301_TS_001_<portal_run_id>
+        deposit(
+            config="portal_config.json",
+            target_dir="/path/to/deposit",
+            picks_uris=["proteasome:*/*", "ribosome:*/*"],
+            segmentations_uris=["membrane:*/*@10.0"],
+        )
+
+        # Deposit with explicit prefix override
+        deposit(
+            config="config.json",
+            target_dir="/path/to/deposit",
+            run_names=["TS_001", "TS_002"],
+            run_name_prefix="custom_prefix_",
+            picks_uris=["*:*/*"],
+        )
+
+        # Multiple projects to same target (successive executions)
+        deposit(config="project1.json", target_dir="/deposit", run_name_prefix="proj1_", ...)
+        deposit(config="project2.json", target_dir="/deposit", run_name_prefix="proj2_", ...)
+
+    Notes:
+        - For data portal projects, run names are automatically transformed from portal run IDs
+          to "{dataset_id}_{portal_run_name}_{portal_run_id}" unless run_name_prefix is provided.
+        - Multiple executions to the same target_dir are safe and idempotent.
+        - Symlinks that already exist and point to the correct source are skipped.
+        - Read-only data from the portal cannot be symlinked and will raise an error.
+    """
+    # Load the copick root
+    root = copick.from_file(config)
+
+    # Get the runs to process
+    runs = root.runs if run_names is None else [root.get_run(name) for name in run_names]
+
+    # For CDP projects, automatically construct run name prefixes from dataset_id and portal_run_name
+    # unless a prefix is explicitly provided
+    is_cdp = isinstance(root, CopickRootCDP)
+    run_prefixes = []
+    for run in runs:
+        if is_cdp and not run_name_prefix:
+            run_prefixes.append(f"{run.portal_dataset_id}_{run.portal_run_name}_")
+        elif run_name_prefix:
+            run_prefixes.append(run_name_prefix)
+        else:
+            run_prefixes.append("")
+
+    # Build run_args - each run gets its own prefix
+    run_args = [
+        {
+            "target_dir": target_dir,
+            "run_name_prefix": prefix,
+            "picks_uris": picks_uris,
+            "meshes_uris": meshes_uris,
+            "segmentations_uris": segmentations_uris,
+            "tomograms_uris": tomograms_uris,
+            "features_uris": features_uris,
+        }
+        for prefix in run_prefixes
+    ]
+
+    # Process runs in parallel
+    results = map_runs(
+        callback=deposit_run,
+        root=root,
+        runs=runs,
+        workers=n_workers,
+        run_args=run_args,
+        show_progress=True,
+        task_desc="Depositing runs",
+    )
+
+    # Calculate total files that should have been processed
+    total_files = sum(r["processed"] for r in results.values() if r is not None)
+
+    # Report results
+    report_results(results, total_files, logger)

--- a/src/copick/util/uri.py
+++ b/src/copick/util/uri.py
@@ -1,0 +1,694 @@
+import fnmatch
+import re
+from typing import Any, Dict, List, Optional, Union
+from urllib.parse import parse_qs
+
+from copick.models import (
+    CopickFeatures,
+    CopickMesh,
+    CopickPicks,
+    CopickRoot,
+    CopickRun,
+    CopickSegmentation,
+    CopickTomogram,
+)
+
+# ============================================================================
+# URI Parsing
+# ============================================================================
+
+
+def parse_copick_uri(uri: str, object_type: str) -> Dict[str, Any]:
+    """Parse a copick object URI according to the copick URI schemes.
+
+    URI Schemes:
+    - Picks: object_name:user_id/session_id
+    - Meshes: object_name:user_id/session_id
+    - Segmentations: name:user_id/session_id@voxel_spacing?multilabel=true
+    - Tomogram: tomo_type@voxel_spacing
+    - Feature: tomo_type@voxel_spacing:feature_type
+
+    Pattern Support:
+    - Glob patterns by default (e.g., 'mt*:user*/session*')
+    - Use 're:' prefix for regex patterns (e.g., 're:mt.*:user_\\d+/session_\\d+')
+    - Incomplete patterns match everything (e.g., 'mt:user' → 'mt:user/*')
+    - Missing components become wildcards (e.g., 'mt' for picks → 'mt:*/*')
+
+    Args:
+        uri (str): The copick URI to parse.
+        object_type (str): Type of object ('pick', 'mesh', 'segmentation', 'tomogram', 'feature').
+
+    Returns:
+        Dict[str, Any]: A dictionary containing the parsed components.
+                       Includes 'pattern_type' field ('glob' or 'regex').
+
+    Raises:
+        ValueError: If the URI format is invalid or object_type is unknown.
+    """
+    # Remove any leading/trailing whitespace
+    uri = uri.strip()
+
+    # Check for regex prefix
+    pattern_type = "glob"
+    if uri.startswith("re:"):
+        pattern_type = "regex"
+        uri = uri[3:]  # Remove 're:' prefix
+
+    # Handle query parameters (for segmentations)
+    query_params = {}
+    if "?" in uri:
+        uri, query_string = uri.split("?", 1)
+        query_params = parse_qs(query_string)
+        # Flatten single-value lists
+        query_params = {k: v[0] if len(v) == 1 else v for k, v in query_params.items()}
+
+    if object_type in ("pick", "mesh"):
+        # Pattern: object_name:user_id/session_id
+        # Support incomplete patterns: 'obj' → 'obj:*/*', 'obj:user' → 'obj:user/*'
+        parts = uri.split(":")
+        if len(parts) == 1:
+            # Just object_name
+            object_name = parts[0]
+            user_id = "*"
+            session_id = "*"
+        elif len(parts) == 2:
+            object_name = parts[0]
+            session_part = parts[1]
+            if "/" in session_part:
+                user_id, session_id = session_part.split("/", 1)
+            else:
+                user_id = session_part
+                session_id = "*"
+        else:
+            raise ValueError(f"Invalid {object_type} URI format: '{uri}'")
+
+        return {
+            "object_type": object_type,
+            "pattern_type": pattern_type,
+            "object_name": object_name,
+            "user_id": user_id,
+            "session_id": session_id,
+        }
+
+    elif object_type == "segmentation":
+        # Pattern: name:user_id/session_id@voxel_spacing
+        # Support incomplete: 'name' → 'name:*/*@*', 'name:user' → 'name:user/*@*', etc.
+
+        # Split by @ first to get voxel_spacing
+        if "@" in uri:
+            main_part, voxel_spacing = uri.split("@", 1)
+        else:
+            main_part = uri
+            voxel_spacing = "*"
+
+        # Now parse the main part
+        parts = main_part.split(":")
+        if len(parts) == 1:
+            name = parts[0]
+            user_id = "*"
+            session_id = "*"
+        elif len(parts) == 2:
+            name = parts[0]
+            session_part = parts[1]
+            if "/" in session_part:
+                user_id, session_id = session_part.split("/", 1)
+            else:
+                user_id = session_part
+                session_id = "*"
+        else:
+            raise ValueError(f"Invalid segmentation URI format: '{uri}'")
+
+        result = {
+            "object_type": "segmentation",
+            "pattern_type": pattern_type,
+            "name": name,
+            "user_id": user_id,
+            "session_id": session_id,
+            "voxel_spacing": voxel_spacing,
+            "multilabel": None,  # Default value (matches both multilabel and non-multilabel)
+        }
+
+        # Check for multilabel parameter
+        if "multilabel" in query_params:
+            multilabel_val = query_params["multilabel"].lower()
+            result["multilabel"] = multilabel_val in ("true", "1", "yes")
+
+        return result
+
+    elif object_type == "tomogram":
+        # Pattern: tomo_type@voxel_spacing
+        # Support incomplete: 'tomo' → 'tomo@*'
+        if "@" in uri:
+            tomo_type, voxel_spacing = uri.split("@", 1)
+        else:
+            tomo_type = uri
+            voxel_spacing = "*"
+
+        return {
+            "object_type": "tomogram",
+            "pattern_type": pattern_type,
+            "tomo_type": tomo_type,
+            "voxel_spacing": voxel_spacing,
+        }
+
+    elif object_type == "feature":
+        # Pattern: tomo_type@voxel_spacing:feature_type
+        # Support incomplete: 'tomo' → 'tomo@*:*', 'tomo@10' → 'tomo@10:*'
+
+        # Split by @ first
+        if "@" in uri:
+            tomo_type, rest = uri.split("@", 1)
+            # Now check if we have feature_type
+            if ":" in rest:
+                voxel_spacing, feature_type = rest.split(":", 1)
+            else:
+                voxel_spacing = rest
+                feature_type = "*"
+        else:
+            tomo_type = uri
+            voxel_spacing = "*"
+            feature_type = "*"
+
+        return {
+            "object_type": "feature",
+            "pattern_type": pattern_type,
+            "tomo_type": tomo_type,
+            "voxel_spacing": voxel_spacing,
+            "feature_type": feature_type,
+        }
+
+    else:
+        raise ValueError(
+            f"Unknown object type: {object_type}. Must be one of: pick, mesh, segmentation, tomogram, feature",
+        )
+
+
+# ============================================================================
+# URI Serialization
+# ============================================================================
+
+
+def serialize_copick_uri(
+    obj: Union[CopickPicks, CopickMesh, CopickSegmentation, CopickTomogram, CopickFeatures],
+) -> str:
+    """Serialize a copick object to its URI representation.
+
+    Args:
+        obj: A copick object (CopickPicks, CopickMesh, CopickSegmentation, CopickTomogram, or CopickFeatures).
+
+    Returns:
+        str: The URI representation of the object.
+
+    Raises:
+        ValueError: If the object type is not recognized.
+    """
+    if isinstance(obj, (CopickPicks, CopickMesh)):
+        return f"{obj.pickable_object_name}:{obj.user_id}/{obj.session_id}"
+
+    elif isinstance(obj, CopickSegmentation):
+        uri = f"{obj.name}:{obj.user_id}/{obj.session_id}@{obj.voxel_size}"
+        if obj.is_multilabel:
+            uri += "?multilabel=true"
+        return uri
+
+    elif isinstance(obj, CopickTomogram):
+        return f"{obj.tomo_type}@{obj.voxel_spacing.voxel_size}"
+
+    elif isinstance(obj, CopickFeatures):
+        return f"{obj.tomo_type}@{obj.tomogram.voxel_spacing.voxel_size}:{obj.feature_type}"
+
+    else:
+        raise ValueError(f"Unknown copick object type: {type(obj).__name__}")
+
+
+def serialize_copick_uri_from_dict(
+    object_type: str,
+    object_name: Optional[str] = None,
+    name: Optional[str] = None,
+    user_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    tomo_type: Optional[str] = None,
+    voxel_spacing: Optional[float] = None,
+    feature_type: Optional[str] = None,
+    multilabel: Optional[bool] = None,
+) -> str:
+    """Serialize copick object parameters into a URI according to copick URI schemes.
+
+    Args:
+        object_type (str): Type of copick object ('pick', 'mesh', 'segmentation', 'tomogram', 'feature')
+        object_name (str, optional): Object name for picks/meshes
+        name (str, optional): Name for segmentations
+        user_id (str, optional): User ID for picks/meshes/segmentations
+        session_id (str, optional): Session ID for picks/meshes/segmentations
+        tomo_type (str, optional): Tomogram type for tomograms/features
+        voxel_spacing (float, optional): Voxel spacing for segmentations/tomograms/features
+        feature_type (str, optional): Feature type for features
+        multilabel (bool, optional): Whether segmentation is multilabel
+
+    Returns:
+        str: The serialized copick URI
+
+    Raises:
+        ValueError: If required parameters are missing for the given object type
+    """
+    if object_type == "pick":
+        if not all([object_name, user_id, session_id]):
+            raise ValueError("Picks require object_name, user_id, and session_id")
+        return f"{object_name}:{user_id}/{session_id}"
+
+    elif object_type == "mesh":
+        if not all([object_name, user_id, session_id]):
+            raise ValueError("Meshes require object_name, user_id, and session_id")
+        return f"{object_name}:{user_id}/{session_id}"
+
+    elif object_type == "segmentation":
+        if not all([name, user_id, session_id, voxel_spacing is not None]):
+            raise ValueError("Segmentations require name, user_id, session_id, and voxel_spacing")
+        uri = f"{name}:{user_id}/{session_id}@{voxel_spacing}"
+        if multilabel is True:
+            uri += "?multilabel=true"
+        return uri
+
+    elif object_type == "tomogram":
+        if not all([tomo_type, voxel_spacing is not None]):
+            raise ValueError("Tomograms require tomo_type and voxel_spacing")
+        return f"{tomo_type}@{voxel_spacing}"
+
+    elif object_type == "feature":
+        if not all([tomo_type, voxel_spacing is not None, feature_type]):
+            raise ValueError("Features require tomo_type, voxel_spacing, and feature_type")
+        return f"{tomo_type}@{voxel_spacing}:{feature_type}"
+
+    else:
+        raise ValueError(f"Unknown object type: {object_type}")
+
+
+# ============================================================================
+# Object Resolution (Public API)
+# ============================================================================
+
+
+def resolve_copick_objects(
+    uri: str,
+    root: "CopickRoot",
+    object_type: str,
+    run_name: Optional[str] = None,
+) -> List[Union["CopickPicks", "CopickMesh", "CopickSegmentation", "CopickTomogram", "CopickFeatures"]]:
+    """Resolve a copick URI to actual copick objects.
+
+    This function parses a URI string and delegates to get_copick_objects_by_type()
+    for the actual filtering logic.
+
+    Args:
+        uri (str): The copick URI to resolve.
+        root (CopickRoot): The copick root to search in.
+        object_type (str): Type of object ('pick', 'mesh', 'segmentation', 'tomogram', 'feature').
+        run_name (str, optional): Specific run name to search in. If None, searches all runs.
+
+    Returns:
+        List: List of matching copick objects.
+
+    Raises:
+        ValueError: If the URI is invalid or object_type is invalid.
+    """
+    # Parse the URI to extract filter parameters
+    parsed = parse_copick_uri(uri, object_type)
+
+    # Remove object_type and pattern_type from parsed dict as they're not needed by get_copick_objects_by_type
+    parsed.pop("object_type", None)
+
+    # Delegate to get_copick_objects_by_type with the parsed filters
+    return get_copick_objects_by_type(root, object_type, run_name, **parsed)
+
+
+def get_copick_objects_by_type(
+    root: "CopickRoot",
+    object_type: str,
+    run_name: Optional[str] = None,
+    **filters,
+) -> List[Union["CopickPicks", "CopickMesh", "CopickSegmentation", "CopickTomogram", "CopickFeatures"]]:
+    """Get copick objects by type with optional filters.
+
+    This is a convenience function that provides a more direct way to query objects
+    without needing to construct URIs. Uses CopickRun's built-in get_* methods when
+    possible for exact matches, falls back to pattern matching only when needed.
+
+    Args:
+        root (CopickRoot): The copick root to search in.
+        object_type (str): The type of objects to retrieve ('pick', 'mesh', 'segmentation', 'tomogram', 'feature').
+        run_name (str, optional): Specific run name to search in.
+        **filters: Additional filters based on object type.
+                  For picks/meshes: object_name, user_id, session_id
+                  For segmentations: name, user_id, session_id, voxel_spacing, multilabel
+                  For tomograms: tomo_type, voxel_spacing
+                  For features: tomo_type, voxel_spacing, feature_type
+
+    Returns:
+        List: List of matching copick objects.
+
+    Raises:
+        ValueError: If the object_type is invalid or required filters are missing.
+    """
+    # Get runs to search
+    runs_to_search = []
+    if run_name:
+        run = root.get_run(run_name)
+        if run is None:
+            raise ValueError(f"Run '{run_name}' not found")
+        runs_to_search = [run]
+    else:
+        runs_to_search = root.runs
+
+    # Dispatch to type-specific handler
+    handlers = {
+        "pick": _get_picks_from_runs,
+        "mesh": _get_meshes_from_runs,
+        "segmentation": _get_segmentations_from_runs,
+        "tomogram": _get_tomograms_from_runs,
+        "feature": _get_features_from_runs,
+    }
+
+    if object_type not in handlers:
+        raise ValueError(
+            f"Unknown object type: {object_type}. Must be one of: pick, mesh, segmentation, tomogram, feature",
+        )
+
+    return handlers[object_type](runs_to_search, filters)
+
+
+# ============================================================================
+# Pattern Matching Helpers (Private)
+# ============================================================================
+
+
+def _is_pattern(value: str, pattern_type: str) -> bool:
+    """Check if a value is actually a pattern (not just a literal string).
+
+    Args:
+        value: The value to check.
+        pattern_type: Either "glob" or "regex".
+
+    Returns:
+        bool: True if the value is a pattern that requires matching.
+    """
+    if value == "*":
+        return True
+    if pattern_type == "regex":
+        return True  # Regex is always treated as a pattern
+    # Check for glob wildcards
+    return "*" in value or "?" in value or "[" in value
+
+
+def _matches_pattern(value: str, pattern: str, pattern_type: str) -> bool:
+    """Check if a value matches a pattern based on pattern type."""
+    # Wildcard matches everything
+    if pattern == "*":
+        return True
+
+    if pattern_type == "glob":
+        return fnmatch.fnmatch(value, pattern)
+    elif pattern_type == "regex":
+        try:
+            return re.match(pattern, value) is not None
+        except re.error as e:
+            raise ValueError(f"Invalid regex pattern '{pattern}': {e}") from e
+    else:
+        raise ValueError(f"Unknown pattern type: {pattern_type}")
+
+
+def _matches_numeric_pattern(value: Union[str, float], pattern: str, pattern_type: str) -> bool:
+    """Check if a numeric value matches a pattern."""
+    # Wildcard matches everything
+    if pattern == "*":
+        return True
+
+    if pattern_type == "glob":
+        # For exact numeric comparison, try to match as numbers
+        try:
+            return float(value) == float(pattern)
+        except (ValueError, TypeError):
+            # Fall back to string matching for non-numeric patterns
+            return _matches_pattern(str(value), pattern, pattern_type)
+    else:
+        # For regex, convert value to string for matching
+        return _matches_pattern(str(value), pattern, pattern_type)
+
+
+# ============================================================================
+# Type-Specific Object Handlers (Private)
+# ============================================================================
+
+
+def _get_picks_from_runs(
+    runs: List["CopickRun"],
+    filters: Dict[str, Any],
+) -> List["CopickPicks"]:
+    """Get picks using CopickRun.get_picks when possible for exact matches.
+
+    Args:
+        runs: List of runs to search.
+        filters: Filter dictionary with optional keys: object_name, user_id, session_id, pattern_type.
+
+    Returns:
+        List of matching picks.
+    """
+    results = []
+    pattern_type = filters.get("pattern_type", "glob")
+    object_name = filters.get("object_name")
+    user_id = filters.get("user_id")
+    session_id = filters.get("session_id")
+
+    # Check if we can use the built-in get_picks method (no patterns)
+    use_builtin = (
+        not (object_name and _is_pattern(object_name, pattern_type))
+        and not (user_id and _is_pattern(user_id, pattern_type))
+        and not (session_id and _is_pattern(session_id, pattern_type))
+    )
+
+    if use_builtin:
+        # Use the built-in filtering - much cleaner!
+        for run in runs:
+            picks = run.get_picks(
+                object_name=None if object_name == "*" else object_name,
+                user_id=None if user_id == "*" else user_id,
+                session_id=None if session_id == "*" else session_id,
+            )
+            results.extend(picks)
+    else:
+        # Need pattern matching
+        for run in runs:
+            for pick in run.picks:
+                if (
+                    (not object_name or _matches_pattern(pick.pickable_object_name, object_name, pattern_type))
+                    and (not user_id or _matches_pattern(pick.user_id, user_id, pattern_type))
+                    and (not session_id or _matches_pattern(pick.session_id, session_id, pattern_type))
+                ):
+                    results.append(pick)
+
+    return results
+
+
+def _get_meshes_from_runs(
+    runs: List["CopickRun"],
+    filters: Dict[str, Any],
+) -> List["CopickMesh"]:
+    """Get meshes using CopickRun.get_meshes when possible for exact matches.
+
+    Args:
+        runs: List of runs to search.
+        filters: Filter dictionary with optional keys: object_name, user_id, session_id, pattern_type.
+
+    Returns:
+        List of matching meshes.
+    """
+    results = []
+    pattern_type = filters.get("pattern_type", "glob")
+    object_name = filters.get("object_name")
+    user_id = filters.get("user_id")
+    session_id = filters.get("session_id")
+
+    # Check if we can use the built-in get_meshes method (no patterns)
+    use_builtin = (
+        not (object_name and _is_pattern(object_name, pattern_type))
+        and not (user_id and _is_pattern(user_id, pattern_type))
+        and not (session_id and _is_pattern(session_id, pattern_type))
+    )
+
+    if use_builtin:
+        # Use the built-in filtering
+        for run in runs:
+            meshes = run.get_meshes(
+                object_name=None if object_name == "*" else object_name,
+                user_id=None if user_id == "*" else user_id,
+                session_id=None if session_id == "*" else session_id,
+            )
+            results.extend(meshes)
+    else:
+        # Need pattern matching
+        for run in runs:
+            for mesh in run.meshes:
+                if (
+                    (not object_name or _matches_pattern(mesh.pickable_object_name, object_name, pattern_type))
+                    and (not user_id or _matches_pattern(mesh.user_id, user_id, pattern_type))
+                    and (not session_id or _matches_pattern(mesh.session_id, session_id, pattern_type))
+                ):
+                    results.append(mesh)
+
+    return results
+
+
+def _get_segmentations_from_runs(
+    runs: List["CopickRun"],
+    filters: Dict[str, Any],
+) -> List["CopickSegmentation"]:
+    """Get segmentations using CopickRun.get_segmentations when possible for exact matches.
+
+    Args:
+        runs: List of runs to search.
+        filters: Filter dictionary with optional keys: name, user_id, session_id, voxel_spacing, multilabel, pattern_type.
+
+    Returns:
+        List of matching segmentations.
+    """
+    results = []
+    pattern_type = filters.get("pattern_type", "glob")
+    name = filters.get("name")
+    user_id = filters.get("user_id")
+    session_id = filters.get("session_id")
+    voxel_spacing = filters.get("voxel_spacing")
+    multilabel = filters.get("multilabel")
+
+    # Check if we need pattern matching
+    use_builtin = (
+        not (name and _is_pattern(name, pattern_type))
+        and not (user_id and _is_pattern(user_id, pattern_type))
+        and not (session_id and _is_pattern(session_id, pattern_type))
+        and not (voxel_spacing and isinstance(voxel_spacing, str) and _is_pattern(voxel_spacing, pattern_type))
+    )
+
+    if use_builtin:
+        # Use built-in filtering
+        for run in runs:
+            # Convert voxel_spacing to float if it's not a wildcard
+            vs_value = None
+            if voxel_spacing and voxel_spacing != "*":
+                try:
+                    vs_value = float(voxel_spacing)
+                except (ValueError, TypeError):
+                    vs_value = None
+
+            segs = run.get_segmentations(
+                name=None if name == "*" else name,
+                user_id=None if user_id == "*" else user_id,
+                session_id=None if session_id == "*" else session_id,
+                is_multilabel=multilabel,
+                voxel_size=vs_value,
+            )
+            results.extend(segs)
+    else:
+        # Pattern matching needed
+        for run in runs:
+            for seg in run.segmentations:
+                if (
+                    (not name or _matches_pattern(seg.name, name, pattern_type))
+                    and (not user_id or _matches_pattern(seg.user_id, user_id, pattern_type))
+                    and (not session_id or _matches_pattern(seg.session_id, session_id, pattern_type))
+                    and (not voxel_spacing or _matches_numeric_pattern(seg.voxel_size, voxel_spacing, pattern_type))
+                    and (multilabel is None or seg.is_multilabel == multilabel)
+                ):
+                    results.append(seg)
+
+    return results
+
+
+def _get_tomograms_from_runs(
+    runs: List["CopickRun"],
+    filters: Dict[str, Any],
+) -> List["CopickTomogram"]:
+    """Get tomograms with optional filtering.
+
+    Args:
+        runs: List of runs to search.
+        filters: Filter dictionary with optional keys: tomo_type, voxel_spacing, pattern_type.
+
+    Returns:
+        List of matching tomograms.
+    """
+    results = []
+    pattern_type = filters.get("pattern_type", "glob")
+    tomo_type = filters.get("tomo_type")
+    voxel_spacing = filters.get("voxel_spacing")
+
+    for run in runs:
+        for vs in run.voxel_spacings:
+            # Skip if voxel_spacing filter doesn't match
+            if voxel_spacing and not _matches_numeric_pattern(vs.voxel_size, voxel_spacing, pattern_type):
+                continue
+
+            # Get tomograms (use built-in method if not a pattern)
+            if tomo_type and not _is_pattern(tomo_type, pattern_type):
+                # Exact match - use built-in get_tomograms
+                tomos = vs.get_tomograms(tomo_type)
+            else:
+                # Need pattern matching or get all
+                tomos = [
+                    t for t in vs.tomograms if not tomo_type or _matches_pattern(t.tomo_type, tomo_type, pattern_type)
+                ]
+
+            results.extend(tomos)
+
+    return results
+
+
+def _get_features_from_runs(
+    runs: List["CopickRun"],
+    filters: Dict[str, Any],
+) -> List["CopickFeatures"]:
+    """Get features with simplified nesting and use of built-in methods.
+
+    Args:
+        runs: List of runs to search.
+        filters: Filter dictionary with optional keys: tomo_type, voxel_spacing, feature_type, pattern_type.
+
+    Returns:
+        List of matching features.
+    """
+    results = []
+    pattern_type = filters.get("pattern_type", "glob")
+    tomo_type = filters.get("tomo_type")
+    voxel_spacing = filters.get("voxel_spacing")
+    feature_type = filters.get("feature_type")
+
+    for run in runs:
+        for vs in run.voxel_spacings:
+            # Skip if voxel_spacing filter doesn't match
+            if voxel_spacing and not _matches_numeric_pattern(vs.voxel_size, voxel_spacing, pattern_type):
+                continue
+
+            # Get tomograms (use built-in method if not a pattern)
+            if tomo_type and not _is_pattern(tomo_type, pattern_type):
+                # Exact match - use built-in get_tomograms
+                tomos = vs.get_tomograms(tomo_type)
+            else:
+                # Need pattern matching or get all
+                tomos = [
+                    t for t in vs.tomograms if not tomo_type or _matches_pattern(t.tomo_type, tomo_type, pattern_type)
+                ]
+
+            for tomo in tomos:
+                # Get features (use built-in method if not a pattern)
+                if feature_type and not _is_pattern(feature_type, pattern_type):
+                    # Exact match
+                    feat = tomo.get_features(feature_type)
+                    if feat:
+                        results.append(feat)
+                else:
+                    # Pattern matching or get all
+                    features = [
+                        f
+                        for f in tomo.features
+                        if not feature_type or _matches_pattern(f.feature_type, feature_type, pattern_type)
+                    ]
+                    results.extend(features)
+
+    return results

--- a/src/copick/util/uri.py
+++ b/src/copick/util/uri.py
@@ -36,7 +36,7 @@ def parse_copick_uri(uri: str, object_type: str) -> Dict[str, Any]:
 
     Args:
         uri (str): The copick URI to parse.
-        object_type (str): Type of object ('pick', 'mesh', 'segmentation', 'tomogram', 'feature').
+        object_type (str): Type of object ('picks', 'mesh', 'segmentation', 'tomogram', 'feature').
 
     Returns:
         Dict[str, Any]: A dictionary containing the parsed components.
@@ -62,7 +62,7 @@ def parse_copick_uri(uri: str, object_type: str) -> Dict[str, Any]:
         # Flatten single-value lists
         query_params = {k: v[0] if len(v) == 1 else v for k, v in query_params.items()}
 
-    if object_type in ("pick", "mesh"):
+    if object_type in ("picks", "mesh"):
         # Pattern: object_name:user_id/session_id
         # Support incomplete patterns: 'obj' → 'obj:*/*', 'obj:user' → 'obj:user/*'
         parts = uri.split(":")
@@ -179,7 +179,7 @@ def parse_copick_uri(uri: str, object_type: str) -> Dict[str, Any]:
 
     else:
         raise ValueError(
-            f"Unknown object type: {object_type}. Must be one of: pick, mesh, segmentation, tomogram, feature",
+            f"Unknown object type: {object_type}. Must be one of: picks, mesh, segmentation, tomogram, feature",
         )
 
 
@@ -235,7 +235,7 @@ def serialize_copick_uri_from_dict(
     """Serialize copick object parameters into a URI according to copick URI schemes.
 
     Args:
-        object_type (str): Type of copick object ('pick', 'mesh', 'segmentation', 'tomogram', 'feature')
+        object_type (str): Type of copick object ('picks', 'mesh', 'segmentation', 'tomogram', 'feature')
         object_name (str, optional): Object name for picks/meshes
         name (str, optional): Name for segmentations
         user_id (str, optional): User ID for picks/meshes/segmentations
@@ -251,7 +251,7 @@ def serialize_copick_uri_from_dict(
     Raises:
         ValueError: If required parameters are missing for the given object type
     """
-    if object_type == "pick":
+    if object_type == "picks":
         if not all([object_name, user_id, session_id]):
             raise ValueError("Picks require object_name, user_id, and session_id")
         return f"{object_name}:{user_id}/{session_id}"
@@ -302,7 +302,7 @@ def resolve_copick_objects(
     Args:
         uri (str): The copick URI to resolve.
         root (CopickRoot): The copick root to search in.
-        object_type (str): Type of object ('pick', 'mesh', 'segmentation', 'tomogram', 'feature').
+        object_type (str): Type of object ('picks', 'mesh', 'segmentation', 'tomogram', 'feature').
         run_name (str, optional): Specific run name to search in. If None, searches all runs.
 
     Returns:
@@ -335,7 +335,7 @@ def get_copick_objects_by_type(
 
     Args:
         root (CopickRoot): The copick root to search in.
-        object_type (str): The type of objects to retrieve ('pick', 'mesh', 'segmentation', 'tomogram', 'feature').
+        object_type (str): The type of objects to retrieve ('picks', 'mesh', 'segmentation', 'tomogram', 'feature').
         run_name (str, optional): Specific run name to search in.
         **filters: Additional filters based on object type.
                   For picks/meshes: object_name, user_id, session_id
@@ -361,7 +361,7 @@ def get_copick_objects_by_type(
 
     # Dispatch to type-specific handler
     handlers = {
-        "pick": _get_picks_from_runs,
+        "picks": _get_picks_from_runs,
         "mesh": _get_meshes_from_runs,
         "segmentation": _get_segmentations_from_runs,
         "tomogram": _get_tomograms_from_runs,
@@ -370,7 +370,7 @@ def get_copick_objects_by_type(
 
     if object_type not in handlers:
         raise ValueError(
-            f"Unknown object type: {object_type}. Must be one of: pick, mesh, segmentation, tomogram, feature",
+            f"Unknown object type: {object_type}. Must be one of: picks, mesh, segmentation, tomogram, feature",
         )
 
     return handlers[object_type](runs_to_search, filters)

--- a/tests/test_deposit.py
+++ b/tests/test_deposit.py
@@ -1,0 +1,513 @@
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+# Use the existing CLEANUP setting from conftest
+from conftest import CLEANUP
+from copick.ops.deposit import deposit
+
+
+def _count_symlinks(directory: Path) -> int:
+    """Count total number of symlinks in a directory recursively."""
+    count = 0
+    if not directory.exists():
+        return count
+    for item in directory.rglob("*"):
+        if item.is_symlink():
+            count += 1
+    return count
+
+
+def _verify_symlink_target(symlink_path: Path, source_root: Path) -> bool:
+    """Verify that a symlink points to a valid file in the source root."""
+    if not symlink_path.is_symlink():
+        return False
+    target = symlink_path.resolve()
+    if not target.exists():
+        return False
+    # Check if target is within source root
+    try:
+        target.relative_to(source_root)
+        return True
+    except ValueError:
+        return False
+
+
+def _get_deposited_runs(target_dir: Path) -> list:
+    """Get list of run names in the deposit directory."""
+    exp_runs_dir = target_dir / "ExperimentRuns"
+    if not exp_runs_dir.exists():
+        return []
+    return [d.name for d in exp_runs_dir.iterdir() if d.is_dir()]
+
+
+def _check_directory_structure(target_dir: Path, expected_runs: list) -> bool:
+    """Verify the deposit directory structure matches expectations."""
+    exp_runs_dir = target_dir / "ExperimentRuns"
+    if not exp_runs_dir.exists():
+        return False
+
+    deposited_runs = _get_deposited_runs(target_dir)
+    return set(deposited_runs) == set(expected_runs)
+
+
+@pytest.fixture(params=pytest.common_cases)
+def test_payload(request) -> Dict[str, Any]:
+    """Reuse the existing test payload fixture."""
+    from copick.impl.filesystem import CopickRootFSSpec
+
+    payload = request.getfixturevalue(request.param)
+    payload["root"] = CopickRootFSSpec.from_file(payload["cfg_file"])
+    return payload
+
+
+def test_deposit_basic_picks_and_meshes(test_payload: Dict[str, Any]):
+    """Test basic deposit with all picks and meshes."""
+    temp_deposit = Path(tempfile.mkdtemp())
+
+    try:
+        deposit(
+            config=str(test_payload["cfg_file"]),
+            target_dir=str(temp_deposit),
+            picks_uris=["*:*/*"],
+            meshes_uris=["*:*/*"],
+            n_workers=4,
+        )
+
+        # Verify ExperimentRuns directory exists
+        assert (temp_deposit / "ExperimentRuns").exists(), "ExperimentRuns directory not created"
+
+        # Verify all runs are deposited
+        deposited_runs = _get_deposited_runs(temp_deposit)
+        assert "TS_001" in deposited_runs, "TS_001 not deposited"
+        assert "TS_002" in deposited_runs, "TS_002 not deposited"
+        assert "TS_003" in deposited_runs, "TS_003 not deposited"
+
+        # Verify picks directory and symlinks for TS_001
+        picks_dir = temp_deposit / "ExperimentRuns" / "TS_001" / "Picks"
+        assert picks_dir.exists(), "Picks directory not created for TS_001"
+
+        picks = list(picks_dir.glob("*.json"))
+        assert len(picks) > 0, "No picks deposited for TS_001"
+
+        # Verify all picks are symlinks
+        for pick in picks:
+            assert pick.is_symlink(), f"{pick.name} is not a symlink"
+            assert pick.resolve().exists(), f"Symlink target for {pick.name} does not exist"
+
+        # Verify meshes directory and symlinks for TS_001
+        meshes_dir = temp_deposit / "ExperimentRuns" / "TS_001" / "Meshes"
+        assert meshes_dir.exists(), "Meshes directory not created for TS_001"
+
+        meshes = list(meshes_dir.glob("*.glb"))
+        assert len(meshes) > 0, "No meshes deposited for TS_001"
+
+        # Verify all meshes are symlinks
+        for mesh in meshes:
+            assert mesh.is_symlink(), f"{mesh.name} is not a symlink"
+            assert mesh.resolve().exists(), f"Symlink target for {mesh.name} does not exist"
+
+    finally:
+        if CLEANUP:
+            shutil.rmtree(temp_deposit)
+
+
+def test_deposit_filtered_picks_by_object(test_payload: Dict[str, Any]):
+    """Test deposit with filtered picks by object name."""
+    temp_deposit = Path(tempfile.mkdtemp())
+
+    try:
+        deposit(
+            config=str(test_payload["cfg_file"]),
+            target_dir=str(temp_deposit),
+            picks_uris=["proteasome:*/*"],  # Only proteasome picks
+            n_workers=4,
+        )
+
+        # Verify TS_001 picks
+        picks_dir = temp_deposit / "ExperimentRuns" / "TS_001" / "Picks"
+        if picks_dir.exists():
+            picks = list(picks_dir.glob("*.json"))
+
+            # All picks should contain "proteasome" in name
+            for pick in picks:
+                assert "proteasome" in pick.name, f"Non-proteasome pick found: {pick.name}"
+
+    finally:
+        if CLEANUP:
+            shutil.rmtree(temp_deposit)
+
+
+def test_deposit_filtered_picks_by_user(test_payload: Dict[str, Any]):
+    """Test deposit with filtered picks by user."""
+    temp_deposit = Path(tempfile.mkdtemp())
+
+    try:
+        deposit(
+            config=str(test_payload["cfg_file"]),
+            target_dir=str(temp_deposit),
+            picks_uris=["*:gapstop/*"],  # Only gapstop user
+            n_workers=4,
+        )
+
+        # Verify TS_001 picks
+        picks_dir = temp_deposit / "ExperimentRuns" / "TS_001" / "Picks"
+        if picks_dir.exists():
+            picks = list(picks_dir.glob("*.json"))
+
+            # All picks should start with "gapstop"
+            for pick in picks:
+                assert pick.name.startswith("gapstop_"), f"Non-gapstop pick found: {pick.name}"
+
+    finally:
+        if CLEANUP:
+            shutil.rmtree(temp_deposit)
+
+
+def test_deposit_segmentations_with_voxel_size(test_payload: Dict[str, Any]):
+    """Test deposit of segmentations with voxel size filter."""
+    temp_deposit = Path(tempfile.mkdtemp())
+
+    try:
+        deposit(
+            config=str(test_payload["cfg_file"]),
+            target_dir=str(temp_deposit),
+            segmentations_uris=["*:*/*@10.0"],  # Only 10.0 voxel size
+            n_workers=4,
+        )
+
+        # Verify TS_001 segmentations
+        seg_dir = temp_deposit / "ExperimentRuns" / "TS_001" / "Segmentations"
+        if seg_dir.exists():
+            segs = list(seg_dir.glob("*.zarr"))
+
+            # All segmentations should start with "10.000_"
+            for seg in segs:
+                assert seg.name.startswith("10.000_"), f"Wrong voxel size segmentation: {seg.name}"
+
+    finally:
+        if CLEANUP:
+            shutil.rmtree(temp_deposit)
+
+
+def test_deposit_tomograms(test_payload: Dict[str, Any]):
+    """Test deposit of tomograms with tomo_type filter."""
+    temp_deposit = Path(tempfile.mkdtemp())
+
+    try:
+        deposit(
+            config=str(test_payload["cfg_file"]),
+            target_dir=str(temp_deposit),
+            tomograms_uris=["wbp@10.0"],  # Only wbp tomograms at 10.0
+            n_workers=4,
+        )
+
+        # Verify TS_001 tomograms
+        tomo_dir = temp_deposit / "ExperimentRuns" / "TS_001" / "VoxelSpacing10.000"
+        if tomo_dir.exists():
+            tomos = list(tomo_dir.glob("*.zarr"))
+
+            # Should have wbp.zarr
+            wbp_found = any(t.name == "wbp.zarr" for t in tomos)
+            assert wbp_found, "wbp.zarr not found in deposited tomograms"
+
+    finally:
+        if CLEANUP:
+            shutil.rmtree(temp_deposit)
+
+
+def test_deposit_run_name_filtering(test_payload: Dict[str, Any]):
+    """Test depositing specific runs only."""
+    temp_deposit = Path(tempfile.mkdtemp())
+
+    try:
+        deposit(
+            config=str(test_payload["cfg_file"]),
+            target_dir=str(temp_deposit),
+            run_names=["TS_001", "TS_002"],  # Only these runs
+            picks_uris=["*:*/*"],
+            n_workers=4,
+        )
+
+        deposited_runs = _get_deposited_runs(temp_deposit)
+
+        # Only TS_001 and TS_002 should be deposited
+        assert "TS_001" in deposited_runs, "TS_001 not deposited"
+        assert "TS_002" in deposited_runs, "TS_002 not deposited"
+        assert "TS_003" not in deposited_runs, "TS_003 should not be deposited"
+
+    finally:
+        if CLEANUP:
+            shutil.rmtree(temp_deposit)
+
+
+def test_deposit_run_name_prefix(test_payload: Dict[str, Any]):
+    """Test depositing with run name prefix."""
+    temp_deposit = Path(tempfile.mkdtemp())
+    prefix = "test_prefix_"
+
+    try:
+        deposit(
+            config=str(test_payload["cfg_file"]),
+            target_dir=str(temp_deposit),
+            run_name_prefix=prefix,
+            picks_uris=["*:*/*"],
+            n_workers=4,
+        )
+
+        deposited_runs = _get_deposited_runs(temp_deposit)
+
+        # All runs should have the prefix
+        for run in deposited_runs:
+            assert run.startswith(prefix), f"Run {run} does not have prefix {prefix}"
+
+        # Original run names should be present with prefix
+        assert f"{prefix}TS_001" in deposited_runs, "Prefixed TS_001 not found"
+        assert f"{prefix}TS_002" in deposited_runs, "Prefixed TS_002 not found"
+        assert f"{prefix}TS_003" in deposited_runs, "Prefixed TS_003 not found"
+
+    finally:
+        if CLEANUP:
+            shutil.rmtree(temp_deposit)
+
+
+def test_deposit_run_name_regex(test_payload: Dict[str, Any]):
+    """Test depositing with run name regex extraction."""
+    temp_deposit = Path(tempfile.mkdtemp())
+
+    try:
+        # Use regex to extract just "TS_001" from "TS_001" (identity in this case)
+        deposit(
+            config=str(test_payload["cfg_file"]),
+            target_dir=str(temp_deposit),
+            run_name_regex=r"^(TS_\d+).*",  # Extract TS_XXX part
+            picks_uris=["*:*/*"],
+            n_workers=4,
+        )
+
+        deposited_runs = _get_deposited_runs(temp_deposit)
+
+        # Should have extracted run names
+        assert len(deposited_runs) > 0, "No runs deposited"
+        assert "TS_001" in deposited_runs, "TS_001 not found"
+
+    finally:
+        if CLEANUP:
+            shutil.rmtree(temp_deposit)
+
+
+def test_deposit_idempotency(test_payload: Dict[str, Any]):
+    """Test that running deposit twice is idempotent."""
+    temp_deposit = Path(tempfile.mkdtemp())
+
+    try:
+        # First deposit
+        deposit(
+            config=str(test_payload["cfg_file"]),
+            target_dir=str(temp_deposit),
+            picks_uris=["*:*/*"],
+            n_workers=4,
+        )
+
+        # Count symlinks after first deposit
+        first_count = _count_symlinks(temp_deposit)
+        assert first_count > 0, "No symlinks created in first deposit"
+
+        # Second deposit (should be idempotent)
+        deposit(
+            config=str(test_payload["cfg_file"]),
+            target_dir=str(temp_deposit),
+            picks_uris=["*:*/*"],
+            n_workers=4,
+        )
+
+        # Count symlinks after second deposit
+        second_count = _count_symlinks(temp_deposit)
+
+        # Counts should be the same
+        assert first_count == second_count, "Deposit is not idempotent"
+
+    finally:
+        if CLEANUP:
+            shutil.rmtree(temp_deposit)
+
+
+def test_deposit_multiple_projects_same_target(test_payload: Dict[str, Any]):
+    """Test depositing multiple projects to the same target directory."""
+    temp_deposit = Path(tempfile.mkdtemp())
+
+    try:
+        # First deposit with prefix1
+        deposit(
+            config=str(test_payload["cfg_file"]),
+            target_dir=str(temp_deposit),
+            run_name_prefix="proj1_",
+            picks_uris=["*:*/*"],
+            n_workers=4,
+        )
+
+        # Second deposit with prefix2
+        deposit(
+            config=str(test_payload["cfg_file"]),
+            target_dir=str(temp_deposit),
+            run_name_prefix="proj2_",
+            picks_uris=["*:*/*"],
+            n_workers=4,
+        )
+
+        deposited_runs = _get_deposited_runs(temp_deposit)
+
+        # Should have both sets of runs
+        proj1_runs = [r for r in deposited_runs if r.startswith("proj1_")]
+        proj2_runs = [r for r in deposited_runs if r.startswith("proj2_")]
+
+        assert len(proj1_runs) > 0, "No proj1 runs deposited"
+        assert len(proj2_runs) > 0, "No proj2 runs deposited"
+
+        # Both should have TS_001
+        assert "proj1_TS_001" in deposited_runs, "proj1_TS_001 not found"
+        assert "proj2_TS_001" in deposited_runs, "proj2_TS_001 not found"
+
+    finally:
+        if CLEANUP:
+            shutil.rmtree(temp_deposit)
+
+
+def test_deposit_features(test_payload: Dict[str, Any]):
+    """Test deposit of features."""
+    temp_deposit = Path(tempfile.mkdtemp())
+
+    try:
+        deposit(
+            config=str(test_payload["cfg_file"]),
+            target_dir=str(temp_deposit),
+            features_uris=["wbp@10.0:*"],  # All features for wbp at 10.0
+            n_workers=4,
+        )
+
+        # Verify TS_001 features
+        features_dir = temp_deposit / "ExperimentRuns" / "TS_001" / "VoxelSpacing10.000"
+        if features_dir.exists():
+            features = list(features_dir.glob("*_features.zarr"))
+
+            # Should have feature files
+            if len(features) > 0:
+                # Verify they are symlinks
+                for feature in features:
+                    assert feature.is_symlink(), f"{feature.name} is not a symlink"
+                    assert feature.resolve().exists(), f"Symlink target for {feature.name} does not exist"
+
+    finally:
+        if CLEANUP:
+            shutil.rmtree(temp_deposit)
+
+
+def test_deposit_empty_uris(test_payload: Dict[str, Any]):
+    """Test deposit with no URIs (should not create anything)."""
+    temp_deposit = Path(tempfile.mkdtemp())
+
+    try:
+        deposit(
+            config=str(test_payload["cfg_file"]),
+            target_dir=str(temp_deposit),
+            # No URI parameters provided
+            n_workers=4,
+        )
+
+        # When no URIs are provided, nothing should be deposited
+        # The ExperimentRuns directory may or may not exist depending on implementation
+        # but there should be no symlinks
+        symlink_count = _count_symlinks(temp_deposit)
+        assert symlink_count == 0, f"Expected no symlinks but found {symlink_count}"
+
+        # If ExperimentRuns exists, it should be empty or have empty run directories
+        exp_runs_dir = temp_deposit / "ExperimentRuns"
+        if exp_runs_dir.exists():
+            deposited_runs = _get_deposited_runs(temp_deposit)
+            # Even if run directories exist, they should have no content symlinks
+            for run_name in deposited_runs:
+                run_dir = exp_runs_dir / run_name
+                run_symlinks = sum(1 for _ in run_dir.rglob("*") if _.is_symlink())
+                assert run_symlinks == 0, f"Run {run_name} has unexpected symlinks"
+
+    finally:
+        if CLEANUP:
+            shutil.rmtree(temp_deposit)
+
+
+def test_deposit_parallel_processing(test_payload: Dict[str, Any]):
+    """Test deposit with different worker counts."""
+    temp_deposit = Path(tempfile.mkdtemp())
+
+    try:
+        # Test with different worker counts
+        for n_workers in [1, 4, 8]:
+            # Clean up from previous iteration
+            if temp_deposit.exists():
+                shutil.rmtree(temp_deposit)
+            temp_deposit.mkdir()
+
+            deposit(
+                config=str(test_payload["cfg_file"]),
+                target_dir=str(temp_deposit),
+                picks_uris=["*:*/*"],
+                meshes_uris=["*:*/*"],
+                n_workers=n_workers,
+            )
+
+            # Verify all runs deposited
+            deposited_runs = _get_deposited_runs(temp_deposit)
+            assert len(deposited_runs) == 3, f"Not all runs deposited with {n_workers} workers"
+
+            # Verify picks exist
+            picks_dir = temp_deposit / "ExperimentRuns" / "TS_001" / "Picks"
+            assert picks_dir.exists(), f"Picks not deposited with {n_workers} workers"
+
+    finally:
+        if CLEANUP:
+            shutil.rmtree(temp_deposit)
+
+
+def test_deposit_combined_filters(test_payload: Dict[str, Any]):
+    """Test deposit with multiple URI filters combined."""
+    temp_deposit = Path(tempfile.mkdtemp())
+
+    try:
+        deposit(
+            config=str(test_payload["cfg_file"]),
+            target_dir=str(temp_deposit),
+            picks_uris=["proteasome:*/*", "ribosome:gapstop/*"],
+            meshes_uris=["membrane:*/*"],
+            segmentations_uris=["*:*/*@10.0"],
+            tomograms_uris=["wbp@10.0", "denoised@10.0"],
+            n_workers=4,
+        )
+
+        # Verify TS_001 has expected content
+        run_dir = temp_deposit / "ExperimentRuns" / "TS_001"
+        assert run_dir.exists(), "TS_001 not deposited"
+
+        # Check picks
+        picks_dir = run_dir / "Picks"
+        if picks_dir.exists():
+            picks = list(picks_dir.glob("*.json"))
+            # Should have proteasome and ribosome (from gapstop) picks
+            pick_names = [p.name for p in picks]
+            has_proteasome = any("proteasome" in name for name in pick_names)
+            has_ribosome = any("ribosome" in name and "gapstop" in name for name in pick_names)
+            assert has_proteasome or has_ribosome, "Expected picks not found"
+
+        # Check meshes
+        meshes_dir = run_dir / "Meshes"
+        if meshes_dir.exists():
+            meshes = list(meshes_dir.glob("*.glb"))
+            # Should have membrane meshes
+            has_membrane = any("membrane" in m.name for m in meshes)
+            assert has_membrane, "Membrane mesh not found"
+
+    finally:
+        if CLEANUP:
+            shutil.rmtree(temp_deposit)

--- a/tests/test_deposit.py
+++ b/tests/test_deposit.py
@@ -54,9 +54,13 @@ def _check_directory_structure(target_dir: Path, expected_runs: list) -> bool:
     return set(deposited_runs) == set(expected_runs)
 
 
-@pytest.fixture(params=pytest.common_cases)
+@pytest.fixture(params=["local_overlay_only", "local"])
 def test_payload(request) -> Dict[str, Any]:
-    """Reuse the existing test payload fixture."""
+    """Test deposit only with local filesystem configurations.
+
+    Deposit operations require local filesystems because they create symlinks,
+    which are not supported by remote filesystems (S3, SSH, SMB, etc.).
+    """
     from copick.impl.filesystem import CopickRootFSSpec
 
     payload = request.getfixturevalue(request.param)

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -14,8 +14,8 @@ class TestParseURI:
 
     def test_parse_pick_uri_complete(self):
         """Test parsing a complete pick URI."""
-        result = parse_copick_uri("ribosome:gapstop/0", "pick")
-        assert result["object_type"] == "pick"
+        result = parse_copick_uri("ribosome:gapstop/0", "picks")
+        assert result["object_type"] == "picks"
         assert result["pattern_type"] == "glob"
         assert result["object_name"] == "ribosome"
         assert result["user_id"] == "gapstop"
@@ -24,27 +24,27 @@ class TestParseURI:
     def test_parse_pick_uri_incomplete(self):
         """Test parsing incomplete pick URIs with wildcard defaults."""
         # Just object name
-        result = parse_copick_uri("ribosome", "pick")
+        result = parse_copick_uri("ribosome", "picks")
         assert result["object_name"] == "ribosome"
         assert result["user_id"] == "*"
         assert result["session_id"] == "*"
 
         # Object name and user ID
-        result = parse_copick_uri("ribosome:gapstop", "pick")
+        result = parse_copick_uri("ribosome:gapstop", "picks")
         assert result["object_name"] == "ribosome"
         assert result["user_id"] == "gapstop"
         assert result["session_id"] == "*"
 
     def test_parse_pick_uri_glob_patterns(self):
         """Test parsing pick URIs with glob patterns."""
-        result = parse_copick_uri("ribo*:gapstop/*", "pick")
+        result = parse_copick_uri("ribo*:gapstop/*", "picks")
         assert result["object_name"] == "ribo*"
         assert result["user_id"] == "gapstop"
         assert result["session_id"] == "*"
 
     def test_parse_pick_uri_regex(self):
         """Test parsing pick URIs with regex patterns."""
-        result = parse_copick_uri("re:ribo.*:gapstop/\\d+", "pick")
+        result = parse_copick_uri("re:ribo.*:gapstop/\\d+", "picks")
         assert result["pattern_type"] == "regex"
         assert result["object_name"] == "ribo.*"
         assert result["user_id"] == "gapstop"
@@ -162,7 +162,7 @@ class TestSerializeURI:
             assert "/" in uri
 
             # Parse it back
-            parsed = parse_copick_uri(uri, "pick")
+            parsed = parse_copick_uri(uri, "picks")
             assert parsed["object_name"] == pick.pickable_object_name
             assert parsed["user_id"] == pick.user_id
             assert parsed["session_id"] == pick.session_id
@@ -258,7 +258,7 @@ class TestSerializeURI:
     def test_serialize_from_dict_picks(self):
         """Test serializing picks from dict parameters."""
         uri = serialize_copick_uri_from_dict(
-            object_type="pick",
+            object_type="picks",
             object_name="ribosome",
             user_id="gapstop",
             session_id="0",
@@ -299,7 +299,7 @@ class TestSerializeURI:
     def test_serialize_from_dict_missing_params(self):
         """Test that missing required parameters raise errors."""
         with pytest.raises(ValueError, match="require"):
-            serialize_copick_uri_from_dict(object_type="pick", object_name="ribosome")
+            serialize_copick_uri_from_dict(object_type="picks", object_name="ribosome")
 
 
 class TestResolveObjects:
@@ -317,7 +317,7 @@ class TestResolveObjects:
             pick = run.picks[0]
             uri = f"{pick.pickable_object_name}:{pick.user_id}/{pick.session_id}"
 
-            resolved = resolve_copick_objects(uri, root, "pick", run.name)
+            resolved = resolve_copick_objects(uri, root, "picks", run.name)
             assert len(resolved) == 1
             assert resolved[0].pickable_object_name == pick.pickable_object_name
             assert resolved[0].user_id == pick.user_id
@@ -330,7 +330,7 @@ class TestResolveObjects:
         root = copick.from_file(str(fixture["cfg_file"]))
 
         # Get all picks for ribosome
-        resolved = resolve_copick_objects("ribosome", root, "pick")
+        resolved = resolve_copick_objects("ribosome", root, "picks")
         ribosome_picks = [p for p in resolved if p.pickable_object_name == "ribosome"]
         assert len(ribosome_picks) > 0
 
@@ -345,7 +345,7 @@ class TestResolveObjects:
         root = copick.from_file(str(fixture["cfg_file"]))
 
         # Match all picks with user_id starting with 'gap'
-        resolved = resolve_copick_objects("*:gap*/*", root, "pick")
+        resolved = resolve_copick_objects("*:gap*/*", root, "picks")
         assert len(resolved) > 0
 
         for pick in resolved:
@@ -488,7 +488,7 @@ class TestGetObjectsByType:
         fixture = request.getfixturevalue(case)
         root = copick.from_file(str(fixture["cfg_file"]))
 
-        picks = get_copick_objects_by_type(root, "pick")
+        picks = get_copick_objects_by_type(root, "picks")
         assert len(picks) > 0
         assert all(hasattr(p, "pickable_object_name") for p in picks)
 
@@ -499,7 +499,7 @@ class TestGetObjectsByType:
         root = copick.from_file(str(fixture["cfg_file"]))
 
         # Get all ribosome picks
-        picks = get_copick_objects_by_type(root, "pick", object_name="ribosome")
+        picks = get_copick_objects_by_type(root, "picks", object_name="ribosome")
         assert all(p.pickable_object_name == "ribosome" for p in picks)
 
     @pytest.mark.parametrize("case", pytest.common_cases)
@@ -509,7 +509,7 @@ class TestGetObjectsByType:
         root = copick.from_file(str(fixture["cfg_file"]))
 
         run = root.runs[0]
-        picks = get_copick_objects_by_type(root, "pick", run_name=run.name)
+        picks = get_copick_objects_by_type(root, "picks", run_name=run.name)
 
         # All picks should belong to the specified run
         for pick in picks:
@@ -558,7 +558,7 @@ class TestGetObjectsByType:
         root = copick.from_file(str(local["cfg_file"]))
 
         with pytest.raises(ValueError, match="not found"):
-            get_copick_objects_by_type(root, "pick", run_name="nonexistent_run")
+            get_copick_objects_by_type(root, "picks", run_name="nonexistent_run")
 
 
 class TestPatternMatching:
@@ -571,7 +571,7 @@ class TestPatternMatching:
         root = copick.from_file(str(fixture["cfg_file"]))
 
         # Match picks with numeric session IDs
-        resolved = resolve_copick_objects("re:.*:.*/(\\d+)", root, "pick")
+        resolved = resolve_copick_objects("re:.*:.*/(\\d+)", root, "picks")
 
         if resolved:
             for pick in resolved:

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -1,0 +1,613 @@
+import copick
+import pytest
+from copick.util.uri import (
+    get_copick_objects_by_type,
+    parse_copick_uri,
+    resolve_copick_objects,
+    serialize_copick_uri,
+    serialize_copick_uri_from_dict,
+)
+
+
+class TestParseURI:
+    """Test URI parsing functionality."""
+
+    def test_parse_pick_uri_complete(self):
+        """Test parsing a complete pick URI."""
+        result = parse_copick_uri("ribosome:gapstop/0", "pick")
+        assert result["object_type"] == "pick"
+        assert result["pattern_type"] == "glob"
+        assert result["object_name"] == "ribosome"
+        assert result["user_id"] == "gapstop"
+        assert result["session_id"] == "0"
+
+    def test_parse_pick_uri_incomplete(self):
+        """Test parsing incomplete pick URIs with wildcard defaults."""
+        # Just object name
+        result = parse_copick_uri("ribosome", "pick")
+        assert result["object_name"] == "ribosome"
+        assert result["user_id"] == "*"
+        assert result["session_id"] == "*"
+
+        # Object name and user ID
+        result = parse_copick_uri("ribosome:gapstop", "pick")
+        assert result["object_name"] == "ribosome"
+        assert result["user_id"] == "gapstop"
+        assert result["session_id"] == "*"
+
+    def test_parse_pick_uri_glob_patterns(self):
+        """Test parsing pick URIs with glob patterns."""
+        result = parse_copick_uri("ribo*:gapstop/*", "pick")
+        assert result["object_name"] == "ribo*"
+        assert result["user_id"] == "gapstop"
+        assert result["session_id"] == "*"
+
+    def test_parse_pick_uri_regex(self):
+        """Test parsing pick URIs with regex patterns."""
+        result = parse_copick_uri("re:ribo.*:gapstop/\\d+", "pick")
+        assert result["pattern_type"] == "regex"
+        assert result["object_name"] == "ribo.*"
+        assert result["user_id"] == "gapstop"
+        assert result["session_id"] == "\\d+"
+
+    def test_parse_mesh_uri(self):
+        """Test parsing mesh URIs (same format as picks)."""
+        result = parse_copick_uri("membrane:membrain/0", "mesh")
+        assert result["object_type"] == "mesh"
+        assert result["object_name"] == "membrane"
+        assert result["user_id"] == "membrain"
+        assert result["session_id"] == "0"
+
+    def test_parse_segmentation_uri_complete(self):
+        """Test parsing a complete segmentation URI."""
+        result = parse_copick_uri("painting:test.user/123@10.0?multilabel=true", "segmentation")
+        assert result["object_type"] == "segmentation"
+        assert result["name"] == "painting"
+        assert result["user_id"] == "test.user"
+        assert result["session_id"] == "123"
+        assert result["voxel_spacing"] == "10.0"
+        assert result["multilabel"] is True
+
+    def test_parse_segmentation_uri_no_multilabel(self):
+        """Test parsing segmentation URI without multilabel parameter."""
+        result = parse_copick_uri("membrane:membrain/0@20.0", "segmentation")
+        assert result["name"] == "membrane"
+        assert result["user_id"] == "membrain"
+        assert result["session_id"] == "0"
+        assert result["voxel_spacing"] == "20.0"
+        assert result["multilabel"] is None  # Default: match both
+
+    def test_parse_segmentation_uri_incomplete(self):
+        """Test parsing incomplete segmentation URIs."""
+        # Just name
+        result = parse_copick_uri("painting", "segmentation")
+        assert result["name"] == "painting"
+        assert result["user_id"] == "*"
+        assert result["session_id"] == "*"
+        assert result["voxel_spacing"] == "*"
+
+        # Name and user
+        result = parse_copick_uri("painting:test.user", "segmentation")
+        assert result["name"] == "painting"
+        assert result["user_id"] == "test.user"
+        assert result["session_id"] == "*"
+        assert result["voxel_spacing"] == "*"
+
+        # Name, user, session
+        result = parse_copick_uri("painting:test.user/123", "segmentation")
+        assert result["name"] == "painting"
+        assert result["user_id"] == "test.user"
+        assert result["session_id"] == "123"
+        assert result["voxel_spacing"] == "*"
+
+    def test_parse_tomogram_uri_complete(self):
+        """Test parsing a complete tomogram URI."""
+        result = parse_copick_uri("wbp@10.0", "tomogram")
+        assert result["object_type"] == "tomogram"
+        assert result["tomo_type"] == "wbp"
+        assert result["voxel_spacing"] == "10.0"
+
+    def test_parse_tomogram_uri_incomplete(self):
+        """Test parsing incomplete tomogram URI."""
+        result = parse_copick_uri("wbp", "tomogram")
+        assert result["tomo_type"] == "wbp"
+        assert result["voxel_spacing"] == "*"
+
+    def test_parse_feature_uri_complete(self):
+        """Test parsing a complete feature URI."""
+        result = parse_copick_uri("wbp@10.0:sobel", "feature")
+        assert result["object_type"] == "feature"
+        assert result["tomo_type"] == "wbp"
+        assert result["voxel_spacing"] == "10.0"
+        assert result["feature_type"] == "sobel"
+
+    def test_parse_feature_uri_incomplete(self):
+        """Test parsing incomplete feature URIs."""
+        # Just tomo type
+        result = parse_copick_uri("wbp", "feature")
+        assert result["tomo_type"] == "wbp"
+        assert result["voxel_spacing"] == "*"
+        assert result["feature_type"] == "*"
+
+        # Tomo type and voxel spacing
+        result = parse_copick_uri("wbp@10.0", "feature")
+        assert result["tomo_type"] == "wbp"
+        assert result["voxel_spacing"] == "10.0"
+        assert result["feature_type"] == "*"
+
+    def test_parse_uri_invalid_object_type(self):
+        """Test parsing with invalid object type."""
+        with pytest.raises(ValueError, match="Unknown object type"):
+            parse_copick_uri("test:user/session", "invalid_type")
+
+
+class TestSerializeURI:
+    """Test URI serialization functionality."""
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_serialize_picks_roundtrip(self, case, request):
+        """Test that picks can be serialized and parsed back."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get a pick and serialize it
+        run = root.runs[0]
+        picks = run.picks
+        if picks:
+            pick = picks[0]
+            uri = serialize_copick_uri(pick)
+
+            # URI should match expected format
+            assert ":" in uri
+            assert "/" in uri
+
+            # Parse it back
+            parsed = parse_copick_uri(uri, "pick")
+            assert parsed["object_name"] == pick.pickable_object_name
+            assert parsed["user_id"] == pick.user_id
+            assert parsed["session_id"] == pick.session_id
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_serialize_meshes_roundtrip(self, case, request):
+        """Test that meshes can be serialized and parsed back."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        meshes = run.meshes
+        if meshes:
+            mesh = meshes[0]
+            uri = serialize_copick_uri(mesh)
+
+            parsed = parse_copick_uri(uri, "mesh")
+            assert parsed["object_name"] == mesh.pickable_object_name
+            assert parsed["user_id"] == mesh.user_id
+            assert parsed["session_id"] == mesh.session_id
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_serialize_segmentations_roundtrip(self, case, request):
+        """Test that segmentations can be serialized and parsed back."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        segs = run.segmentations
+        if segs:
+            seg = segs[0]
+            uri = serialize_copick_uri(seg)
+
+            # URI should contain @ for voxel spacing
+            assert "@" in uri
+
+            parsed = parse_copick_uri(uri, "segmentation")
+            assert parsed["name"] == seg.name
+            assert parsed["user_id"] == seg.user_id
+            assert parsed["session_id"] == seg.session_id
+            assert float(parsed["voxel_spacing"]) == seg.voxel_size
+
+            # Check multilabel flag
+            if seg.is_multilabel:
+                assert "?multilabel=true" in uri
+                assert parsed["multilabel"] is True
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_serialize_tomograms_roundtrip(self, case, request):
+        """Test that tomograms can be serialized and parsed back."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        if run.voxel_spacings:
+            vs = run.voxel_spacings[0]
+            tomos = vs.tomograms
+            if tomos:
+                tomo = tomos[0]
+                uri = serialize_copick_uri(tomo)
+
+                assert "@" in uri
+
+                parsed = parse_copick_uri(uri, "tomogram")
+                assert parsed["tomo_type"] == tomo.tomo_type
+                assert float(parsed["voxel_spacing"]) == tomo.voxel_spacing.voxel_size
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_serialize_features_roundtrip(self, case, request):
+        """Test that features can be serialized and parsed back."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        if run.voxel_spacings:
+            vs = run.voxel_spacings[0]
+            tomos = vs.tomograms
+            for tomo in tomos:
+                features = tomo.features
+                if features:
+                    feat = features[0]
+                    uri = serialize_copick_uri(feat)
+
+                    assert "@" in uri
+                    assert ":" in uri
+
+                    parsed = parse_copick_uri(uri, "feature")
+                    assert parsed["tomo_type"] == feat.tomo_type
+                    assert float(parsed["voxel_spacing"]) == feat.tomogram.voxel_spacing.voxel_size
+                    assert parsed["feature_type"] == feat.feature_type
+                    return
+
+    def test_serialize_from_dict_picks(self):
+        """Test serializing picks from dict parameters."""
+        uri = serialize_copick_uri_from_dict(
+            object_type="pick",
+            object_name="ribosome",
+            user_id="gapstop",
+            session_id="0",
+        )
+        assert uri == "ribosome:gapstop/0"
+
+    def test_serialize_from_dict_segmentations(self):
+        """Test serializing segmentations from dict parameters."""
+        uri = serialize_copick_uri_from_dict(
+            object_type="segmentation",
+            name="painting",
+            user_id="test.user",
+            session_id="123",
+            voxel_spacing=10.0,
+            multilabel=True,
+        )
+        assert uri == "painting:test.user/123@10.0?multilabel=true"
+
+    def test_serialize_from_dict_tomograms(self):
+        """Test serializing tomograms from dict parameters."""
+        uri = serialize_copick_uri_from_dict(
+            object_type="tomogram",
+            tomo_type="wbp",
+            voxel_spacing=10.0,
+        )
+        assert uri == "wbp@10.0"
+
+    def test_serialize_from_dict_features(self):
+        """Test serializing features from dict parameters."""
+        uri = serialize_copick_uri_from_dict(
+            object_type="feature",
+            tomo_type="wbp",
+            voxel_spacing=10.0,
+            feature_type="sobel",
+        )
+        assert uri == "wbp@10.0:sobel"
+
+    def test_serialize_from_dict_missing_params(self):
+        """Test that missing required parameters raise errors."""
+        with pytest.raises(ValueError, match="require"):
+            serialize_copick_uri_from_dict(object_type="pick", object_name="ribosome")
+
+
+class TestResolveObjects:
+    """Test object resolution from URIs."""
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_picks_exact(self, case, request):
+        """Test resolving picks with exact match."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Find a specific pick to test
+        run = root.runs[0]
+        if run.picks:
+            pick = run.picks[0]
+            uri = f"{pick.pickable_object_name}:{pick.user_id}/{pick.session_id}"
+
+            resolved = resolve_copick_objects(uri, root, "pick", run.name)
+            assert len(resolved) == 1
+            assert resolved[0].pickable_object_name == pick.pickable_object_name
+            assert resolved[0].user_id == pick.user_id
+            assert resolved[0].session_id == pick.session_id
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_picks_wildcard(self, case, request):
+        """Test resolving picks with wildcards."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get all picks for ribosome
+        resolved = resolve_copick_objects("ribosome", root, "pick")
+        ribosome_picks = [p for p in resolved if p.pickable_object_name == "ribosome"]
+        assert len(ribosome_picks) > 0
+
+        # All should be ribosome picks
+        for pick in ribosome_picks:
+            assert pick.pickable_object_name == "ribosome"
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_picks_glob_pattern(self, case, request):
+        """Test resolving picks with glob patterns."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Match all picks with user_id starting with 'gap'
+        resolved = resolve_copick_objects("*:gap*/*", root, "pick")
+        assert len(resolved) > 0
+
+        for pick in resolved:
+            assert pick.user_id.startswith("gap")
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_meshes_exact(self, case, request):
+        """Test resolving meshes with exact match."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        if run.meshes:
+            mesh = run.meshes[0]
+            uri = f"{mesh.pickable_object_name}:{mesh.user_id}/{mesh.session_id}"
+
+            resolved = resolve_copick_objects(uri, root, "mesh", run.name)
+            assert len(resolved) == 1
+            assert resolved[0].pickable_object_name == mesh.pickable_object_name
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_segmentations_exact(self, case, request):
+        """Test resolving segmentations with exact match."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        if run.segmentations:
+            seg = run.segmentations[0]
+            uri = f"{seg.name}:{seg.user_id}/{seg.session_id}@{seg.voxel_size}"
+
+            resolved = resolve_copick_objects(uri, root, "segmentation", run.name)
+            assert len(resolved) == 1
+            assert resolved[0].name == seg.name
+            assert resolved[0].voxel_size == seg.voxel_size
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_segmentations_multilabel_default(self, case, request):
+        """Test that segmentations match both multilabel and non-multilabel by default."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get all segmentations without specifying multilabel
+        resolved = resolve_copick_objects("*:*/*@*", root, "segmentation")
+
+        # Should include both multilabel and non-multilabel segmentations
+        has_multilabel = any(seg.is_multilabel for seg in resolved)
+        has_non_multilabel = any(not seg.is_multilabel for seg in resolved)
+
+        # At least one type should exist (depends on test data)
+        assert has_multilabel or has_non_multilabel
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_segmentations_multilabel_filter(self, case, request):
+        """Test filtering segmentations by multilabel flag."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get multilabel segmentations only
+        resolved = resolve_copick_objects("*:*/*@*?multilabel=true", root, "segmentation")
+
+        if resolved:
+            # All should be multilabel
+            for seg in resolved:
+                assert seg.is_multilabel
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_tomograms_exact(self, case, request):
+        """Test resolving tomograms with exact match."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        if run.voxel_spacings:
+            vs = run.voxel_spacings[0]
+            tomos = vs.tomograms
+            if tomos:
+                tomo = tomos[0]
+                uri = f"{tomo.tomo_type}@{vs.voxel_size}"
+
+                resolved = resolve_copick_objects(uri, root, "tomogram", run.name)
+                assert len(resolved) >= 1
+
+                # Find our specific tomogram
+                found = [t for t in resolved if t.tomo_type == tomo.tomo_type]
+                assert len(found) >= 1
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_tomograms_wildcard(self, case, request):
+        """Test resolving all tomograms with wildcards."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get all tomograms
+        resolved = resolve_copick_objects("*@*", root, "tomogram")
+        assert len(resolved) > 0
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_features_exact(self, case, request):
+        """Test resolving features with exact match."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        if run.voxel_spacings:
+            vs = run.voxel_spacings[0]
+            for tomo in vs.tomograms:
+                if tomo.features:
+                    feat = tomo.features[0]
+                    uri = f"{feat.tomo_type}@{vs.voxel_size}:{feat.feature_type}"
+
+                    resolved = resolve_copick_objects(uri, root, "feature", run.name)
+                    assert len(resolved) >= 1
+
+                    found = [f for f in resolved if f.feature_type == feat.feature_type]
+                    assert len(found) >= 1
+                    return
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_resolve_features_wildcard(self, case, request):
+        """Test resolving all features with wildcards."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get all features
+        resolved = resolve_copick_objects("*@*:*", root, "feature")
+
+        # Should have at least some features
+        if resolved:
+            for feat in resolved:
+                assert feat.feature_type is not None
+
+
+class TestGetObjectsByType:
+    """Test direct object retrieval by type."""
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_get_picks_all(self, case, request):
+        """Test getting all picks."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        picks = get_copick_objects_by_type(root, "pick")
+        assert len(picks) > 0
+        assert all(hasattr(p, "pickable_object_name") for p in picks)
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_get_picks_filtered(self, case, request):
+        """Test getting filtered picks."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get all ribosome picks
+        picks = get_copick_objects_by_type(root, "pick", object_name="ribosome")
+        assert all(p.pickable_object_name == "ribosome" for p in picks)
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_get_picks_by_run(self, case, request):
+        """Test getting picks for specific run."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        run = root.runs[0]
+        picks = get_copick_objects_by_type(root, "pick", run_name=run.name)
+
+        # All picks should belong to the specified run
+        for pick in picks:
+            assert pick.run.name == run.name
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_get_segmentations_all(self, case, request):
+        """Test getting all segmentations."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        segs = get_copick_objects_by_type(root, "segmentation")
+        if segs:
+            assert all(hasattr(s, "name") for s in segs)
+            assert all(hasattr(s, "voxel_size") for s in segs)
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_get_tomograms_all(self, case, request):
+        """Test getting all tomograms."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        tomos = get_copick_objects_by_type(root, "tomogram")
+        assert len(tomos) > 0
+        assert all(hasattr(t, "tomo_type") for t in tomos)
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_get_features_all(self, case, request):
+        """Test getting all features."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        features = get_copick_objects_by_type(root, "feature")
+        if features:
+            assert all(hasattr(f, "feature_type") for f in features)
+
+    def test_get_objects_invalid_type(self, local):
+        """Test getting objects with invalid type."""
+        root = copick.from_file(str(local["cfg_file"]))
+
+        with pytest.raises(ValueError, match="Unknown object type"):
+            get_copick_objects_by_type(root, "invalid_type")
+
+    def test_get_objects_invalid_run(self, local):
+        """Test getting objects with non-existent run."""
+        root = copick.from_file(str(local["cfg_file"]))
+
+        with pytest.raises(ValueError, match="not found"):
+            get_copick_objects_by_type(root, "pick", run_name="nonexistent_run")
+
+
+class TestPatternMatching:
+    """Test advanced pattern matching with regex."""
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_regex_picks_pattern(self, case, request):
+        """Test regex pattern matching for picks."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Match picks with numeric session IDs
+        resolved = resolve_copick_objects("re:.*:.*/(\\d+)", root, "pick")
+
+        if resolved:
+            for pick in resolved:
+                assert pick.session_id.isdigit()
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_glob_voxel_spacing_pattern(self, case, request):
+        """Test glob pattern for voxel spacings."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get tomograms at voxel spacing 10.0
+        resolved = resolve_copick_objects("*@10.0", root, "tomogram")
+
+        if resolved:
+            for tomo in resolved:
+                assert tomo.voxel_spacing.voxel_size == 10.0
+
+    @pytest.mark.parametrize("case", pytest.common_cases)
+    def test_combined_filters(self, case, request):
+        """Test combining multiple filters."""
+        fixture = request.getfixturevalue(case)
+        root = copick.from_file(str(fixture["cfg_file"]))
+
+        # Get specific object with specific user at specific voxel spacing
+        run = root.runs[0]
+        resolved = get_copick_objects_by_type(
+            root,
+            "segmentation",
+            run_name=run.name,
+            name="painting",
+            voxel_spacing="10.0",
+            pattern_type="glob",
+        )
+
+        # All results should match all filters
+        for seg in resolved:
+            assert seg.name == "painting"
+            assert seg.voxel_size == 10.0


### PR DESCRIPTION
# Add `copick deposit` CLI command for creating depositable project views

## Summary
Implements a new `copick deposit` command that creates a hierarchical directory structure suitable for uploading to the CryoET Data Portal by creating symlinks to project data files (merging multiple copick projects is possible).

## Changes

### Core Implementation
- **`copick/src/copick/ops/deposit.py`**: Core deposit functionality
  - `deposit()`: Main function for creating depositable views with symlinks
  - `deposit_run()`: Per-run processing with URI-based filtering
  - Supports filtering by picks, meshes, segmentations, tomograms, and features via URI patterns
  - Automatic run name transformation for Data Portal projects

### CLI Integration
- **`copick/src/copick/cli/deposit.py`**: Click command wrapper
  - Multiple URI filters for different data types
  - Run name filtering, prefixing, and regex extraction

### Documentation
- **`copick/docs/cli.md`**: Complete CLI reference

## Features

### URI-Based Filtering
```bash
# Deposit specific picks and meshes
copick deposit -c config.json --target-dir /deposit \
    --picks "proteasome:*/*" --picks "ribosome:*/*" \
    --meshes "membrane:*/*"
```

### Run Name Management
```bash
# With prefix
copick deposit -c config.json --target-dir /deposit \
    --run-name-prefix "proj1_" --picks "*:*/*"

# With regex extraction
copick deposit -c config.json --target-dir /deposit \
    --run-name-regex "^(TS_\d+).*" --picks "*:*/*"
```

### Multi-Project Deposits
```bash
# Multiple projects to same target (idempotent)
copick deposit -c project1.json --target-dir /deposit --run-name-prefix "proj1_" ...
copick deposit -c project2.json --target-dir /deposit --run-name-prefix "proj2_" ...
```