### PR TITLE
deps: Remove pandas pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "numcodecs<0.16.0",
     "numpy>=2.0.2",
     "ome-zarr>=0.10.2",
-    "pandas>=2.0.0,<3.0.0",
+    "pandas>=2.0.0",
     "psutil>=7.0.0",
     "pydantic>=2",
     "s3fs>=2025.5.1",

--- a/uv.lock
+++ b/uv.lock
@@ -848,7 +848,7 @@ requires-dist = [
     { name = "numcodecs", specifier = "<0.16.0" },
     { name = "numpy", specifier = ">=2.0.2" },
     { name = "ome-zarr", specifier = ">=0.10.2" },
-    { name = "pandas", specifier = ">=2.0.0,<3.0.0" },
+    { name = "pandas", specifier = ">=2.0.0" },
     { name = "pooch", marker = "extra == 'fledgeling'", specifier = ">=1.8.2" },
     { name = "pooch", marker = "extra == 'test'", specifier = ">=1.8.2" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },


### PR DESCRIPTION
dynamotable has been updated to be compatible with pandas>3, so we can remove the copick pandas pin to unbreak installs. 