### PR TITLE
fix: Fix run name determination in deposit.

### DIFF
--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -826,7 +826,7 @@ class CopickRunCDP(CopickRunOverlay):
 
     @property
     def portal_run_name(self) -> str:
-        return self.meta.name
+        return self.meta.portal_run_name
 
     @property
     def portal_dataset_id(self) -> int:

--- a/src/copick/ops/deposit.py
+++ b/src/copick/ops/deposit.py
@@ -359,7 +359,14 @@ def deposit(
             )
 
     # Get the runs to process
-    runs = root.runs if run_names is None else [root.get_run(name) for name in run_names]
+    if run_names is None:
+        runs = root.runs
+    else:
+        by_name = {r.name: r for r in root.runs}
+        missing = [n for n in run_names if n not in by_name]
+        if missing:
+            raise ValueError(f"Run names not found in project: {missing}")
+        runs = [by_name[n] for n in run_names]
 
     # For CDP projects, automatically construct run name prefixes from dataset_id and portal_run_name
     # unless a prefix is explicitly provided


### PR DESCRIPTION
Portal run name determination was broken by fixes to portal queries. This fix restores correct deposit run name determination. 