### PR TITLE
fix: Fix click URI-type

### DIFF
--- a/src/copick/cli/types.py
+++ b/src/copick/cli/types.py
@@ -44,7 +44,7 @@ class CopickURI(click.ParamType):
             return None
         return str(value)
 
-    def get_metavar(self, param):
+    def get_metavar(self, param, **kwargs):
         return "URI"
 
     def __repr__(self):


### PR DESCRIPTION
Fixing function signature error by accepting context variable.