### PR TITLE
feat: Global cache for cryoET data portal annotations/tomograms

### DIFF
--- a/docs/snippets/segmentation_read_image.py
+++ b/docs/snippets/segmentation_read_image.py
@@ -11,7 +11,7 @@ root = copick.from_file("path/to/config.json")
 run = root.runs[0]
 
 # Get 'proteasome' segmentation of user 'alice'
-segmentation = run.get_segmentations(object_name="proteasome", user_id="alice")[0]
+segmentation = run.get_segmentations(name="proteasome", user_id="alice")[0]
 
 # Get the segmentation array from the segmentation
 seg_zarr = zarr.open(segmentation.zarr())["0"]

--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -115,16 +115,6 @@ class PortalAnnotationMeta(BaseModel):
             return _PortalAnnotationFile(**v.to_dict())
         return v
 
-    @classmethod
-    def from_annotation_file(cls, source: cdp.AnnotationFile):
-        return cls(
-            portal_annotation_file=_PortalAnnotationFile(**source.to_dict()),
-            portal_annotation_shape=_PortalAnnotationShape(**source.annotation_shape.to_dict()),
-            portal_annotation=_PortalAnnotation(**source.annotation_shape.annotation.to_dict()),
-            voxel_spacing=source.tomogram_voxel_spacing.voxel_spacing,
-            portal_author_names=[a.name for a in source.annotation_shape.annotation.authors],
-        )
-
     @property
     def annotation_id(self) -> int:
         return self.portal_annotation.id
@@ -177,13 +167,6 @@ class PortalAnnotationMeta(BaseModel):
 class PortalTomogramMeta(BaseModel):
     portal_metadata: Optional[_PortalTomogram] = _PortalTomogram()
     portal_authors: Optional[List[str]] = []
-
-    @classmethod
-    def from_tomogram(cls, source: cdp.Tomogram):
-        return cls(
-            portal_metadata=_PortalTomogram(**source.to_dict()),
-            portal_authors=[a.name for a in source.authors],
-        )
 
     @classmethod
     def from_portal_cached(cls, source: cdp.Tomogram, author_names: List[str]):
@@ -419,21 +402,6 @@ class CopickMeshCDP(CopickMeshOverlay):
 
 class CopickSegmentationMetaCDP(CopickSegmentationMeta):
     portal_metadata: Optional[PortalAnnotationMeta] = PortalAnnotationMeta()
-
-    @classmethod
-    def from_portal(cls, source: cdp.AnnotationFile, name: Optional[str] = None):
-        object_name = f"{name}" if name else f"{camel(source.annotation_shape.annotation.object_name)}-{source.id}"
-
-        portal_meta = PortalAnnotationMeta.from_annotation_file(source)
-
-        return cls(
-            is_multilabel=False,
-            voxel_size=source.tomogram_voxel_spacing.voxel_spacing,
-            user_id="data-portal",
-            session_id=str(source.id),
-            name=object_name,
-            portal_metadata=portal_meta,
-        )
 
     @property
     def portal_annotation_id(self) -> int:

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -876,6 +876,7 @@ class CopickRun:
         object_name: Union[str, Iterable[str]] = None,
         user_id: Union[str, Iterable[str]] = None,
         session_id: Union[str, Iterable[str]] = None,
+        **kwargs,
     ) -> List["CopickPicks"]:
         """Get picks by name, user_id or session_id (or combinations).
 
@@ -883,6 +884,7 @@ class CopickRun:
             object_name: Name of the object to search for.
             user_id: User ID to search for.
             session_id: Session ID to search for.
+            **kwargs: Additional parameters for subclass implementations.
 
         Returns:
             List[CopickPicks]: List of picks that match the search criteria.
@@ -994,6 +996,7 @@ class CopickRun:
         is_multilabel: bool = None,
         name: Union[str, Iterable[str]] = None,
         voxel_size: Union[float, Iterable[float]] = None,
+        **kwargs,
     ) -> List["CopickSegmentation"]:
         """Get segmentations by user_id, session_id, name, type or voxel_size (or combinations).
 
@@ -1003,6 +1006,7 @@ class CopickRun:
             is_multilabel: Whether the segmentation is multilabel or not.
             name: Name of the segmentation to search for.
             voxel_size: Voxel size to search for.
+            **kwargs: Additional parameters for subclass implementations.
 
         Returns:
             List[CopickSegmentation]: List of segmentations that match the search criteria.
@@ -1500,11 +1504,12 @@ class CopickVoxelSpacing:
                 return tomo
         return None
 
-    def get_tomograms(self, tomo_type: str) -> List["CopickTomogram"]:
+    def get_tomograms(self, tomo_type: str = None, **kwargs) -> List["CopickTomogram"]:
         """Get tomograms by type.
 
         Args:
             tomo_type: Type of the tomograms to retrieve.
+            **kwargs: Additional parameters for subclass implementations.
 
         Returns:
             List[CopickTomogram]: The tomograms with the given type.


### PR DESCRIPTION
Big performance improvement for cryoET data portal implementation by: 
- creating a global cache of cryoET data portal metadata (only 1 API call per Class)
- removing per-run queries send to data portal
- fixing metadata- and author-based queries in the process.