### PR TITLE
feat: Allow specifying a run prefix during copick import.

### DIFF
--- a/src/copick/cli/add.py
+++ b/src/copick/cli/add.py
@@ -73,6 +73,7 @@ def tomogram(
     config: str,
     run: str,
     run_regex: str,
+    run_name_prefix: str,
     tomo_type: str,
     file_type: str,
     voxel_size: float,
@@ -150,7 +151,7 @@ def tomogram(
     chunk_size: Tuple[int, int, int] = tuple(map(int, chunk_size.split(",")[:3]))
 
     # Prepare runs and group files
-    run_to_file = prepare_runs_from_paths(root, paths, run, run_regex, create, logger)
+    run_to_file = prepare_runs_from_paths(root, paths, run, run_regex, run_name_prefix, create, logger)
 
     def import_tomogram(run_obj, file_path, **kwargs):
         """Process one tomogram file for a single run"""
@@ -618,6 +619,7 @@ def segmentation(
     config: str,
     run: str,
     run_regex: str,
+    run_name_prefix: str,
     voxel_size: float,
     name: str,
     user_id: str,
@@ -663,7 +665,7 @@ def segmentation(
         paths = [path]
 
     # Prepare runs and group files
-    run_to_file = prepare_runs_from_paths(root, paths, run, run_regex, create, logger)
+    run_to_file = prepare_runs_from_paths(root, paths, run, run_regex, run_name_prefix, create, logger)
 
     def import_segmentation_callback(run_obj, file_path, **kwargs):
         """Process segmentation files for a single run"""
@@ -1049,6 +1051,7 @@ def picks(
     config: str,
     run: str,
     run_regex: str,
+    run_name_prefix: str,
     object_name: str,
     user_id: str,
     session_id: str,
@@ -1161,7 +1164,7 @@ def picks(
         return
 
     # Prepare runs and group files
-    run_to_file = prepare_runs_from_paths(root, paths, run, run_regex, create, logger)
+    run_to_file = prepare_runs_from_paths(root, paths, run, run_regex, run_name_prefix, create, logger)
 
     def import_picks(run_obj, file_path, **kwargs):
         """Process one picks file for a single run"""

--- a/src/copick/cli/util.py
+++ b/src/copick/cli/util.py
@@ -118,6 +118,14 @@ def add_run_options(func: click.Command) -> click.Command:
             help="Regular expression to extract the run name from the filename. If not provided, will use the file "
             "name without extension. The regex should capture the run name in the first group.",
         ),
+        click.option(
+            "--run-name-prefix",
+            required=False,
+            type=str,
+            default="",
+            show_default=True,
+            help="Prefix to prepend to run names after regex extraction.",
+        ),
     ]
 
     for opt in opts:

--- a/src/copick/util/path_util.py
+++ b/src/copick/util/path_util.py
@@ -57,6 +57,7 @@ def prepare_runs_from_paths(
     paths: List[str],
     input_run: str,
     run_regex: str = r"(.*)",
+    run_name_prefix: str = "",
     create: bool = True,
     logger=None,
 ) -> Dict[str, str]:
@@ -69,6 +70,7 @@ def prepare_runs_from_paths(
         paths: List of file paths
         input_run: Run name (empty string means derive from filename)
         run_regex: Regex to match run names in filenames. First group is used as run name.
+        run_name_prefix: Prefix to prepend to run names after regex extraction.
         create: Whether to create runs if they don't exist
         logger: Logger instance
 
@@ -96,7 +98,7 @@ def prepare_runs_from_paths(
         # Match run name with regex
         match = re.search(run_regex, current_run)
         if match:
-            current_run = match.group(1)
+            current_run = f"{run_name_prefix}{match.group(1)}"
         else:
             if logger:
                 logger.warning(f"Run name {current_run} does not match regex {run_regex}. Skipping {path}.")


### PR DESCRIPTION
Adds the `--run-name-prefix` option to applicable `copick add` CLI-commands. This allows prepending unique identifiers (e.g. acquisition dates) when importing data, where run name collisions would otherwise occur. 