### PR TITLE
fix: Support new annotation object id types and paginate queries.

### DIFF
--- a/docs/datamodel.md
+++ b/docs/datamodel.md
@@ -62,8 +62,10 @@ label, color, radius, and other properties.
 
     - `pdb_id`: The PDB ID of the object, if available.
     - `emdb_id`: The EMDB ID of the object, if available.
-    - `identifier`: The GO ID of the object or a UniProtKB accession, if available. When using the data portal, this
-        field is used to find matching annotations in the data portal.
+    - `identifier`: An ontology/database identifier for the object, if available. Supported namespaces are
+        `GO`, `UniProtKB`, `CHEBI`, `PDB` (note the dash separator, e.g. `PDB-1BXN`), `UBERON`, `CL`, and `CDPO`.
+        When using the data portal, this field is matched exactly against the annotation `object_id` to find
+        matching annotations in the data portal.
     - `label`: An integer that indicates which numeric label should be used in segmentations to represent this object.
     - `color`: An array of four integers that represent the RGBA color of the object when rendered in a 3D viewer.
     - `radius`: An integer that represents the radius of the object in angstroms. This is used to determine the size of the

--- a/src/copick/cli/add.py
+++ b/src/copick/cli/add.py
@@ -822,7 +822,8 @@ def segmentation(
     "--identifier",
     type=str,
     default=None,
-    help="Identifier for the object (e.g. Gene Ontology ID or UniProtKB accession).",
+    help="Ontology/database identifier for the object (namespaces: GO, UniProtKB, CHEBI, "
+    "PDB [dash separator, e.g. PDB-1BXN], UBERON, CL, CDPO).",
 )
 @click.option(
     "--map-threshold",

--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -102,6 +102,61 @@ def _retry_portal_call(fn, *args, max_retries=3, base_delay=1.0, max_delay=30.0,
                 raise
 
 
+# Default number of runs to query per batch when building the annotation cache. A single
+# unbounded .find() over a large dataset can overload the portal (the heavyweight Tomogram
+# query 502s on datasets with many annotations), so whole-dataset queries are split into
+# per-run batches and their results concatenated. Kept intentionally conservative;
+# _find_batched halves a batch and retries if the portal still rejects it.
+_PORTAL_QUERY_BATCH_SIZE = 50
+
+
+def _find_batched(fn, client, run_ids, filter_builder, *, batch_size=_PORTAL_QUERY_BATCH_SIZE):
+    """Run a portal ``.find`` over run-id batches and concatenate the results.
+
+    A single ``.find()`` spanning an entire large dataset can overload the portal and
+    fail with repeated HTTP 502s. Splitting the query into per-run batches keeps each
+    response small enough to succeed, while producing the exact same combined result set.
+
+    Args:
+        fn: The portal ``.find`` classmethod to call (e.g. ``cdp.Tomogram.find``).
+        client: The portal client.
+        run_ids: Run IDs to cover; queries are issued in batches of these.
+        filter_builder: Callable mapping a batch of run IDs to the list of query filters
+            (including the run-id filter and any static filters such as shape type).
+        batch_size: Number of runs to query per batch.
+
+    Returns:
+        The concatenated results across all batches. On a transient portal error a batch
+        is halved and retried, so oversized responses shrink to a workable size automatically.
+    """
+    if not run_ids:
+        return []
+
+    results: List[Any] = []
+    # Stack of run-id batches still to fetch; a batch that fails is split back onto it.
+    pending = [run_ids[i : i + batch_size] for i in range(0, len(run_ids), batch_size)]
+    while pending:
+        batch = pending.pop()
+        try:
+            results.extend(_retry_portal_call(fn, client, filter_builder(batch)))
+        except Exception as e:  # noqa: BLE001
+            transient = _is_transient_portal_error(e) or isinstance(e, (ConnectionError, TimeoutError, OSError))
+            if transient and len(batch) > 1:
+                mid = len(batch) // 2
+                logger.warning(
+                    "Portal batch of %d runs failed (%s); splitting into %d + %d and retrying.",
+                    len(batch),
+                    type(e).__name__,
+                    mid,
+                    len(batch) - mid,
+                )
+                pending.append(batch[:mid])
+                pending.append(batch[mid:])
+            else:
+                raise
+    return results
+
+
 def camel(s: str) -> str:
     s = re.sub(r"([_\-])+", " ", s).title().replace(" ", "")
     return "".join([s[0].lower(), s[1:]])
@@ -1320,81 +1375,96 @@ class CopickRootCDP(CopickRoot):
         return {po.identifier: po.name for po in self.pickable_objects if po.identifier is not None}
 
     def _ensure_annotation_cache(self) -> PortalCache:
-        """Lazily fetch and cache all portal annotation data for picks, segmentations, and tomograms."""
+        """Fetch (in per-run batches) and cache all portal annotation data for picks, segmentations, and tomograms."""
         if self._portal_cache is not None:
             return self._portal_cache
 
         client = cdp.Client()
         go_map = self.go_map
+        go_keys = list(go_map.keys())
+        shape_types = ["Point", "OrientedPoint", "SegmentationMask"]
 
-        # 1. Fetch ALL annotation files for all datasets (picks + segmentations)
-        all_anno_files = _retry_portal_call(
+        # Fetch the run IDs for the configured datasets up front. Every query below is
+        # batched over these run IDs (via _find_batched) so a large dataset is not pulled
+        # in a single unbounded .find(), which overloads the portal (the Tomogram query
+        # 502s on datasets with many annotations). The batched results are concatenated
+        # and indexed exactly as before, so the resulting cache is identical.
+        runs = _retry_portal_call(cdp.Run.find, client, [cdp.Run.dataset_id._in(self.dataset_ids)])
+        run_ids = [r.id for r in runs]
+
+        # 1. Fetch annotation files (picks + segmentations)
+        all_anno_files = _find_batched(
             cdp.AnnotationFile.find,
             client,
-            [
-                cdp.AnnotationFile.annotation_shape.annotation.run.dataset_id._in(self.dataset_ids),  # noqa
-                cdp.AnnotationFile.annotation_shape.shape_type._in(
-                    ["Point", "OrientedPoint", "SegmentationMask"],
-                ),  # noqa
-                cdp.AnnotationFile.annotation_shape.annotation.object_id._in(list(go_map.keys())),  # noqa
+            run_ids,
+            lambda b: [
+                cdp.AnnotationFile.annotation_shape.annotation.run.id._in(b),  # noqa
+                cdp.AnnotationFile.annotation_shape.shape_type._in(shape_types),  # noqa
+                cdp.AnnotationFile.annotation_shape.annotation.object_id._in(go_keys),  # noqa
             ],
         )
 
-        # 2. Fetch ALL annotation shapes (direct filters to avoid huge _in() lists)
-        all_shapes = _retry_portal_call(
+        # 2. Fetch annotation shapes
+        all_shapes = _find_batched(
             cdp.AnnotationShape.find,
             client,
-            [
-                cdp.AnnotationShape.annotation.run.dataset_id._in(self.dataset_ids),  # noqa
-                cdp.AnnotationShape.shape_type._in(["Point", "OrientedPoint", "SegmentationMask"]),  # noqa
-                cdp.AnnotationShape.annotation.object_id._in(list(go_map.keys())),  # noqa
+            run_ids,
+            lambda b: [
+                cdp.AnnotationShape.annotation.run.id._in(b),  # noqa
+                cdp.AnnotationShape.shape_type._in(shape_types),  # noqa
+                cdp.AnnotationShape.annotation.object_id._in(go_keys),  # noqa
             ],
         )
 
-        # 3. Fetch ALL annotations
-        all_annotations = _retry_portal_call(
+        # 3. Fetch annotations
+        all_annotations = _find_batched(
             cdp.Annotation.find,
             client,
-            [
-                cdp.Annotation.run.dataset_id._in(self.dataset_ids),  # noqa
-                cdp.Annotation.object_id._in(list(go_map.keys())),  # noqa
+            run_ids,
+            lambda b: [
+                cdp.Annotation.run.id._in(b),  # noqa
+                cdp.Annotation.object_id._in(go_keys),  # noqa
             ],
         )
 
-        # 4. Fetch ALL annotation authors
-        all_authors = _retry_portal_call(
+        # 4. Fetch annotation authors
+        all_authors = _find_batched(
             cdp.AnnotationAuthor.find,
             client,
-            [
-                cdp.AnnotationAuthor.annotation.run.dataset_id._in(self.dataset_ids),  # noqa
-                cdp.AnnotationAuthor.annotation.object_id._in(list(go_map.keys())),  # noqa
+            run_ids,
+            lambda b: [
+                cdp.AnnotationAuthor.annotation.run.id._in(b),  # noqa
+                cdp.AnnotationAuthor.annotation.object_id._in(go_keys),  # noqa
             ],
         )
 
-        # 5. Fetch ALL voxel spacings
-        all_voxel_spacings = _retry_portal_call(
+        # 5. Fetch voxel spacings
+        all_voxel_spacings = _find_batched(
             cdp.TomogramVoxelSpacing.find,
             client,
-            [
-                cdp.TomogramVoxelSpacing.run.dataset_id._in(self.dataset_ids),  # noqa
+            run_ids,
+            lambda b: [
+                cdp.TomogramVoxelSpacing.run.id._in(b),  # noqa
             ],
         )
 
-        # 6. Fetch ALL tomograms for all datasets
-        all_tomograms = _retry_portal_call(
+        # 6. Fetch tomograms
+        all_tomograms = _find_batched(
             cdp.Tomogram.find,
             client,
-            [
-                cdp.Tomogram.tomogram_voxel_spacing.run.dataset_id._in(self.dataset_ids),  # noqa
+            run_ids,
+            lambda b: [
+                cdp.Tomogram.tomogram_voxel_spacing.run.id._in(b),  # noqa
             ],
         )
 
-        # 7. Fetch ALL tomogram authors
-        all_tomogram_authors = _retry_portal_call(
+        # 7. Fetch tomogram authors
+        all_tomogram_authors = _find_batched(
             cdp.TomogramAuthor.find,
             client,
-            [
-                cdp.TomogramAuthor.tomogram.tomogram_voxel_spacing.run.dataset_id._in(self.dataset_ids),  # noqa
+            run_ids,
+            lambda b: [
+                cdp.TomogramAuthor.tomogram.tomogram_voxel_spacing.run.id._in(b),  # noqa
             ],
         )
 

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -25,7 +25,9 @@ class PickableObject(BaseModel):
         color: RGBA color for the object.
         emdb_id: EMDB ID for the object.
         pdb_id: PDB ID for the object.
-        identifier: Identifier for the object (e.g. Gene Ontology ID or UniProtKB accession).
+        identifier: Identifier for the object, drawn from an ontology/database namespace
+            (GO, UniProtKB, CHEBI, PDB [dash separator, e.g. ``PDB-1BXN``], UBERON, CL, or CDPO).
+            When using the data portal, this must match the annotation ``object_id`` exactly.
         map_threshold: Threshold to apply to the map when rendering the isosurface.
         radius: Radius of the particle, when displaying as a sphere.
         metadata: Additional metadata for the object (user-defined contents).
@@ -598,7 +600,9 @@ class CopickRoot:
             color: RGBA color for the object. If None, will use a default color.
             emdb_id: EMDB ID for the object.
             pdb_id: PDB ID for the object.
-            identifier: Identifier for the object (e.g. Gene Ontology ID or UniProtKB accession).
+            identifier: Identifier for the object, drawn from an ontology/database namespace
+            (GO, UniProtKB, CHEBI, PDB [dash separator, e.g. ``PDB-1BXN``], UBERON, CL, or CDPO).
+            When using the data portal, this must match the annotation ``object_id`` exactly.
             map_threshold: Threshold to apply to the map when rendering the isosurface.
             radius: Radius of the particle, when displaying as a sphere.
             metadata: Additional metadata for the object (user-defined contents).

--- a/src/copick/ops/_markdown.py
+++ b/src/copick/ops/_markdown.py
@@ -18,6 +18,7 @@ from copick.models import (
     CopickVoxelSpacing,
     PickableObject,
 )
+from copick.util.ontology import parse_identifier
 
 DEFAULT_MARKDOWN = """\
 # Metadata
@@ -35,18 +36,21 @@ def object_to_md(pickable_object: PickableObject) -> str:
     md = "# PickableObject Metadata\n"
     md += f"## Object: {pickable_object.name}\n"
 
-    if pickable_object.identifier.lower().startswith("go"):
-        md += f"* Identifier: [{pickable_object.identifier}](https://amigo.geneontology.org/amigo/term/{pickable_object.identifier})\n"
-    elif pickable_object.identifier.lower().startswith("uniprotkb"):
-        ident = pickable_object.identifier.split(":")[-1]
-        md += f"* Identifier: [{pickable_object.identifier}](https://www.uniprot.org/uniprotkb/{ident})\n"
-    else:
-        md += f"* Identifier: {pickable_object.identifier}\n"
+    identifier_ref = parse_identifier(pickable_object.identifier)
+    if pickable_object.identifier:
+        if identifier_ref and identifier_ref.url:
+            md += f"* Identifier: [{pickable_object.identifier}]({identifier_ref.url})\n"
+        else:
+            md += f"* Identifier: {pickable_object.identifier}\n"
 
     if pickable_object.emdb_id:
         md += f"* EMDB ID: [{pickable_object.emdb_id}](https://www.ebi.ac.uk/emdb/{pickable_object.emdb_id})\n"
 
-    if pickable_object.pdb_id:
+    # Suppress the duplicate RCSB link when the identifier itself is this same PDB id.
+    pdb_is_identifier = bool(
+        identifier_ref and identifier_ref.namespace == "PDB" and identifier_ref.accession == pickable_object.pdb_id,
+    )
+    if pickable_object.pdb_id and not pdb_is_identifier:
         md += f"* PDB ID: [{pickable_object.pdb_id}](https://www.rcsb.org/structure/{pickable_object.pdb_id})\n"
 
     typ = "particle/segmentation" if pickable_object.is_particle else "segmentation"

--- a/src/copick/util/ontology.py
+++ b/src/copick/util/ontology.py
@@ -1,0 +1,134 @@
+"""Parsing and external-link resolution for CryoET Data Portal object identifiers.
+
+The Data Portal identifies an annotation's object with an ``object_id`` drawn
+from one of several identifier namespaces (see the portal LinkML schema, slot
+``annotation_object_id``). copick stores that value verbatim as
+:attr:`PickableObject.identifier`. This module maps such an identifier to its
+namespace, bare accession, and an external browser URL where available.
+
+Supported namespaces:
+
+===========  ==========================  ==============================
+Namespace    Example                     External resource
+===========  ==========================  ==============================
+GO           ``GO:0005840``              AmiGO (Gene Ontology)
+UniProtKB    ``UniProtKB:P0CX35``        UniProt
+CHEBI        ``CHEBI:15986``             ChEBI (EBI)
+PDB          ``PDB-1BXN`` (dash!)        RCSB PDB
+UBERON       ``UBERON:0000955``          OBO PURL
+CL           ``CL:0000000``             OBO PURL
+CDPO         ``CDPO:0000001``           (no public browser)
+===========  ==========================  ==============================
+"""
+
+import re
+from typing import Callable, List, NamedTuple, Optional, Pattern, Tuple
+
+
+class OntologyRef(NamedTuple):
+    """Parsed representation of an object identifier.
+
+    Attributes:
+        namespace: Canonical namespace (e.g. ``"GO"``, ``"PDB"``) or ``None`` if
+            the identifier does not match any known namespace.
+        accession: The bare accession after the namespace separator (e.g.
+            ``"0005840"``, ``"P0CX35"``, ``"1BXN"``). For unrecognized strings
+            this is the raw identifier.
+        url: External browser URL, or ``None`` when the namespace has no public
+            browser (CDPO) or the identifier is unrecognized.
+    """
+
+    namespace: Optional[str]
+    accession: str
+    url: Optional[str]
+
+
+# Ordered registry: (canonical namespace, regex with named accession group, url_builder | None).
+# Matching is case-insensitive on the scheme (preserving the historical
+# ``identifier.lower().startswith(...)`` behavior), but URLs are rebuilt from the
+# canonical namespace so links are always well-formed regardless of input case.
+# NOTE: PDB uses a dash separator (``PDB-1BXN``), unlike the colon namespaces.
+_NAMESPACES: List[Tuple[str, Pattern, Optional[Callable[[re.Match], str]]]] = [
+    (
+        "GO",
+        re.compile(r"^GO:(?P<num>[0-9]{7})$", re.IGNORECASE),
+        lambda m: f"https://amigo.geneontology.org/amigo/term/GO:{m['num']}",
+    ),
+    (
+        "UniProtKB",
+        re.compile(r"^UniProtKB:(?P<acc>\S+)$", re.IGNORECASE),
+        lambda m: f"https://www.uniprot.org/uniprotkb/{m['acc']}",
+    ),
+    (
+        "CHEBI",
+        re.compile(r"^CHEBI:(?P<num>[0-9]+)$", re.IGNORECASE),
+        lambda m: f"https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:{m['num']}",
+    ),
+    (
+        "PDB",
+        re.compile(r"^PDB-(?P<acc>[0-9a-zA-Z]{4,8})$", re.IGNORECASE),
+        lambda m: f"https://www.rcsb.org/structure/{m['acc']}",
+    ),
+    (
+        "UBERON",
+        re.compile(r"^UBERON:(?P<num>[0-9]{7})$", re.IGNORECASE),
+        lambda m: f"https://purl.obolibrary.org/obo/UBERON_{m['num']}",
+    ),
+    (
+        "CL",
+        re.compile(r"^CL:(?P<num>[0-9]{7})$", re.IGNORECASE),
+        lambda m: f"https://purl.obolibrary.org/obo/CL_{m['num']}",
+    ),
+    (
+        # Recognized namespace, but no public web browser -> render as plain text.
+        "CDPO",
+        re.compile(r"^CDPO:(?P<num>[0-9]{7})$", re.IGNORECASE),
+        None,
+    ),
+]
+
+
+def parse_identifier(identifier: Optional[str]) -> Optional[OntologyRef]:
+    """Map a portal object identifier to its namespace, accession, and URL.
+
+    Args:
+        identifier: The object identifier (e.g. ``"GO:0005840"``, ``"PDB-1BXN"``).
+
+    Returns:
+        ``None`` when ``identifier`` is ``None`` or empty. Otherwise an
+        :class:`OntologyRef`. For recognized namespaces without a public browser
+        (CDPO) and for unrecognized strings, ``url`` is ``None``; unrecognized
+        strings additionally have ``namespace=None``.
+    """
+    if not identifier:
+        return None
+
+    ident = identifier.strip()
+    for namespace, pattern, url_builder in _NAMESPACES:
+        m = pattern.match(ident)
+        if m:
+            groups = m.groupdict()
+            accession = groups.get("acc") or groups.get("num")
+            return OntologyRef(namespace, accession, url_builder(m) if url_builder else None)
+
+    return OntologyRef(None, ident, None)
+
+
+def identifier_to_markdown_link(identifier: Optional[str]) -> Optional[str]:
+    """Render an identifier as a markdown link when resolvable.
+
+    Args:
+        identifier: The object identifier.
+
+    Returns:
+        ``"[identifier](url)"`` when the identifier resolves to a URL, the plain
+        ``identifier`` string when it is recognized but has no URL (or is
+        unrecognized), and ``None`` when ``identifier`` is ``None`` or empty.
+    """
+    if not identifier:
+        return None
+
+    ref = parse_identifier(identifier)
+    if ref and ref.url:
+        return f"[{identifier}]({ref.url})"
+    return identifier

--- a/src/copick/util/portal.py
+++ b/src/copick/util/portal.py
@@ -6,6 +6,7 @@ import distinctipy
 from copick.models import PickableObject
 from copick.util.escape import sanitize_name
 from copick.util.log import get_logger
+from copick.util.ontology import parse_identifier
 
 logger = get_logger(__name__)
 
@@ -54,6 +55,14 @@ def objects_from_datasets(dataset_ids: List[int]) -> List[PickableObject]:
         if apubs:
             pdb_ids = [pub for pub in apubs if pub.startswith("PDB")]
             pdb_id = pdb_ids[0] if pdb_ids else None
+
+        # If the object_id itself is a PDB identifier (e.g. "PDB-1BXN"), use it as
+        # the pdb_id (stripped of the "PDB-" prefix). Only fill when not already
+        # derived from the annotation's publications, so those are never clobbered.
+        if pdb_id is None:
+            ref = parse_identifier(anno.object_id)
+            if ref and ref.namespace == "PDB":
+                pdb_id = ref.accession
 
         # Overwrite all values but is_particle if the object is already in the dict
         po = portal_objects.get(anno.object_id, None)

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -1,0 +1,140 @@
+import pytest
+from copick.models import PickableObject
+from copick.ops._markdown import object_to_md
+from copick.util.ontology import (
+    OntologyRef,
+    identifier_to_markdown_link,
+    parse_identifier,
+)
+
+
+class TestParseIdentifier:
+    """Test cases for copick.util.ontology.parse_identifier."""
+
+    @pytest.mark.parametrize(
+        ("identifier", "expected"),
+        [
+            (
+                "GO:0005840",
+                OntologyRef("GO", "0005840", "https://amigo.geneontology.org/amigo/term/GO:0005840"),
+            ),
+            (
+                "UniProtKB:P0CX35",
+                OntologyRef("UniProtKB", "P0CX35", "https://www.uniprot.org/uniprotkb/P0CX35"),
+            ),
+            (
+                "CHEBI:15986",
+                OntologyRef("CHEBI", "15986", "https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:15986"),
+            ),
+            (
+                "PDB-1BXN",
+                OntologyRef("PDB", "1BXN", "https://www.rcsb.org/structure/1BXN"),
+            ),
+            (
+                "UBERON:0000955",
+                OntologyRef("UBERON", "0000955", "https://purl.obolibrary.org/obo/UBERON_0000955"),
+            ),
+            (
+                "CL:0000000",
+                OntologyRef("CL", "0000000", "https://purl.obolibrary.org/obo/CL_0000000"),
+            ),
+            (
+                # Recognized namespace, but no public browser -> url is None.
+                "CDPO:0000001",
+                OntologyRef("CDPO", "0000001", None),
+            ),
+        ],
+    )
+    def test_known_namespaces(self, identifier, expected):
+        """Each supported namespace resolves to the expected (namespace, accession, url)."""
+        assert parse_identifier(identifier) == expected
+
+    @pytest.mark.parametrize("identifier", ["go:0005840", "pdb-1bxn", "uniprotkb:P0CX35", "chebi:15986"])
+    def test_case_insensitive_scheme(self, identifier):
+        """Lower-cased schemes still resolve to canonical URLs."""
+        ref = parse_identifier(identifier)
+        assert ref is not None
+        assert ref.namespace is not None
+        assert ref.url is not None
+        # URL is rebuilt from the canonical namespace, so it is well-formed regardless of input case.
+        assert ref.url.startswith("https://")
+
+    @pytest.mark.parametrize("identifier", [None, ""])
+    def test_none_or_empty(self, identifier):
+        """None/empty identifiers return None."""
+        assert parse_identifier(identifier) is None
+
+    @pytest.mark.parametrize("identifier", ["ribosome", "FOO:1", "PDB-1BX"])
+    def test_unrecognized(self, identifier):
+        """Unrecognized strings yield namespace=None with the raw string echoed and no URL.
+
+        ``PDB-1BX`` (3 accession chars) is below the ``{4,8}`` bound, so it does NOT match PDB.
+        """
+        assert parse_identifier(identifier) == OntologyRef(None, identifier, None)
+
+    def test_strips_whitespace(self):
+        """Leading/trailing whitespace is stripped before matching."""
+        assert parse_identifier("  GO:0005840  ").namespace == "GO"
+
+
+class TestIdentifierToMarkdownLink:
+    """Test cases for copick.util.ontology.identifier_to_markdown_link."""
+
+    def test_resolvable(self):
+        assert (
+            identifier_to_markdown_link("GO:0005840")
+            == "[GO:0005840](https://amigo.geneontology.org/amigo/term/GO:0005840)"
+        )
+
+    def test_no_url_namespace_returns_plain(self):
+        assert identifier_to_markdown_link("CDPO:0000001") == "CDPO:0000001"
+
+    def test_unrecognized_returns_plain(self):
+        assert identifier_to_markdown_link("ribosome") == "ribosome"
+
+    @pytest.mark.parametrize("identifier", [None, ""])
+    def test_none_or_empty(self, identifier):
+        assert identifier_to_markdown_link(identifier) is None
+
+
+class TestObjectToMd:
+    """Test cases for object_to_md identifier rendering."""
+
+    def _obj(self, **kwargs):
+        defaults = {"name": "test-object", "is_particle": True}
+        defaults.update(kwargs)
+        return PickableObject(**defaults)
+
+    @pytest.mark.parametrize(
+        ("identifier", "expected_url"),
+        [
+            ("GO:0005840", "https://amigo.geneontology.org/amigo/term/GO:0005840"),
+            ("CHEBI:15986", "https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:15986"),
+            ("PDB-1BXN", "https://www.rcsb.org/structure/1BXN"),
+            ("UBERON:0000955", "https://purl.obolibrary.org/obo/UBERON_0000955"),
+            ("CL:0000000", "https://purl.obolibrary.org/obo/CL_0000000"),
+        ],
+    )
+    def test_identifier_link_rendered(self, identifier, expected_url):
+        md = object_to_md(self._obj(identifier=identifier))
+        assert f"* Identifier: [{identifier}]({expected_url})\n" in md
+
+    def test_cdpo_rendered_plain(self):
+        md = object_to_md(self._obj(identifier="CDPO:0000001"))
+        assert "* Identifier: CDPO:0000001\n" in md
+        assert "](http" not in md.split("* Identifier:")[1].split("\n")[0]
+
+    def test_none_identifier_does_not_raise(self):
+        """Regression: a None identifier must not crash and emits no Identifier line."""
+        md = object_to_md(self._obj(identifier=None))
+        assert "* Identifier:" not in md
+
+    def test_pdb_identifier_deduplicates_rcsb_link(self):
+        """When identifier and pdb_id are the same PDB structure, only one RCSB link appears."""
+        md = object_to_md(self._obj(identifier="PDB-1BXN", pdb_id="1BXN"))
+        assert md.count("https://www.rcsb.org/structure/1BXN") == 1
+
+    def test_pdb_id_still_links_when_distinct_from_identifier(self):
+        """A pdb_id distinct from a non-PDB identifier still renders its own RCSB link."""
+        md = object_to_md(self._obj(identifier="GO:0005840", pdb_id="4V9D"))
+        assert "* PDB ID: [4V9D](https://www.rcsb.org/structure/4V9D)\n" in md


### PR DESCRIPTION
The cryoET data portal now supports more Ontologies/Accessions for annotation_object_ids. Support this in copick and make more robust against extremely large annotation sets on the portal. 