### PR TITLE
fix: Fix tomogram dimension determination during RELION STAR import

### DIFF
--- a/src/copick/util/formats.py
+++ b/src/copick/util/formats.py
@@ -1228,8 +1228,11 @@ def get_tomogram_centers_from_copick(
             continue
 
         tomo = tomos[0]
+        import zarr
+
         zarr_store = tomo.zarr()
-        shape = zarr_store["0"].shape  # (z, y, x)
+        group = zarr.open(zarr_store, mode="r")
+        shape = group["0"].shape  # (z, y, x)
 
         # Compute center in Angstrom
         center_z = (shape[0] / 2) * voxel_spacing


### PR DESCRIPTION
Function was attempting to access the FSStore returned by CopickTomogram.zarr() as a Zarr store directly, without first opening the Zarr-group. Fixed by this PR with correct Zarr group initialization. 