### PR TITLE
feat: Normalize run option across CLI tools

### DIFF
--- a/src/copick/cli/export.py
+++ b/src/copick/cli/export.py
@@ -8,6 +8,8 @@ from copick.cli.util import (
     add_export_common_options,
     add_max_workers_option,
     add_pyramid_export_options,
+    add_run_names_option,
+    resolve_run_names,
 )
 from copick.util.log import get_logger
 
@@ -24,6 +26,7 @@ def export(ctx):
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @click.option(
     "--picks-uri",
     required=True,
@@ -43,12 +46,6 @@ def export(ctx):
     default=None,
     help="Output file for combined export (all runs in one file). Mutually exclusive with --output-dir.",
     metavar="PATH",
-)
-@click.option(
-    "--run-names",
-    type=str,
-    default=None,
-    help="Comma-separated list of run names to process.",
 )
 @click.option(
     "--output-format",
@@ -85,7 +82,7 @@ def picks(
     output_dir: str,
     output_file: str,
     output_format: str,
-    run_names: str,
+    run_names,
     voxel_size: float,
     index_map: str,
     include_optics: bool,
@@ -147,10 +144,8 @@ def picks(
     if output_format.lower() in ["em", "star", "dynamo"] and voxel_size is None:
         ctx.fail(f"--voxel-size is required for {output_format.upper()} format export.")
 
-    # Parse run names
-    run_names_list = None
-    if run_names:
-        run_names_list = [name.strip() for name in run_names.split(",") if name.strip()]
+    # Resolve run names (repeatable; legacy comma-separated values tolerated with a warning)
+    run_names_list = resolve_run_names(run_names, logger=logger)
 
     # Load index map if provided
     run_to_index = None
@@ -206,6 +201,7 @@ def picks(
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @click.option(
     "--tomogram-uri",
     required=True,
@@ -229,7 +225,7 @@ def tomogram(
     tomogram_uri: str,
     output_dir: str,
     output_format: str,
-    run_names: str,
+    run_names,
     level: int,
     compression: str,
     copy_all_levels: bool,
@@ -274,10 +270,8 @@ def tomogram(
 
     logger = get_logger(__name__, debug=debug)
 
-    # Parse run names
-    run_names_list = None
-    if run_names:
-        run_names_list = [name.strip() for name in run_names.split(",") if name.strip()]
+    # Resolve run names (repeatable; legacy comma-separated values tolerated with a warning)
+    run_names_list = resolve_run_names(run_names, logger=logger)
 
     # Handle compression
     compression_value = compression if compression and compression.lower() != "none" else None
@@ -305,6 +299,7 @@ def tomogram(
     no_args_is_help=True,
 )
 @add_config_option
+@add_run_names_option
 @click.option(
     "--segmentation-uri",
     required=True,
@@ -328,7 +323,7 @@ def segmentation(
     segmentation_uri: str,
     output_dir: str,
     output_format: str,
-    run_names: str,
+    run_names,
     level: int,
     compression: str,
     copy_all_levels: bool,
@@ -375,10 +370,8 @@ def segmentation(
 
     logger = get_logger(__name__, debug=debug)
 
-    # Parse run names
-    run_names_list = None
-    if run_names:
-        run_names_list = [name.strip() for name in run_names.split(",") if name.strip()]
+    # Resolve run names (repeatable; legacy comma-separated values tolerated with a warning)
+    run_names_list = resolve_run_names(run_names, logger=logger)
 
     # Handle compression
     compression_value = compression if compression and compression.lower() != "none" else None

--- a/src/copick/cli/stats.py
+++ b/src/copick/cli/stats.py
@@ -2,7 +2,13 @@ import json
 
 import click
 
-from copick.cli.util import add_config_option, add_debug_option
+from copick.cli.util import (
+    add_config_option,
+    add_debug_option,
+    add_deprecated_run_alias,
+    add_run_names_option,
+    resolve_run_names,
+)
 from copick.ops.open import from_file
 from copick.ops.stats import meshes_stats, picks_stats, segmentations_stats
 from copick.util.log import get_logger
@@ -25,12 +31,8 @@ def stats(ctx):
     no_args_is_help=True,
 )
 @add_config_option
-@click.option(
-    "--runs",
-    type=str,
-    multiple=True,
-    help="Specific run names to analyze. Can be specified multiple times.",
-)
+@add_run_names_option
+@add_deprecated_run_alias("--runs")
 @click.option(
     "--user-id",
     type=str,
@@ -71,7 +73,8 @@ def stats(ctx):
 def picks(
     ctx,
     config,
-    runs,
+    run_names,
+    legacy_run_names,
     user_id,
     session_id,
     object_name,
@@ -96,7 +99,7 @@ def picks(
 
         \b
         # Restrict the summary to specific runs
-        copick stats picks --config config.json --runs TS_001 --runs TS_002
+        copick stats picks --config config.json -r TS_001 -r TS_002
 
         \b
         # Filter by object and user, then emit JSON using parallel workers
@@ -109,7 +112,7 @@ def picks(
         copick stats meshes: summarize mesh annotations in the project
         copick stats segmentations: summarize segmentation annotations in the project
     """
-    get_logger(__name__, debug)
+    logger = get_logger(__name__, debug)
 
     if config is None:
         raise click.ClickException("Configuration file path is required. Use -c/--config option.")
@@ -117,7 +120,7 @@ def picks(
     root = from_file(config)
 
     # Convert tuples to lists or None
-    runs_param = list(runs) if runs else None
+    runs_param = resolve_run_names(run_names, legacy_run_names, legacy_flag="--runs", logger=logger)
     user_id_param = list(user_id) if user_id else None
     session_id_param = list(session_id) if session_id else None
     object_name_param = list(object_name) if object_name else None
@@ -145,12 +148,8 @@ def picks(
     no_args_is_help=True,
 )
 @add_config_option
-@click.option(
-    "--runs",
-    type=str,
-    multiple=True,
-    help="Specific run names to analyze. Can be specified multiple times.",
-)
+@add_run_names_option
+@add_deprecated_run_alias("--runs")
 @click.option(
     "--user-id",
     type=str,
@@ -191,7 +190,8 @@ def picks(
 def meshes(
     ctx,
     config,
-    runs,
+    run_names,
+    legacy_run_names,
     user_id,
     session_id,
     object_name,
@@ -229,7 +229,7 @@ def meshes(
         copick stats picks: summarize pick annotations in the project
         copick stats segmentations: summarize segmentation annotations in the project
     """
-    get_logger(__name__, debug)
+    logger = get_logger(__name__, debug)
 
     if config is None:
         raise click.ClickException("Configuration file path is required. Use -c/--config option.")
@@ -237,7 +237,7 @@ def meshes(
     root = from_file(config)
 
     # Convert tuples to lists or None
-    runs_param = list(runs) if runs else None
+    runs_param = resolve_run_names(run_names, legacy_run_names, legacy_flag="--runs", logger=logger)
     user_id_param = list(user_id) if user_id else None
     session_id_param = list(session_id) if session_id else None
     object_name_param = list(object_name) if object_name else None
@@ -265,12 +265,8 @@ def meshes(
     no_args_is_help=True,
 )
 @add_config_option
-@click.option(
-    "--runs",
-    type=str,
-    multiple=True,
-    help="Specific run names to analyze. Can be specified multiple times.",
-)
+@add_run_names_option
+@add_deprecated_run_alias("--runs")
 @click.option(
     "--user-id",
     type=str,
@@ -322,7 +318,8 @@ def meshes(
 def segmentations(
     ctx,
     config,
-    runs,
+    run_names,
+    legacy_run_names,
     user_id,
     session_id,
     name,
@@ -367,7 +364,7 @@ def segmentations(
         copick stats picks: summarize pick annotations in the project
         copick stats meshes: summarize mesh annotations in the project
     """
-    get_logger(__name__, debug)
+    logger = get_logger(__name__, debug)
 
     if config is None:
         raise click.ClickException("Configuration file path is required. Use -c/--config option.")
@@ -375,7 +372,7 @@ def segmentations(
     root = from_file(config)
 
     # Convert tuples to lists or None
-    runs_param = list(runs) if runs else None
+    runs_param = resolve_run_names(run_names, legacy_run_names, legacy_flag="--runs", logger=logger)
     user_id_param = list(user_id) if user_id else None
     session_id_param = list(session_id) if session_id else None
     name_param = list(name) if name else None

--- a/src/copick/cli/util.py
+++ b/src/copick/cli/util.py
@@ -1,3 +1,5 @@
+from typing import List, Optional, Sequence
+
 import click
 
 
@@ -54,6 +56,117 @@ def add_debug_option(func: click.Command) -> click.Command:
         func = opt(func)
 
     return func
+
+
+def add_run_names_option(func: click.Command) -> click.Command:
+    """
+    Add the standard ``--run-names`` / ``-r`` run-selection option.
+
+    This is the single, uniform way for copick-internal commands to select which
+    runs to operate on. It is repeatable (``multiple=True``) and yields a tuple in
+    the ``run_names`` parameter; pass that tuple through :func:`resolve_run_names`
+    to obtain a ``list[str] | None`` (``None`` meaning "all runs").
+
+    Args:
+        func (click.Command): The Click command to which the option will be added.
+
+    Returns:
+        click.Command: The Click command with the run-names option added.
+    """
+    opts = [
+        click.option(
+            "--run-names",
+            "-r",
+            multiple=True,
+            help="Specific run names to process (default: all runs). Repeatable; pass -r once per run.",
+        ),
+    ]
+
+    for opt in opts:
+        func = opt(func)
+
+    return func
+
+
+def add_deprecated_run_alias(*flags: str) -> "click.Command":
+    """
+    Add a hidden, deprecated alias for :func:`add_run_names_option`.
+
+    Used for commands whose run-selection flag is being renamed (e.g. ``--runs``
+    or ``--run-ids``). The alias keeps old invocations working while remaining
+    hidden from ``--help``; its value lands in the ``legacy_run_names`` parameter,
+    which :func:`resolve_run_names` merges in (emitting a deprecation warning).
+
+    Args:
+        *flags (str): The deprecated option flag(s), e.g. ``"--runs"`` or
+            ``"--run-ids", "-runs"``.
+
+    Returns:
+        A decorator that adds the hidden alias option to a Click command.
+    """
+
+    def decorator(func: click.Command) -> click.Command:
+        return click.option(
+            *flags,
+            "legacy_run_names",
+            multiple=True,
+            hidden=True,
+            help="Deprecated: use --run-names/-r instead.",
+        )(func)
+
+    return decorator
+
+
+def resolve_run_names(
+    run_names: Sequence[str] = (),
+    legacy_run_names: Sequence[str] = (),
+    *,
+    legacy_flag: Optional[str] = None,
+    logger=None,
+) -> Optional[List[str]]:
+    """
+    Normalize the standard and deprecated run-selection inputs into a run list.
+
+    Merges the values from ``--run-names``/``-r`` with any values collected by a
+    deprecated alias (see :func:`add_deprecated_run_alias`), transparently
+    splitting legacy comma-joined values. Deprecation warnings are emitted (via
+    ``logger``) when a deprecated alias or a comma-joined value is used.
+
+    Args:
+        run_names: Values from the standard ``--run-names``/``-r`` option.
+        legacy_run_names: Values from a deprecated alias option, if any.
+        legacy_flag: Human-readable name of the deprecated flag, used in the
+            warning message (e.g. ``"--runs"``).
+        logger: Optional logger for deprecation warnings.
+
+    Returns:
+        A list of run names, or ``None`` when no runs were specified (meaning
+        "all runs").
+    """
+    values = list(run_names or ())
+
+    legacy = list(legacy_run_names or ())
+    if legacy:
+        if logger is not None:
+            flag = legacy_flag or "This run-selection flag"
+            logger.warning(f"{flag} is deprecated; use --run-names/-r (repeatable) instead.")
+        values.extend(legacy)
+
+    expanded: List[str] = []
+    saw_comma = False
+    for value in values:
+        if value is None:
+            continue
+        if "," in value:
+            saw_comma = True
+            expanded.extend(part.strip() for part in value.split(",") if part.strip())
+        else:
+            expanded.append(value)
+
+    if saw_comma and logger is not None:
+        logger.warning("Comma-separated run names are deprecated; pass -r/--run-names once per run instead.")
+
+    return expanded or None
 
 
 def add_create_overwrite_options(func: click.Command) -> click.Command:
@@ -277,7 +390,9 @@ def add_pyramid_create_options(func: click.Command) -> click.Command:
 
 def add_export_common_options(func: click.Command) -> click.Command:
     """
-    Add common export options: --output-dir, --run-names.
+    Add common export options: --output-dir.
+
+    Run selection is provided separately via :func:`add_run_names_option`.
 
     Args:
         func (click.Command): The Click command to which the options will be added.
@@ -292,12 +407,6 @@ def add_export_common_options(func: click.Command) -> click.Command:
             type=click.Path(file_okay=False, dir_okay=True),
             help="Output directory for exported files.",
             metavar="PATH",
-        ),
-        click.option(
-            "--run-names",
-            type=str,
-            default="",
-            help="Comma-separated list of run names to export. If not specified, exports from all runs.",
         ),
     ]
 

--- a/tests/test_run_names_option.py
+++ b/tests/test_run_names_option.py
@@ -1,0 +1,128 @@
+"""Tests for the shared run-selection option (``--run-names``/``-r``).
+
+Covers the helpers added in :mod:`copick.cli.util` (``add_run_names_option``,
+``add_deprecated_run_alias``, ``resolve_run_names``) and their wiring on the real
+``stats`` and ``export`` commands, including the hidden deprecated ``--runs``
+alias and legacy comma-separated back-compat.
+"""
+
+import click
+import pytest
+from click.testing import CliRunner
+from copick.cli.util import (
+    add_deprecated_run_alias,
+    add_run_names_option,
+    resolve_run_names,
+)
+
+
+class _RecordingLogger:
+    """Minimal logger stub that records ``warning`` calls."""
+
+    def __init__(self):
+        self.warnings = []
+
+    def warning(self, msg, *args, **kwargs):
+        self.warnings.append(msg)
+
+
+# --------------------------------------------------------------------------- #
+# resolve_run_names unit tests
+# --------------------------------------------------------------------------- #
+def test_resolve_empty_returns_none():
+    assert resolve_run_names((), ()) is None
+    assert resolve_run_names(()) is None
+
+
+def test_resolve_repeatable_values():
+    assert resolve_run_names(("TS_001", "TS_002")) == ["TS_001", "TS_002"]
+
+
+def test_resolve_splits_legacy_comma_values_and_warns():
+    logger = _RecordingLogger()
+    assert resolve_run_names(("a,b", "c"), logger=logger) == ["a", "b", "c"]
+    assert any("comma" in w.lower() for w in logger.warnings)
+
+
+def test_resolve_merges_legacy_alias_and_warns():
+    logger = _RecordingLogger()
+    result = resolve_run_names((), ("x", "y"), legacy_flag="--runs", logger=logger)
+    assert result == ["x", "y"]
+    assert any("--runs" in w and "deprecated" in w.lower() for w in logger.warnings)
+
+
+def test_resolve_combines_new_and_legacy():
+    assert resolve_run_names(("a",), ("b,c",)) == ["a", "b", "c"]
+
+
+def test_resolve_clean_input_does_not_warn():
+    logger = _RecordingLogger()
+    resolve_run_names(("a", "b"), logger=logger)
+    assert logger.warnings == []
+
+
+# --------------------------------------------------------------------------- #
+# Decorator wiring on a throwaway command
+# --------------------------------------------------------------------------- #
+@click.command()
+@add_run_names_option
+@add_deprecated_run_alias("--runs")
+def _dummy(run_names, legacy_run_names):
+    resolved = resolve_run_names(run_names, legacy_run_names, legacy_flag="--runs")
+    click.echo(repr(resolved))
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_help_shows_standard_option_hides_alias(runner):
+    out = runner.invoke(_dummy, ["--help"]).output
+    assert "--run-names" in out
+    assert "-r" in out
+    assert "--runs" not in out  # deprecated alias is hidden
+
+
+def test_short_and_long_flags_repeatable(runner):
+    assert runner.invoke(_dummy, ["-r", "a", "-r", "b"]).output.strip() == "['a', 'b']"
+    assert runner.invoke(_dummy, ["--run-names", "a", "--run-names", "b"]).output.strip() == "['a', 'b']"
+
+
+def test_deprecated_alias_still_works(runner):
+    assert runner.invoke(_dummy, ["--runs", "a", "--runs", "b"]).output.strip() == "['a', 'b']"
+
+
+def test_legacy_comma_values_split(runner):
+    assert runner.invoke(_dummy, ["--run-names", "a,b,c"]).output.strip() == "['a', 'b', 'c']"
+
+
+# --------------------------------------------------------------------------- #
+# Real commands expose the standardized option
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    ("import_path", "subcommand"),
+    [
+        ("copick.cli.stats:stats", "picks"),
+        ("copick.cli.stats:stats", "meshes"),
+        ("copick.cli.stats:stats", "segmentations"),
+        ("copick.cli.export:export", "picks"),
+        ("copick.cli.export:export", "tomogram"),
+        ("copick.cli.export:export", "segmentation"),
+    ],
+)
+def test_real_commands_use_standard_option(runner, import_path, subcommand):
+    import importlib
+
+    module_name, group_name = import_path.split(":")
+    group = getattr(importlib.import_module(module_name), group_name)
+    out = runner.invoke(group, [subcommand, "--help"]).output
+    assert "--run-names" in out
+    assert "-r" in out
+
+
+def test_stats_hides_deprecated_runs_alias(runner):
+    from copick.cli.stats import stats
+
+    out = runner.invoke(stats, ["picks", "--help"]).output
+    assert "--runs" not in out  # replaced by --run-names, alias hidden


### PR DESCRIPTION
Normalizes the run selection option across most of the copick CLIs to `-r/--run-names`