### PR TITLE
feat: Add ability to recover broken connections (e.g. ssh)

### DIFF
--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 import cryoet_data_portal as cdp
-import fsspec
 import numpy as np
 import s3fs
 import zarr
@@ -1233,14 +1232,28 @@ class CopickRootCDP(CopickRoot):
     config: CopickConfigCDP
 
     def __init__(self, config: CopickConfigCDP):
+        import weakref
+
+        from copick.util.reconnecting_fs import ReconnectingFileSystem
+
         super().__init__(config)
 
-        self.fs_overlay: AbstractFileSystem = fsspec.core.url_to_fs(config.overlay_root, **config.overlay_fs_args)[0]
+        self.fs_overlay: AbstractFileSystem = ReconnectingFileSystem(
+            config.overlay_root,
+            config.overlay_fs_args,
+        )
         self.root_overlay: str = self.fs_overlay._strip_protocol(config.overlay_root)  # noqa
         self._portal_cache: Optional[PortalCache] = None
 
+        # Set root reference for cache invalidation on reconnect
+        self.fs_overlay._root_ref = weakref.ref(self)
+
         # Eagerly build annotation cache for all datasets
         self._ensure_annotation_cache()
+
+    def reconnect(self) -> None:
+        """Force reconnection of the overlay filesystem and invalidate caches."""
+        self.fs_overlay._reconnect()
 
     @property
     def go_map(self) -> Dict[str, str]:

--- a/src/copick/impl/filesystem.py
+++ b/src/copick/impl/filesystem.py
@@ -2,7 +2,6 @@ import concurrent.futures
 import json
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
-import fsspec
 import zarr
 from fsspec import AbstractFileSystem
 
@@ -907,9 +906,16 @@ class CopickRootFSSpec(CopickRoot):
         Args:
             config: Copick configuration for fsspec-based storage.
         """
+        import weakref
+
+        from copick.util.reconnecting_fs import ReconnectingFileSystem
+
         super().__init__(config)
 
-        self.fs_overlay: AbstractFileSystem = fsspec.core.url_to_fs(config.overlay_root, **config.overlay_fs_args)[0]
+        self.fs_overlay: AbstractFileSystem = ReconnectingFileSystem(
+            config.overlay_root,
+            config.overlay_fs_args,
+        )
         self.fs_static: Optional[AbstractFileSystem] = None
 
         self.root_overlay: str = self.fs_overlay._strip_protocol(config.overlay_root).rstrip("/")
@@ -919,12 +925,23 @@ class CopickRootFSSpec(CopickRoot):
             self.fs_static = self.fs_overlay
             self.root_static = self.fs_static._strip_protocol(config.overlay_root).rstrip("/")
         else:
-            self.fs_static = fsspec.core.url_to_fs(config.static_root, **config.static_fs_args)[0]
+            self.fs_static = ReconnectingFileSystem(config.static_root, config.static_fs_args)
             self.root_static = self.fs_static._strip_protocol(config.static_root).rstrip("/")
+
+        # Set root reference for cache invalidation on reconnect
+        self.fs_overlay._root_ref = weakref.ref(self)
+        if self.fs_static is not self.fs_overlay:
+            self.fs_static._root_ref = weakref.ref(self)
 
     @property
     def static_is_overlay(self) -> bool:
         return self.fs_static == self.fs_overlay and self.root_static == self.root_overlay
+
+    def reconnect(self) -> None:
+        """Force reconnection of all filesystems and invalidate caches."""
+        self.fs_overlay._reconnect()
+        if self.fs_static is not self.fs_overlay:
+            self.fs_static._reconnect()
 
     @classmethod
     def from_file(cls, path: str) -> "CopickRootFSSpec":

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -497,6 +497,22 @@ class CopickRoot:
         self._runs = self.query()
         self._objects = None  # Reset objects to force reloading
 
+    def reconnect(self) -> None:
+        """Reconnect to the storage backend and invalidate all caches.
+
+        Override in subclasses that use remote filesystems (e.g. SSH, S3).
+        No-op for local filesystem backends.
+        """
+        pass
+
+    def _invalidate_all_caches(self) -> None:
+        """Invalidate all cached child objects, forcing re-query on next access."""
+        if self._runs is not None:
+            for run in self._runs:
+                run._invalidate_caches()
+        self._runs = None
+        self._objects = None
+
     def save_config(self, config_path: str) -> None:
         """Save the configuration to a JSON file.
 
@@ -1327,6 +1343,16 @@ class CopickRun:
         self.refresh_meshes()
         self.refresh_segmentations()
 
+    def _invalidate_caches(self) -> None:
+        """Invalidate all cached child data for this run."""
+        if self._voxel_spacings is not None:
+            for vs in self._voxel_spacings:
+                vs._invalidate_caches()
+        self._voxel_spacings = None
+        self._picks = None
+        self._meshes = None
+        self._segmentations = None
+
     def ensure(self, create: bool = False) -> bool:
         """Check if the run record exists, optionally create it if it does not.
 
@@ -1524,6 +1550,10 @@ class CopickVoxelSpacing:
     def refresh(self) -> None:
         """Refresh `CopickVoxelSpacing.tomograms` from storage."""
         self.refresh_tomograms()
+
+    def _invalidate_caches(self) -> None:
+        """Invalidate all cached child data for this voxel spacing."""
+        self._tomograms = None
 
     def new_tomogram(self, tomo_type: str, exist_ok: bool = False, **kwargs) -> "CopickTomogram":
         """Create a new tomogram object, also creates the Zarr-store in the storage backend.
@@ -1733,6 +1763,10 @@ class CopickTomogram:
     def refresh(self) -> None:
         """Refresh `CopickTomogram.features` from storage."""
         self.refresh_features()
+
+    def _invalidate_caches(self) -> None:
+        """Invalidate all cached features for this tomogram."""
+        self._features = None
 
     def delete(self) -> None:
         """Delete the tomogram record."""

--- a/src/copick/util/reconnecting_fs.py
+++ b/src/copick/util/reconnecting_fs.py
@@ -1,0 +1,173 @@
+"""Reconnecting filesystem wrapper for automatic recovery from broken connections.
+
+Provides a ``ReconnectingFileSystem`` that wraps any fsspec ``AbstractFileSystem`` and
+transparently retries operations when the underlying connection (e.g. SSH tunnel) drops.
+"""
+
+import logging
+import weakref
+from functools import wraps
+from typing import Any, Dict, Optional
+
+import fsspec
+from fsspec import AbstractFileSystem
+
+logger = logging.getLogger(__name__)
+
+# Exception class names that indicate a stale/broken connection.
+# Checked by class name through the MRO to avoid hard dependencies on asyncssh etc.
+_CONNECTION_ERROR_NAMES = frozenset(
+    {
+        "SFTPNoConnection",
+        "SFTPError",
+        "SFTPConnectionLost",
+        "ConnectionLost",
+        "DisconnectError",
+        "BrokenPipeError",
+        "ConnectionResetError",
+        "ConnectionRefusedError",
+        "ConnectionAbortedError",
+    },
+)
+
+
+def _is_connection_error(exc: BaseException) -> bool:
+    """Check if an exception indicates a broken or stale connection."""
+    for cls in type(exc).__mro__:
+        if cls.__name__ in _CONNECTION_ERROR_NAMES:
+            return True
+    # OSError with errno for broken pipe (32) or connection reset (104)
+    if isinstance(exc, OSError) and exc.errno in (32, 104):
+        return True
+    return False
+
+
+def _make_retry_method(method_name: str):
+    """Create a method that delegates to the wrapped filesystem with retry on connection error."""
+
+    def method(self, *args, **kwargs):
+        try:
+            return getattr(self._fs, method_name)(*args, **kwargs)
+        except Exception as exc:
+            if _is_connection_error(exc):
+                logger.warning("Connection error during %s, reconnecting: %s", method_name, exc)
+                self._reconnect()
+                return getattr(self._fs, method_name)(*args, **kwargs)
+            raise
+
+    method.__name__ = method_name
+    method.__qualname__ = f"ReconnectingFileSystem.{method_name}"
+    return method
+
+
+class ReconnectingFileSystem(AbstractFileSystem):
+    """A filesystem wrapper that automatically reconnects on connection errors.
+
+    Subclasses ``AbstractFileSystem`` so that ``isinstance`` checks pass. Delegates all
+    operations to a wrapped filesystem created from a URL and fs_args. When a connection
+    error is detected (e.g. ``SFTPNoConnection``), the wrapped filesystem is recreated
+    from the stored configuration and the operation is retried once.
+
+    Attributes:
+        _url: The URL used to create the wrapped filesystem.
+        _fs_args: The arguments used to create the wrapped filesystem.
+        _fs: The current wrapped filesystem instance.
+        _root_ref: Weak reference to the CopickRoot for cache invalidation.
+    """
+
+    protocol = "reconnecting"
+
+    def __init__(self, url: str, fs_args: Optional[Dict[str, Any]] = None, **kwargs):
+        super().__init__(skip_instance_cache=True, **kwargs)
+        self._url = url
+        self._fs_args = fs_args or {}
+        self._fs: AbstractFileSystem = fsspec.core.url_to_fs(url, **self._fs_args)[0]
+        self._root_ref: Optional[weakref.ref] = None
+
+    @property
+    def protocol(self):
+        """Expose the wrapped filesystem's protocol for downstream compatibility."""
+        return self._fs.protocol
+
+    def _reconnect(self) -> None:
+        """Recreate the underlying filesystem from stored configuration.
+
+        Clears fsspec's instance cache for the wrapped filesystem class, creates a fresh
+        filesystem instance, and invalidates all copick data caches (if a root reference
+        is set) so stale objects are re-queried on next access.
+        """
+        logger.info("Reconnecting filesystem for %s", self._url)
+        type(self._fs).clear_instance_cache()
+        self._fs = fsspec.core.url_to_fs(self._url, **self._fs_args)[0]
+        if self._root_ref is not None:
+            root = self._root_ref()
+            if root is not None:
+                root._invalidate_all_caches()
+
+    # -- Explicitly overridden methods (used by copick, zarr FSStore, and fsspec FSMap) --
+    # Each delegates to self._fs with automatic retry on connection error.
+
+    # Core directory/file info methods
+    ls = _make_retry_method("ls")
+    info = _make_retry_method("info")
+    glob = _make_retry_method("glob")
+    find = _make_retry_method("find")
+    du = _make_retry_method("du")
+    exists = _make_retry_method("exists")
+    isdir = _make_retry_method("isdir")
+    isfile = _make_retry_method("isfile")
+
+    # File read/write methods
+    cat = _make_retry_method("cat")
+    cat_file = _make_retry_method("cat_file")
+    pipe = _make_retry_method("pipe")
+    pipe_file = _make_retry_method("pipe_file")
+    open = _make_retry_method("open")
+
+    # Directory creation methods
+    mkdir = _make_retry_method("mkdir")
+    mkdirs = _make_retry_method("mkdirs")
+    makedirs = _make_retry_method("makedirs")
+
+    # File/directory removal methods
+    rm = _make_retry_method("rm")
+    rm_file = _make_retry_method("rm_file")
+    rmdir = _make_retry_method("rmdir")
+
+    # Other methods used by zarr/fsspec
+    touch = _make_retry_method("touch")
+    get_mapper = _make_retry_method("get_mapper")
+
+    # Cache management — delegate without retry (not I/O)
+    def invalidate_cache(self, path=None):
+        return self._fs.invalidate_cache(path)
+
+    # Protocol/path utilities — delegate to the wrapped filesystem class
+    def _strip_protocol(self, path):
+        return self._fs._strip_protocol(path)
+
+    @staticmethod
+    def _parent(path):
+        # Delegate to the general AbstractFileSystem implementation
+        return AbstractFileSystem._parent(path)
+
+    # -- Fallback for any method not explicitly overridden --
+
+    def __getattr__(self, name):
+        """Delegate attribute access to the wrapped filesystem with retry for callables."""
+        attr = getattr(self._fs, name)
+        if not callable(attr):
+            return attr
+
+        @wraps(attr)
+        def wrapper(*args, **kwargs):
+            try:
+                return attr(*args, **kwargs)
+            except Exception as exc:
+                if _is_connection_error(exc):
+                    logger.warning("Connection error during %s, reconnecting: %s", name, exc)
+                    self._reconnect()
+                    return getattr(self._fs, name)(*args, **kwargs)
+                raise
+
+        return wrapper

--- a/tests/test_reconnecting_fs.py
+++ b/tests/test_reconnecting_fs.py
@@ -1,0 +1,121 @@
+"""Tests for ReconnectingFileSystem and cache invalidation."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from copick.util.reconnecting_fs import ReconnectingFileSystem, _is_connection_error
+from fsspec import AbstractFileSystem
+from fsspec.implementations.memory import MemoryFileSystem
+
+
+# -- Helper: a fake SFTP exception that mimics asyncssh's SFTPNoConnection --
+class SFTPNoConnection(Exception):  # noqa: N818 — mirrors asyncssh's naming
+    pass
+
+
+class SFTPError(OSError):
+    pass
+
+
+# -- Tests for _is_connection_error --
+
+
+def test_is_connection_error_sftp_no_connection():
+    assert _is_connection_error(SFTPNoConnection("Connection not open"))
+
+
+def test_is_connection_error_stdlib_connection_reset():
+    assert _is_connection_error(ConnectionResetError("Connection reset by peer"))
+
+
+def test_is_connection_error_broken_pipe_errno():
+    exc = OSError(32, "Broken pipe")
+    assert _is_connection_error(exc)
+
+
+def test_is_connection_error_false_for_unrelated():
+    assert not _is_connection_error(ValueError("some error"))
+    assert not _is_connection_error(FileNotFoundError("no such file"))
+    assert not _is_connection_error(OSError(2, "No such file or directory"))
+
+
+# -- Tests for ReconnectingFileSystem --
+
+
+def test_isinstance_abstract_filesystem():
+    fs = ReconnectingFileSystem("memory://test")
+    assert isinstance(fs, AbstractFileSystem)
+
+
+def test_protocol_delegates_to_wrapped():
+    fs = ReconnectingFileSystem("memory://test")
+    assert fs.protocol == MemoryFileSystem.protocol
+
+
+def test_retry_on_connection_error():
+    """Verify that a connection error triggers reconnection and retry."""
+    fs = ReconnectingFileSystem("memory://test")
+
+    call_count = 0
+    original_exists = fs._fs.exists
+
+    def flaky_exists(path, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise SFTPNoConnection("Connection not open")
+        return original_exists(path, **kwargs)
+
+    fs._fs.exists = flaky_exists
+
+    with patch.object(fs, "_reconnect", wraps=fs._reconnect) as mock_reconnect:
+        result = fs.exists("memory://test/nonexistent")
+        mock_reconnect.assert_called_once()
+    assert not result
+
+
+def test_non_connection_error_not_retried():
+    """Non-connection errors should propagate immediately without reconnect."""
+    fs = ReconnectingFileSystem("memory://test")
+
+    def bad_exists(path, **kwargs):
+        raise ValueError("not a connection error")
+
+    fs._fs.exists = bad_exists
+
+    with patch.object(fs, "_reconnect") as mock_reconnect:
+        with pytest.raises(ValueError, match="not a connection error"):
+            fs.exists("memory://test/foo")
+        mock_reconnect.assert_not_called()
+
+
+def test_reconnect_recreates_filesystem():
+    """After _reconnect(), the wrapped filesystem should be a new instance."""
+    fs = ReconnectingFileSystem("memory://test")
+    old_fs = fs._fs
+
+    fs._reconnect()
+
+    assert fs._fs is not old_fs
+
+
+def test_reconnect_invalidates_root_caches():
+    """Reconnection should call _invalidate_all_caches on the root if set."""
+    fs = ReconnectingFileSystem("memory://test")
+
+    mock_root = MagicMock()
+    import weakref
+
+    fs._root_ref = weakref.ref(mock_root)
+
+    fs._reconnect()
+
+    mock_root._invalidate_all_caches.assert_called_once()
+
+
+def test_getattr_fallback_delegates():
+    """Methods not explicitly overridden should still delegate via __getattr__."""
+    fs = ReconnectingFileSystem("memory://test")
+    # _strip_protocol is explicitly overridden, but created/modified are not
+    # Just verify that accessing an attribute on the wrapped fs works
+    assert fs.storage_options is not None or fs.storage_options is None  # no AttributeError


### PR DESCRIPTION
## Summary

Adds automatic reconnection support for remote filesystems (SSH, S3, etc.) in copick. When an SSH tunnel drops and is recreated, copick previously held stale filesystem objects that would throw `SFTPNoConnection: Connection not open` errors, requiring a full application restart.

This PR introduces a `ReconnectingFileSystem` wrapper that:

- **Subclasses `fsspec.AbstractFileSystem`** so `isinstance` checks and downstream tools (zarr, fsspec FSMap) work transparently
- **Automatically retries** filesystem operations on connection errors by recreating the underlying filesystem from the stored config
- **Invalidates all cached data** (runs, voxel spacings, picks, etc.) after reconnection so stale objects are re-queried
- **Exposes `root.reconnect()`** for manual/proactive reconnection after known tunnel restarts

All reconnection logic lives in copick core — no changes needed in napari-copick, chimerax-copick, or any downstream plugin.

### Changes

- **`copick/src/copick/util/reconnecting_fs.py`** (new): `ReconnectingFileSystem(AbstractFileSystem)` with retry-on-connection-error for all delegated methods, plus `_is_connection_error()` detection via class name MRO (avoids hard dependency on asyncssh)
- **`copick/src/copick/models.py`**: Added `reconnect()` (no-op base), `_invalidate_all_caches()` on `CopickRoot`, and `_invalidate_caches()` on `CopickRun`, `CopickVoxelSpacing`, `CopickTomogram`
- **`copick/src/copick/impl/filesystem.py`**: `CopickRootFSSpec` now wraps filesystems in `ReconnectingFileSystem`, added `reconnect()` override
- **`copick/src/copick/impl/cryoet_data_portal.py`**: `CopickRootCDP` now wraps overlay filesystem in `ReconnectingFileSystem`, added `reconnect()` override
- **`copick/tests/test_reconnecting_fs.py`** (new): 10 unit tests covering error detection, retry behavior, filesystem recreation, cache invalidation, and `isinstance` compatibility

### How it works

1. `ReconnectingFileSystem` wraps a real fsspec filesystem and delegates all method calls to it
2. If a method raises a connection error (e.g. `SFTPNoConnection`, `ConnectionResetError`, `BrokenPipeError`), the wrapper:
   - Clears fsspec's instance cache for that filesystem class
   - Recreates the filesystem from the original URL + args
   - Invalidates all copick data caches via a weak reference to the root
   - Retries the operation once
3. Non-connection errors propagate immediately without retry
4. The `protocol` property delegates to the wrapped filesystem, so protocol checks (e.g. in `deposit`) work correctly
