### PR TITLE
feat: Caching mechanism for data portal metadata 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "dynamotable>=0.2.0",
     "emfile==0.3.0",
     "aiohttp>=3.9.0",
+    "filelock>=3.18.0",
     "fsspec>=2025.5.1",
     "mlcroissant>=1.1.0",
     "mrcfile>=1.5.4",

--- a/src/copick/cli/cache.py
+++ b/src/copick/cli/cache.py
@@ -1,0 +1,193 @@
+import json
+
+import click
+
+from copick.cli.util import add_config_option, add_debug_option
+from copick.util.log import get_logger
+
+
+def _load_cdp_config(config_path, logger):
+    """Load a config file as a ``CopickConfigCDP`` without constructing a root (no portal query).
+
+    Returns the config object, or ``None`` when the config is not a CryoET Data Portal config
+    (in which case there is no portal cache to manage).
+    """
+    with open(config_path) as f:
+        data = json.load(f)
+
+    if data.get("config_type") != "cryoet_data_portal":
+        logger.info(
+            f"Config '{config_path}' is not a CryoET Data Portal config (config_type="
+            f"{data.get('config_type')!r}); no portal cache to manage.",
+        )
+        return None
+
+    # Building the pydantic config model does not touch the portal; only CopickRootCDP.__init__ does.
+    from copick.impl.cryoet_data_portal import CopickConfigCDP
+
+    return CopickConfigCDP(**data)
+
+
+@click.group(short_help="Inspect and invalidate the CryoET Data Portal query cache.")
+@click.pass_context
+def cache(ctx):
+    """
+    Inspect and invalidate the CryoET Data Portal query cache.
+
+    Portal-backed copick projects persist the portal query results issued at project
+    initialization to a small on-disk cache so that repeated process startups (e.g. many
+    parallel processing jobs) read the cache instead of re-querying the portal. These
+    commands report on and manually invalidate that cache. They never contact the portal.
+    """
+    pass
+
+
+@cache.command(
+    context_settings={"show_default": True},
+    short_help="Show the portal cache location and freshness.",
+)
+@add_config_option
+@add_debug_option
+@click.pass_context
+def info(ctx, config, debug=False):
+    """
+    Show the portal cache location and freshness.
+
+    Reports each candidate cache location for the project (the overlay cache and any local
+    fallback), whether a cache file is present, and whether it is fresh or stale relative to
+    the configured TTL. Does not contact the CryoET Data Portal.
+
+    Examples:
+
+        \b
+        # Inspect the cache for a portal-backed project
+        copick cache info -c cdp_config.json
+
+    See Also:
+
+        \b
+        copick cache clear: remove the portal cache
+    """
+    logger = get_logger(__name__, debug=debug)
+
+    if not config:
+        ctx.fail("Provide a configuration file via -c/--config (or the COPICK_CONFIG env var).")
+        return
+
+    from copick.util import portal_cache
+
+    try:
+        cfg = _load_cdp_config(config, logger)
+    except Exception as e:
+        logger.critical(f"Failed to load configuration: {e}")
+        ctx.fail(f"Error loading configuration: {e}")
+        return
+
+    if cfg is None:
+        return
+
+    try:
+        statuses = portal_cache.status_for_config(cfg)
+    except Exception as e:
+        logger.critical(f"Failed to inspect portal cache: {e}")
+        ctx.fail(f"Error inspecting portal cache: {e}")
+        return
+
+    settings = portal_cache.settings_from_config(cfg)
+    logger.info(f"Portal cache {'enabled' if settings.enabled else 'DISABLED'}, TTL {settings.ttl_seconds}s.")
+    for status in statuses:
+        if not status.exists:
+            logger.info(f"  [missing]  {status.path}")
+            continue
+        state = "fresh" if status.fresh else "stale"
+        age = f"{status.age_seconds:.0f}s" if status.age_seconds is not None else "unknown age"
+        lock = "" if status.lockable else " (no lock on this backend)"
+        logger.info(f"  [{state}]  {status.path} — created {status.created}, age {age}{lock}")
+
+
+@cache.command(
+    context_settings={"show_default": True},
+    short_help="Remove the portal cache to force a refresh.",
+)
+@add_config_option
+@click.option(
+    "--all",
+    "remove_all",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Remove every portal cache file in the cache directory, not just the current fingerprint "
+    "(use after changing the project's pickable objects).",
+)
+@click.option(
+    "--yes",
+    "-y",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Do not prompt for confirmation.",
+)
+@add_debug_option
+@click.pass_context
+def clear(ctx, config, remove_all=False, assume_yes=False, debug=False):
+    """
+    Remove the portal cache to force a refresh.
+
+    Deletes the on-disk CryoET Data Portal query cache for the project so the next process
+    re-queries the portal and rewrites the cache. Does not contact the portal itself. By
+    default only the cache file matching the current configuration is removed; pass `--all`
+    to clear every portal cache file in the cache directory (useful when the project's
+    pickable objects changed and the old cache no longer matches).
+
+    Examples:
+
+        \b
+        # Invalidate the cache for a portal-backed project
+        copick cache clear -c cdp_config.json
+
+        \b
+        # Clear all portal cache files without confirmation
+        copick cache clear -c cdp_config.json --all --yes
+
+    See Also:
+
+        \b
+        copick cache info: show the portal cache location and freshness
+    """
+    logger = get_logger(__name__, debug=debug)
+
+    if not config:
+        ctx.fail("Provide a configuration file via -c/--config (or the COPICK_CONFIG env var).")
+        return
+
+    from copick.util import portal_cache
+
+    try:
+        cfg = _load_cdp_config(config, logger)
+    except Exception as e:
+        logger.critical(f"Failed to load configuration: {e}")
+        ctx.fail(f"Error loading configuration: {e}")
+        return
+
+    if cfg is None:
+        return
+
+    scope = "all portal cache files" if remove_all else "the current portal cache file"
+    if not assume_yes and not click.confirm(f"Remove {scope} for this project?", default=True):
+        logger.info("Aborted; nothing removed.")
+        return
+
+    try:
+        removed = portal_cache.clear(cfg, remove_all=remove_all)
+    except Exception as e:
+        logger.critical(f"Failed to clear portal cache: {e}")
+        ctx.fail(f"Error clearing portal cache: {e}")
+        return
+
+    if removed:
+        for path in removed:
+            logger.info(f"Removed {path}.")
+        logger.info(f"Removed {len(removed)} cache file(s).")
+    else:
+        logger.info("No portal cache files found; nothing to remove.")

--- a/src/copick/cli/cli.py
+++ b/src/copick/cli/cli.py
@@ -3,6 +3,7 @@ import click
 from copick import __version__ as version
 from copick.cli.add import add
 from copick.cli.browse import browse
+from copick.cli.cache import cache
 from copick.cli.config import config
 from copick.cli.cp import cp
 from copick.cli.deposit import deposit
@@ -23,7 +24,7 @@ logger = get_logger(__name__)
 COMMAND_CATEGORIES = {
     "Data Management": ["add", "cp", "export", "mv", "new", "rm", "sync"],
     "Data Processing": ["convert", "inference", "logical", "process", "training", "evaluation"],
-    "Utilities": ["browse", "config", "deposit", "info", "setup", "stats", "download"],
+    "Utilities": ["browse", "cache", "config", "deposit", "info", "setup", "stats", "download"],
 }
 
 
@@ -184,6 +185,7 @@ def add_core_commands(cmd: click.group) -> click.group:
 
     cmd.add_command(add)
     cmd.add_command(browse)
+    cmd.add_command(cache)
     cmd.add_command(config)
     cmd.add_command(cp)
     cmd.add_command(deposit)

--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -37,7 +37,9 @@ from copick.models import (
     CopickVoxelSpacingMeta,
     PickableObject,
 )
+from copick.util import portal_cache
 from copick.util.log import get_logger
+from copick.util.portal_cache import SHAPE_TYPES
 
 # Don't import Geometry at runtime to keep CLI snappy
 if TYPE_CHECKING:
@@ -182,16 +184,44 @@ _PortalTomogram = _portal_to_model(cdp.Tomogram, "_PortalTomogram")
 class PortalCache:
     """Cache for portal annotation data shared across all runs."""
 
+    runs: List[Any] = field(default_factory=list)  # PortalObject(Run)
     picks_files_by_run: Dict[int, List[Any]] = field(default_factory=dict)  # Point/OrientedPoint
     seg_files_by_run: Dict[int, List[Any]] = field(default_factory=dict)  # SegmentationMask
     annotation_shapes: Dict[int, Any] = field(default_factory=dict)  # id -> shape
     annotations: Dict[int, Any] = field(default_factory=dict)  # id -> annotation
     author_names: Dict[int, List[str]] = field(default_factory=dict)  # annotation_id -> names
     voxel_spacings: Dict[int, Any] = field(default_factory=dict)  # id -> voxel_spacing
+    voxel_spacings_by_run: Dict[int, List[Any]] = field(default_factory=dict)  # run_id -> voxel_spacings
 
     # Tomogram cache
     tomograms_by_vs: Dict[int, List[Any]] = field(default_factory=dict)  # vs_id -> tomograms
     tomogram_authors: Dict[int, List[str]] = field(default_factory=dict)  # tomogram_id -> authors
+
+
+class PortalObject:
+    """Serializable stand-in for a ``cryoet_data_portal`` client object.
+
+    Wraps the scalar-field dict produced by a cdp ``Model.to_dict()`` and exposes those
+    scalars as attributes plus a ``to_dict()`` method. The same wrapper is used for freshly
+    fetched objects and for objects rehydrated from the disk cache, so :class:`PortalCache`
+    construction and every downstream consumer work without knowing the provenance. Full-dict
+    passthrough guarantees all scalar keys are present regardless of the ``_Portal*`` model
+    field sets.
+    """
+
+    __slots__ = ("_data",)
+
+    def __init__(self, data: Dict[str, Any]):
+        object.__setattr__(self, "_data", data)
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self._data[name]
+        except KeyError as e:
+            raise AttributeError(name) from e
+
+    def to_dict(self) -> Dict[str, Any]:
+        return self._data
 
 
 class PortalAnnotationMeta(BaseModel):
@@ -206,7 +236,8 @@ class PortalAnnotationMeta(BaseModel):
     @field_validator("portal_annotation", mode="before")
     @classmethod
     def check_portal_annotation(cls, v: Union[_PortalAnnotation, cdp.Annotation]) -> _PortalAnnotation:
-        if isinstance(v, cdp.Annotation):
+        # Accept raw cdp objects and cache-rehydrated PortalObjects; both expose to_dict().
+        if isinstance(v, (cdp.Annotation, PortalObject)):
             return _PortalAnnotation(**v.to_dict())
         return v
 
@@ -216,14 +247,14 @@ class PortalAnnotationMeta(BaseModel):
         cls,
         v: Union[_PortalAnnotationShape, cdp.AnnotationShape],
     ) -> _PortalAnnotationShape:
-        if isinstance(v, cdp.AnnotationShape):
+        if isinstance(v, (cdp.AnnotationShape, PortalObject)):
             return _PortalAnnotationShape(**v.to_dict())
         return v
 
     @field_validator("portal_annotation_file", mode="before")
     @classmethod
     def check_portal_annotation_file(cls, v: Union[_PortalAnnotationFile, cdp.AnnotationFile]) -> _PortalAnnotationFile:
-        if isinstance(v, cdp.AnnotationFile):
+        if isinstance(v, (cdp.AnnotationFile, PortalObject)):
             return _PortalAnnotationFile(**v.to_dict())
         return v
 
@@ -311,6 +342,13 @@ class CopickConfigCDP(CopickConfig):
     dataset_ids: List[int]
 
     overlay_fs_args: Optional[Dict[str, Any]] = {}
+
+    # Disk cache for portal query results (see copick.util.portal_cache). Each field can be
+    # overridden at runtime by the matching COPICK_PORTAL_CACHE* environment variable.
+    portal_cache: bool = True  # master enable/disable
+    portal_cache_ttl_seconds: int = 86400  # 24h; <= 0 means "never expire"
+    portal_cache_dir: Optional[str] = None  # pin the cache location (else overlay + local fallback)
+    portal_cache_lock_timeout_seconds: int = 60  # bound the cold-start lock wait before direct fetch
 
 
 class CopickPicksFileCDP(CopickPicksFile):
@@ -951,14 +989,11 @@ class CopickRunCDP(CopickRunOverlay):
         if self.portal_run_id is None:
             return []
 
-        client = cdp.Client()
-        portal_vs = _retry_portal_call(
-            cdp.TomogramVoxelSpacing.find,
-            client,
-            [cdp.TomogramVoxelSpacing.run_id == self.portal_run_id],  # noqa
-        )
+        # Served from the shared annotation cache (fetched once at root init / from disk),
+        # rather than a per-run portal query that would fan out to N calls for N runs.
+        cache = self.root._ensure_annotation_cache()
+        portal_vs = cache.voxel_spacings_by_run.get(self.portal_run_id, [])
 
-        # portal_vs = self.portal_run.tomogram_voxel_spacings
         clz, meta_clz = self._voxel_spacing_factory()
 
         return [clz(meta=meta_clz.from_portal(vs), run=self) for vs in portal_vs]
@@ -1374,49 +1409,72 @@ class CopickRootCDP(CopickRoot):
     def go_map(self) -> Dict[str, str]:
         return {po.identifier: po.name for po in self.pickable_objects if po.identifier is not None}
 
-    def _ensure_annotation_cache(self) -> PortalCache:
-        """Fetch (in per-run batches) and cache all portal annotation data for picks, segmentations, and tomograms."""
-        if self._portal_cache is not None:
+    def _ensure_annotation_cache(self, force: bool = False) -> PortalCache:
+        """Return the portal annotation cache, building it from disk or the portal as needed.
+
+        The cache is memoized in-memory (``self._portal_cache``); beneath that sits a
+        time-limited, lock-protected disk cache (see :mod:`copick.util.portal_cache`) so a new
+        process reads the previous run's portal query results instead of re-querying. ``force``
+        bypasses both layers, refetches from the portal, and rewrites the disk cache.
+        """
+        if self._portal_cache is not None and not force:
             return self._portal_cache
 
-        client = cdp.Client()
-        go_map = self.go_map
-        go_keys = list(go_map.keys())
-        shape_types = ["Point", "OrientedPoint", "SegmentationMask"]
+        settings = portal_cache.settings_from_config(self.config)
+        fingerprint = portal_cache.fingerprint_for_config(self.config)
+        data = portal_cache.get_or_fetch(
+            fingerprint=fingerprint,
+            dataset_ids=self.dataset_ids,
+            settings=settings,
+            fetch_fn=self._fetch_portal_data,
+            fs_overlay=self.fs_overlay,
+            root_overlay=self.root_overlay,
+            force=force,
+        )
+        self._portal_cache = self._build_cache(data)
+        return self._portal_cache
 
-        # Fetch the run IDs for the configured datasets up front. Every query below is
-        # batched over these run IDs (via _find_batched) so a large dataset is not pulled
-        # in a single unbounded .find(), which overloads the portal (the Tomogram query
-        # 502s on datasets with many annotations). The batched results are concatenated
-        # and indexed exactly as before, so the resulting cache is identical.
+    def _fetch_portal_data(self) -> Dict[str, List[Dict[str, Any]]]:
+        """Run the batched portal queries and return their raw results as serializable dicts.
+
+        Every query is batched over the configured datasets' run IDs (via ``_find_batched``) so a
+        large dataset is not pulled in a single unbounded ``.find()``, which overloads the portal
+        (the Tomogram query 502s on datasets with many annotations). Results are returned as
+        ``cdp`` ``.to_dict()`` payloads so they can be indexed by :meth:`_build_cache` and persisted
+        to the disk cache unchanged.
+        """
+        client = cdp.Client()
+        go_keys = list(self.go_map.keys())
+
+        # Runs for the configured datasets; every subsequent query is batched over these IDs.
         runs = _retry_portal_call(cdp.Run.find, client, [cdp.Run.dataset_id._in(self.dataset_ids)])
         run_ids = [r.id for r in runs]
 
-        # 1. Fetch annotation files (picks + segmentations)
+        # 1. Annotation files (picks + segmentations)
         all_anno_files = _find_batched(
             cdp.AnnotationFile.find,
             client,
             run_ids,
             lambda b: [
                 cdp.AnnotationFile.annotation_shape.annotation.run.id._in(b),  # noqa
-                cdp.AnnotationFile.annotation_shape.shape_type._in(shape_types),  # noqa
+                cdp.AnnotationFile.annotation_shape.shape_type._in(SHAPE_TYPES),  # noqa
                 cdp.AnnotationFile.annotation_shape.annotation.object_id._in(go_keys),  # noqa
             ],
         )
 
-        # 2. Fetch annotation shapes
+        # 2. Annotation shapes
         all_shapes = _find_batched(
             cdp.AnnotationShape.find,
             client,
             run_ids,
             lambda b: [
                 cdp.AnnotationShape.annotation.run.id._in(b),  # noqa
-                cdp.AnnotationShape.shape_type._in(shape_types),  # noqa
+                cdp.AnnotationShape.shape_type._in(SHAPE_TYPES),  # noqa
                 cdp.AnnotationShape.annotation.object_id._in(go_keys),  # noqa
             ],
         )
 
-        # 3. Fetch annotations
+        # 3. Annotations
         all_annotations = _find_batched(
             cdp.Annotation.find,
             client,
@@ -1427,7 +1485,7 @@ class CopickRootCDP(CopickRoot):
             ],
         )
 
-        # 4. Fetch annotation authors
+        # 4. Annotation authors
         all_authors = _find_batched(
             cdp.AnnotationAuthor.find,
             client,
@@ -1438,7 +1496,7 @@ class CopickRootCDP(CopickRoot):
             ],
         )
 
-        # 5. Fetch voxel spacings
+        # 5. Voxel spacings
         all_voxel_spacings = _find_batched(
             cdp.TomogramVoxelSpacing.find,
             client,
@@ -1448,7 +1506,7 @@ class CopickRootCDP(CopickRoot):
             ],
         )
 
-        # 6. Fetch tomograms
+        # 6. Tomograms
         all_tomograms = _find_batched(
             cdp.Tomogram.find,
             client,
@@ -1458,7 +1516,7 @@ class CopickRootCDP(CopickRoot):
             ],
         )
 
-        # 7. Fetch tomogram authors
+        # 7. Tomogram authors
         all_tomogram_authors = _find_batched(
             cdp.TomogramAuthor.find,
             client,
@@ -1468,13 +1526,45 @@ class CopickRootCDP(CopickRoot):
             ],
         )
 
-        # Build cache
+        return {
+            "runs": [r.to_dict() for r in runs],
+            "annotation_files": [x.to_dict() for x in all_anno_files],
+            "annotation_shapes": [x.to_dict() for x in all_shapes],
+            "annotations": [x.to_dict() for x in all_annotations],
+            "annotation_authors": [x.to_dict() for x in all_authors],
+            "voxel_spacings": [x.to_dict() for x in all_voxel_spacings],
+            "tomograms": [x.to_dict() for x in all_tomograms],
+            "tomogram_authors": [x.to_dict() for x in all_tomogram_authors],
+        }
+
+    def _build_cache(self, data: Dict[str, List[Dict[str, Any]]]) -> PortalCache:
+        """Index raw portal data (from the portal or the disk cache) into a :class:`PortalCache`.
+
+        ``data`` is the serializable payload produced by :meth:`_fetch_portal_data`. Each record is
+        wrapped in a :class:`PortalObject` so the indexing and all downstream consumers are agnostic
+        to whether the data came from a live query or from disk.
+        """
+        runs = [PortalObject(d) for d in data.get("runs", [])]
+        all_anno_files = [PortalObject(d) for d in data.get("annotation_files", [])]
+        all_shapes = [PortalObject(d) for d in data.get("annotation_shapes", [])]
+        all_annotations = [PortalObject(d) for d in data.get("annotations", [])]
+        all_authors = [PortalObject(d) for d in data.get("annotation_authors", [])]
+        all_voxel_spacings = [PortalObject(d) for d in data.get("voxel_spacings", [])]
+        all_tomograms = [PortalObject(d) for d in data.get("tomograms", [])]
+        all_tomogram_authors = [PortalObject(d) for d in data.get("tomogram_authors", [])]
+
         cache = PortalCache()
+        cache.runs = runs
 
         # Index by id
         cache.annotation_shapes = {s.id: s for s in all_shapes}
         cache.annotations = {a.id: a for a in all_annotations}
-        cache.voxel_spacings = {vs.id: vs for vs in all_voxel_spacings}
+
+        # Voxel spacings: keep the id index and also group by run so voxel-spacing lookups are
+        # served from the cache instead of a per-run portal query.
+        for vs in all_voxel_spacings:
+            cache.voxel_spacings[vs.id] = vs
+            cache.voxel_spacings_by_run.setdefault(vs.run_id, []).append(vs)
 
         # Group annotation files by run_id and shape_type
         for af in all_anno_files:
@@ -1483,34 +1573,22 @@ class CopickRootCDP(CopickRoot):
             run_id = annotation.run_id
 
             if shape.shape_type in ["Point", "OrientedPoint"]:
-                if run_id not in cache.picks_files_by_run:
-                    cache.picks_files_by_run[run_id] = []
-                cache.picks_files_by_run[run_id].append(af)
+                cache.picks_files_by_run.setdefault(run_id, []).append(af)
             elif shape.shape_type == "SegmentationMask" and af.format == "zarr":
-                if run_id not in cache.seg_files_by_run:
-                    cache.seg_files_by_run[run_id] = []
-                cache.seg_files_by_run[run_id].append(af)
+                cache.seg_files_by_run.setdefault(run_id, []).append(af)
 
         # Build annotation author names lookup
         for author in all_authors:
-            if author.annotation_id not in cache.author_names:
-                cache.author_names[author.annotation_id] = []
-            cache.author_names[author.annotation_id].append(author.name)
+            cache.author_names.setdefault(author.annotation_id, []).append(author.name)
 
         # Group tomograms by voxel spacing
         for tomo in all_tomograms:
-            vs_id = tomo.tomogram_voxel_spacing_id
-            if vs_id not in cache.tomograms_by_vs:
-                cache.tomograms_by_vs[vs_id] = []
-            cache.tomograms_by_vs[vs_id].append(tomo)
+            cache.tomograms_by_vs.setdefault(tomo.tomogram_voxel_spacing_id, []).append(tomo)
 
         # Build tomogram author lookup
         for author in all_tomogram_authors:
-            if author.tomogram_id not in cache.tomogram_authors:
-                cache.tomogram_authors[author.tomogram_id] = []
-            cache.tomogram_authors[author.tomogram_id].append(author.name)
+            cache.tomogram_authors.setdefault(author.tomogram_id, []).append(author.name)
 
-        self._portal_cache = cache
         return cache
 
     @property
@@ -1543,11 +1621,12 @@ class CopickRootCDP(CopickRoot):
         return CopickObjectCDP, PickableObject
 
     def query(self) -> List[CopickRunCDP]:
-        client = cdp.Client()
-        portal_runs = _retry_portal_call(cdp.Run.find, client, [cdp.Run.dataset_id._in(self.dataset_ids)])  # noqa
+        # Runs come from the shared annotation cache (fetched once at init / from disk) rather
+        # than a fresh cdp.Run.find on every .runs access.
+        cache = self._ensure_annotation_cache()
 
         runs = []
-        for pr in portal_runs:
+        for pr in cache.runs:
             rm = CopickRunMetaCDP.from_portal(pr)
             runs.append(CopickRunCDP(root=self, meta=rm))
 

--- a/src/copick/util/portal_cache.py
+++ b/src/copick/util/portal_cache.py
@@ -1,0 +1,499 @@
+"""Time-limited, lock-protected disk cache for CryoET Data Portal query results.
+
+A portal-backed copick project (:class:`~copick.impl.cryoet_data_portal.CopickRootCDP`)
+eagerly queries the CryoET Data Portal when it is constructed. Running many concurrent
+processing jobs — each building its own root — multiplies these queries until the portal
+starts returning HTTP 503. This module persists the raw portal query results to disk so
+subsequent process startups read the cache instead of re-querying.
+
+Design invariants:
+
+* **Correctness rests on atomic rename**, not on the lock. Writes go to a unique temp
+  path and are atomically renamed into place, so a reader never observes a partial file.
+* **The lock only reduces the cold-start stampede.** It is a best-effort dedup so that,
+  when many jobs start at once with no cache yet, one fetches and the rest read the
+  published result. It is a no-op on backends where an ``O_EXCL`` lock is meaningless
+  (e.g. S3 overlays) or when :mod:`filelock` is unavailable.
+* **Caching can only make startup faster or, worst case, exactly as slow as today.** Every
+  failure path (unreadable/corrupt cache, unwritable location, lock timeout) degrades to
+  querying the portal as before; it never breaks project construction.
+
+The module operates purely on JSON-serializable ``data`` dicts (``{key: [dict, ...]}``) and
+a config object; it never imports the portal implementation, so both the root and the CLI
+(``copick cache ...``) can reuse the fingerprint/path/clear helpers.
+"""
+
+import json
+import os
+import uuid
+from contextlib import nullcontext, suppress
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import Any, Callable, Dict, List, Optional
+
+from copick.util.log import get_logger
+
+logger = get_logger(__name__)
+
+# Shape types fetched for the annotation cache. Defined here (not in the portal impl) so the
+# fingerprint and the portal fetch share a single source of truth without a circular import.
+SHAPE_TYPES = ["Point", "OrientedPoint", "SegmentationMask"]
+
+# Bump when the on-disk document layout changes; a mismatch invalidates old caches.
+SCHEMA_VERSION = 1
+
+# Keys of the serializable ``data`` payload (raw portal query results, one list of dicts each).
+DATA_KEYS = (
+    "runs",
+    "annotation_files",
+    "annotation_shapes",
+    "annotations",
+    "annotation_authors",
+    "voxel_spacings",
+    "tomograms",
+    "tomogram_authors",
+)
+
+_CACHE_DIRNAME = ".copick_cache"
+
+
+def _cdp_version() -> str:
+    """Version of the installed ``cryoet_data_portal`` SDK (folded into the fingerprint)."""
+    try:
+        import cryoet_data_portal as cdp
+
+        return str(getattr(cdp, "__version__", "unknown"))
+    except Exception:  # noqa: BLE001 - version is best-effort
+        return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Settings (config fields + environment overrides)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CacheSettings:
+    """Resolved cache knobs (environment overrides config field, which overrides default)."""
+
+    enabled: bool = True
+    ttl_seconds: int = 86400  # 24h; <= 0 means "never expire"
+    lock_timeout_seconds: int = 60
+    cache_dir: Optional[str] = None
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    val = raw.strip().lower()
+    if val in ("1", "true", "yes", "on"):
+        return True
+    if val in ("0", "false", "no", "off"):
+        return False
+    logger.warning("Ignoring malformed boolean env %s=%r; using %s.", name, raw, default)
+    return default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw.strip())
+    except ValueError:
+        logger.warning("Ignoring malformed integer env %s=%r; using %s.", name, raw, default)
+        return default
+
+
+def _env_str(name: str, default: Optional[str]) -> Optional[str]:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    return raw
+
+
+def settings_from_config(config: Any) -> CacheSettings:
+    """Resolve cache settings from a ``CopickConfigCDP`` plus environment overrides."""
+    return CacheSettings(
+        enabled=_env_bool("COPICK_PORTAL_CACHE", bool(getattr(config, "portal_cache", True))),
+        ttl_seconds=_env_int(
+            "COPICK_PORTAL_CACHE_TTL",
+            int(getattr(config, "portal_cache_ttl_seconds", 86400)),
+        ),
+        lock_timeout_seconds=_env_int(
+            "COPICK_PORTAL_CACHE_LOCK_TIMEOUT",
+            int(getattr(config, "portal_cache_lock_timeout_seconds", 60)),
+        ),
+        cache_dir=_env_str("COPICK_PORTAL_CACHE_DIR", getattr(config, "portal_cache_dir", None)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint
+# ---------------------------------------------------------------------------
+
+
+def object_identifiers(config: Any) -> List[str]:
+    """Sorted list of pickable-object identifiers (the portal ``object_id`` filter keys).
+
+    Matches ``CopickRootCDP.go_map`` keys: identifiers that are not ``None``. The annotation
+    queries filter by these, so the cache is only valid for the same identifier set.
+    """
+    ids = [
+        po.identifier for po in getattr(config, "pickable_objects", []) if getattr(po, "identifier", None) is not None
+    ]
+    return sorted(ids)
+
+
+def compute_fingerprint(dataset_ids: List[int], identifiers: List[str]) -> str:
+    """Stable hash of everything that changes the portal query result set."""
+    payload = {
+        "dataset_ids": sorted(int(d) for d in dataset_ids),
+        "identifiers": sorted(identifiers),
+        "shape_types": SHAPE_TYPES,
+        "cdp_version": _cdp_version(),
+        "schema_version": SCHEMA_VERSION,
+    }
+    return sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
+
+
+def fingerprint_for_config(config: Any) -> str:
+    """Compute the cache fingerprint for a ``CopickConfigCDP`` (root and CLI share this)."""
+    return compute_fingerprint(list(getattr(config, "dataset_ids", [])), object_identifiers(config))
+
+
+# ---------------------------------------------------------------------------
+# Cache locations (overlay primary, local fallback)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CacheLocation:
+    """One candidate cache location: an fsspec filesystem plus the cache/lock paths."""
+
+    fs: Any
+    directory: str
+    path: str
+    # OS path when this location is on a local filesystem (enables atomic os.replace and a
+    # filelock ``SoftFileLock``); ``None`` for remote backends (atomic-rename-only, no lock).
+    local_path: Optional[str] = None
+
+    @property
+    def lockable(self) -> bool:
+        return self.local_path is not None
+
+
+def _fs_is_local(fs: Any) -> bool:
+    inner = getattr(fs, "_fs", fs)  # unwrap ReconnectingFileSystem
+    proto = getattr(inner, "protocol", None)
+    protos = proto if isinstance(proto, (list, tuple)) else (proto,)
+    return any(p in ("file", "local") for p in protos)
+
+
+def _local_location(file_path: str) -> CacheLocation:
+    import fsspec
+
+    fs = fsspec.filesystem("file", auto_mkdir=True)
+    directory = os.path.dirname(file_path)
+    return CacheLocation(fs=fs, directory=directory, path=file_path, local_path=file_path)
+
+
+def _xdg_cache_file(fingerprint: str) -> str:
+    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return os.path.join(base, "copick", "portal", f"portal_{fingerprint}.json")
+
+
+def build_overlay_fs(config: Any):
+    """Build an overlay filesystem + stripped root from a config (used by the CLI)."""
+    from copick.util.reconnecting_fs import ReconnectingFileSystem
+
+    fs = ReconnectingFileSystem(config.overlay_root, getattr(config, "overlay_fs_args", None) or {})
+    root_overlay = fs._strip_protocol(config.overlay_root)  # noqa: SLF001
+    return fs, root_overlay
+
+
+def resolve_locations(
+    fingerprint: str,
+    settings: CacheSettings,
+    fs_overlay: Any = None,
+    root_overlay: Optional[str] = None,
+) -> List[CacheLocation]:
+    """Ordered candidate cache locations. Reads try each in order; writes use the first that succeeds.
+
+    * A pinned ``cache_dir`` short-circuits to a single local location.
+    * Otherwise: the overlay (``{root_overlay}/.copick_cache/portal_{fp}.json``) first, then a
+      local ``~/.cache/copick/portal/`` fallback for read-only overlays.
+    """
+    filename = f"portal_{fingerprint}.json"
+
+    if settings.cache_dir:
+        return [_local_location(os.path.join(settings.cache_dir, filename))]
+
+    locations: List[CacheLocation] = []
+    if fs_overlay is not None and root_overlay:
+        directory = f"{root_overlay.rstrip('/')}/{_CACHE_DIRNAME}"
+        path = f"{directory}/{filename}"
+        local_path = path if _fs_is_local(fs_overlay) else None
+        locations.append(CacheLocation(fs=fs_overlay, directory=directory, path=path, local_path=local_path))
+
+    locations.append(_local_location(_xdg_cache_file(fingerprint)))
+    return locations
+
+
+# ---------------------------------------------------------------------------
+# Load / store
+# ---------------------------------------------------------------------------
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _load_location(loc: CacheLocation, fingerprint: str, ttl_seconds: int) -> Optional[Dict[str, Any]]:
+    """Return the ``data`` payload from ``loc`` if present, valid, and fresh; else ``None``."""
+    try:
+        if not loc.fs.exists(loc.path):
+            return None
+        with loc.fs.open(loc.path, "r") as f:
+            doc = json.load(f)
+        if doc.get("schema_version") != SCHEMA_VERSION:
+            logger.debug("Portal cache %s: schema mismatch, ignoring.", loc.path)
+            return None
+        if doc.get("fingerprint") != fingerprint:
+            logger.debug("Portal cache %s: fingerprint mismatch, ignoring.", loc.path)
+            return None
+        if ttl_seconds and ttl_seconds > 0:
+            created = doc.get("created")
+            try:
+                age = (_now_utc() - datetime.fromisoformat(created)).total_seconds()
+            except (TypeError, ValueError):
+                return None
+            if age > ttl_seconds:
+                logger.debug("Portal cache %s: stale (age %.0fs > ttl %ds).", loc.path, age, ttl_seconds)
+                return None
+        data = doc.get("data")
+        if not isinstance(data, dict):
+            return None
+        logger.debug("Portal cache hit: %s", loc.path)
+        return data
+    except Exception as e:  # noqa: BLE001 - any read failure is a cache miss
+        logger.debug("Portal cache %s: unreadable (%s), ignoring.", loc.path, e)
+        return None
+
+
+def _atomic_write_text(loc: CacheLocation, text: str) -> None:
+    """Write ``text`` to ``loc.path`` atomically (unique temp + rename)."""
+    with suppress(Exception):
+        loc.fs.makedirs(loc.directory, exist_ok=True)
+
+    token = f"{os.getpid()}.{uuid.uuid4().hex}"
+    if loc.local_path is not None:
+        tmp = f"{loc.local_path}.{token}.tmp"
+        with open(tmp, "w") as f:
+            f.write(text)
+            f.flush()
+            with suppress(OSError):
+                os.fsync(f.fileno())
+        os.replace(tmp, loc.local_path)
+        return
+
+    # Remote backend: unique temp key + rename (atomic on POSIX-backed remotes; on stores
+    # without atomic rename the object is still written whole, never byte-partial).
+    tmp = f"{loc.path}.{token}.tmp"
+    with loc.fs.open(tmp, "w") as f:
+        f.write(text)
+    try:
+        loc.fs.mv(tmp, loc.path)
+    except Exception:  # noqa: BLE001 - fall back to a direct overwrite
+        with loc.fs.open(loc.path, "w") as f:
+            f.write(text)
+        with suppress(Exception):
+            loc.fs.rm(tmp)
+
+
+def _store_location(
+    loc: CacheLocation,
+    fingerprint: str,
+    dataset_ids: List[int],
+    data: Dict[str, Any],
+) -> bool:
+    """Serialize and atomically write the cache document to ``loc``. Returns success."""
+    try:
+        doc = {
+            "schema_version": SCHEMA_VERSION,
+            "created": _now_utc().isoformat(),
+            "cdp_version": _cdp_version(),
+            "dataset_ids": sorted(int(d) for d in dataset_ids),
+            "fingerprint": fingerprint,
+            "data": data,
+        }
+        # default=str coerces cdp date fields (deposition/release/last_modified) that the
+        # consumers never read; _Portal* models ignore the extra keys on load.
+        text = json.dumps(doc, default=str)
+        _atomic_write_text(loc, text)
+        logger.debug("Portal cache written: %s", loc.path)
+        return True
+    except Exception as e:  # noqa: BLE001 - a failed store just means the next process refetches
+        logger.info("Could not write portal cache to %s (%s); continuing without it.", loc.path, e)
+        return False
+
+
+def _make_lock(loc: CacheLocation, timeout: int):
+    """A ``SoftFileLock`` for lockable local locations, else a no-op context manager."""
+    if not loc.lockable:
+        return nullcontext()
+    try:
+        from filelock import SoftFileLock
+    except Exception:  # noqa: BLE001 - filelock optional; degrade to atomic-rename-only
+        return nullcontext()
+    with suppress(Exception):
+        os.makedirs(os.path.dirname(loc.local_path), exist_ok=True)
+    return SoftFileLock(f"{loc.local_path}.lock", timeout=max(1, timeout))
+
+
+def get_or_fetch(
+    fingerprint: str,
+    dataset_ids: List[int],
+    settings: CacheSettings,
+    fetch_fn: Callable[[], Dict[str, Any]],
+    fs_overlay: Any = None,
+    root_overlay: Optional[str] = None,
+    force: bool = False,
+) -> Dict[str, Any]:
+    """Return the portal ``data`` payload from cache, or fetch it once and persist it.
+
+    ``fetch_fn`` performs the portal queries and returns a JSON-serializable ``data`` dict; it
+    is invoked **at most once**. When caching is disabled, ``fetch_fn`` is called directly.
+    """
+    if not settings.enabled:
+        return fetch_fn()
+
+    locations = resolve_locations(fingerprint, settings, fs_overlay, root_overlay)
+    if not locations:
+        return fetch_fn()
+
+    # Fast read pass (lock-free): any fresh hit wins.
+    if not force:
+        for loc in locations:
+            data = _load_location(loc, fingerprint, settings.ttl_seconds)
+            if data is not None:
+                return data
+
+    # Miss: fetch once, gated by a per-location lock to collapse the cold-start herd.
+    fetched: Dict[str, Dict[str, Any]] = {}
+
+    def fetch_once() -> Dict[str, Any]:
+        if "data" not in fetched:
+            fetched["data"] = fetch_fn()
+        return fetched["data"]
+
+    for loc in locations:
+        try:
+            with _make_lock(loc, settings.lock_timeout_seconds):
+                if not force:
+                    # Double-check: a sibling may have published while we waited on the lock.
+                    data = _load_location(loc, fingerprint, settings.ttl_seconds)
+                    if data is not None:
+                        return data
+                data = fetch_once()
+                if _store_location(loc, fingerprint, dataset_ids, data):
+                    return data
+                # Store failed at this location; try the next candidate.
+        except Exception as e:  # noqa: BLE001 - includes filelock Timeout
+            logger.info("Portal cache lock/store at %s failed (%s); trying next location.", loc.path, e)
+            if not force:
+                data = _load_location(loc, fingerprint, settings.ttl_seconds)
+                if data is not None:
+                    return data
+
+    # No location could persist the cache — return the (already) fetched data uncached.
+    return fetch_once()
+
+
+# ---------------------------------------------------------------------------
+# Inspection / invalidation (used by the CLI)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CacheStatus:
+    """Read-only status of a single cache location (for ``copick cache info``)."""
+
+    path: str
+    exists: bool
+    fresh: Optional[bool] = None
+    created: Optional[str] = None
+    age_seconds: Optional[float] = None
+    lockable: bool = False
+
+
+def status_for_config(
+    config: Any,
+    fs_overlay: Any = None,
+    root_overlay: Optional[str] = None,
+) -> List[CacheStatus]:
+    """Report each candidate cache location's presence and freshness. Never queries the portal."""
+    settings = settings_from_config(config)
+    if fs_overlay is None:
+        fs_overlay, root_overlay = build_overlay_fs(config)
+    fingerprint = fingerprint_for_config(config)
+    locations = resolve_locations(fingerprint, settings, fs_overlay, root_overlay)
+
+    out: List[CacheStatus] = []
+    for loc in locations:
+        status = CacheStatus(path=loc.path, exists=False, lockable=loc.lockable)
+        try:
+            if loc.fs.exists(loc.path):
+                status.exists = True
+                with loc.fs.open(loc.path, "r") as f:
+                    doc = json.load(f)
+                status.created = doc.get("created")
+                valid = doc.get("schema_version") == SCHEMA_VERSION and doc.get("fingerprint") == fingerprint
+                if status.created:
+                    with suppress(TypeError, ValueError):
+                        age = (_now_utc() - datetime.fromisoformat(status.created)).total_seconds()
+                        status.age_seconds = age
+                        ttl = settings.ttl_seconds
+                        status.fresh = valid and (ttl <= 0 or age <= ttl)
+                else:
+                    status.fresh = valid
+        except Exception as e:  # noqa: BLE001 - status is best-effort
+            logger.debug("Could not read cache status at %s (%s).", loc.path, e)
+        out.append(status)
+    return out
+
+
+def clear(
+    config: Any,
+    remove_all: bool = False,
+    fs_overlay: Any = None,
+    root_overlay: Optional[str] = None,
+) -> List[str]:
+    """Remove the portal disk cache for ``config``. Returns the removed paths. No portal query.
+
+    With ``remove_all`` every ``portal_*.json`` in each candidate directory is removed (use when
+    the pickable objects changed and the fingerprint no longer matches); otherwise only the file
+    matching the current fingerprint is removed.
+    """
+    settings = settings_from_config(config)
+    if fs_overlay is None:
+        fs_overlay, root_overlay = build_overlay_fs(config)
+    fingerprint = fingerprint_for_config(config)
+    locations = resolve_locations(fingerprint, settings, fs_overlay, root_overlay)
+
+    removed: List[str] = []
+    for loc in locations:
+        try:
+            if remove_all:
+                for path in loc.fs.glob(f"{loc.directory}/portal_*.json"):
+                    with suppress(Exception):
+                        loc.fs.rm(path)
+                        removed.append(path)
+            elif loc.fs.exists(loc.path):
+                loc.fs.rm(loc.path)
+                removed.append(loc.path)
+        except Exception as e:  # noqa: BLE001 - clearing is best-effort per location
+            logger.debug("Could not clear cache at %s (%s).", loc.path, e)
+    return removed

--- a/tests/test_cache_cli.py
+++ b/tests/test_cache_cli.py
@@ -1,0 +1,131 @@
+"""CLI tests for `copick cache info` / `copick cache clear`.
+
+These never contact the CryoET Data Portal: the commands operate purely on the config file and
+the on-disk cache. The cache is seeded directly through ``portal_cache`` (with a stub fetch), so
+no portal client is ever constructed.
+"""
+
+import json
+
+import fsspec
+import pytest
+from click.testing import CliRunner
+from copick.cli.cache import cache
+from copick.util import portal_cache
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch, tmp_path):
+    for var in (
+        "COPICK_PORTAL_CACHE",
+        "COPICK_PORTAL_CACHE_TTL",
+        "COPICK_PORTAL_CACHE_DIR",
+        "COPICK_PORTAL_CACHE_LOCK_TIMEOUT",
+        "COPICK_CONFIG",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _cdp_config(tmp_path):
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    data = {
+        "config_type": "cryoet_data_portal",
+        "name": "test",
+        "description": "test",
+        "overlay_root": str(overlay),
+        "overlay_fs_args": {"auto_mkdir": True},
+        "dataset_ids": [10000],
+        "pickable_objects": [
+            {"name": "ribosome", "is_particle": True, "label": 1, "identifier": "GO:0000001"},
+            {"name": "membrane", "is_particle": False, "label": 2, "identifier": "GO:0000002"},
+        ],
+    }
+    path = tmp_path / "cdp_config.json"
+    path.write_text(json.dumps(data))
+    return path, overlay
+
+
+def _fs_config(tmp_path):
+    data = {
+        "config_type": "filesystem",
+        "name": "test",
+        "overlay_root": str(tmp_path / "ov"),
+        "pickable_objects": [{"name": "ribosome", "is_particle": True, "label": 1}],
+    }
+    path = tmp_path / "fs_config.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def _seed_cache(config_path):
+    """Write a valid cache file for the config, without touching the portal."""
+    from copick.impl.cryoet_data_portal import CopickConfigCDP
+
+    cfg = CopickConfigCDP(**json.loads(config_path.read_text()))
+    fs, root = portal_cache.build_overlay_fs(cfg)
+    portal_cache.get_or_fetch(
+        fingerprint=portal_cache.fingerprint_for_config(cfg),
+        dataset_ids=cfg.dataset_ids,
+        settings=portal_cache.settings_from_config(cfg),
+        fetch_fn=lambda: {k: [] for k in portal_cache.DATA_KEYS},
+        fs_overlay=fs,
+        root_overlay=root,
+    )
+    fp = portal_cache.fingerprint_for_config(cfg)
+    return f"{root}/.copick_cache/portal_{fp}.json"
+
+
+def test_info_missing(runner, tmp_path):
+    config_path, _ = _cdp_config(tmp_path)
+    result = runner.invoke(cache, ["info", "-c", str(config_path)])
+    assert result.exit_code == 0, result.output
+
+
+def test_info_and_clear_cycle(runner, tmp_path):
+    config_path, _ = _cdp_config(tmp_path)
+    cache_path = _seed_cache(config_path)
+
+    fs = fsspec.filesystem("file")
+    assert fs.exists(cache_path)
+
+    # info succeeds while the cache exists
+    assert runner.invoke(cache, ["info", "-c", str(config_path)]).exit_code == 0
+
+    # clear removes the cache file
+    result = runner.invoke(cache, ["clear", "-c", str(config_path), "-y"])
+    assert result.exit_code == 0, result.output
+    assert not fs.exists(cache_path)
+
+    # clearing again is a no-op that still succeeds
+    assert runner.invoke(cache, ["clear", "-c", str(config_path), "-y"]).exit_code == 0
+
+
+def test_clear_all(runner, tmp_path):
+    config_path, overlay = _cdp_config(tmp_path)
+    _seed_cache(config_path)
+
+    fs = fsspec.filesystem("file")
+    cache_dir = f"{overlay}/.copick_cache"
+    assert len(fs.glob(f"{cache_dir}/portal_*.json")) == 1
+
+    result = runner.invoke(cache, ["clear", "-c", str(config_path), "--all", "-y"])
+    assert result.exit_code == 0, result.output
+    assert fs.glob(f"{cache_dir}/portal_*.json") == []
+
+
+def test_clear_non_cdp_is_noop(runner, tmp_path):
+    config_path = _fs_config(tmp_path)
+    result = runner.invoke(cache, ["clear", "-c", str(config_path), "-y"])
+    assert result.exit_code == 0, result.output
+
+
+def test_missing_config_errors(runner):
+    result = runner.invoke(cache, ["info"])
+    assert result.exit_code != 0

--- a/tests/test_portal_cache.py
+++ b/tests/test_portal_cache.py
@@ -1,0 +1,293 @@
+"""Offline unit tests for the portal disk cache (copick.util.portal_cache).
+
+These never contact the CryoET Data Portal: ``fetch_fn`` is a stub that returns canned data
+and counts its own invocations, so we can assert the cache is read/written correctly and that
+the portal is queried at most once.
+"""
+
+import json
+import threading
+
+import fsspec
+import pytest
+from copick.util import portal_cache
+
+
+class FakeObject:
+    def __init__(self, identifier):
+        self.identifier = identifier
+
+
+class FakeConfig:
+    """Minimal stand-in for CopickConfigCDP with the attributes the cache reads."""
+
+    config_type = "cryoet_data_portal"
+
+    def __init__(
+        self,
+        overlay_root,
+        dataset_ids=(10000,),
+        identifiers=("GO:0000001", "GO:0000002"),
+        enabled=True,
+        ttl=86400,
+        cache_dir=None,
+        lock_timeout=30,
+    ):
+        self.overlay_root = overlay_root
+        self.overlay_fs_args = {"auto_mkdir": True}
+        self.dataset_ids = list(dataset_ids)
+        self.pickable_objects = [FakeObject(i) for i in identifiers]
+        self.portal_cache = enabled
+        self.portal_cache_ttl_seconds = ttl
+        self.portal_cache_dir = cache_dir
+        self.portal_cache_lock_timeout_seconds = lock_timeout
+
+
+def _sample_data():
+    data = {k: [] for k in portal_cache.DATA_KEYS}
+    data["runs"] = [{"id": 1, "name": "TS_1", "dataset_id": 10000}]
+    data["voxel_spacings"] = [{"id": 11, "run_id": 1, "voxel_spacing": 10.0}]
+    return data
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch, tmp_path):
+    """Keep cache env overrides unset and redirect the XDG fallback into the temp dir."""
+    for var in (
+        "COPICK_PORTAL_CACHE",
+        "COPICK_PORTAL_CACHE_TTL",
+        "COPICK_PORTAL_CACHE_DIR",
+        "COPICK_PORTAL_CACHE_LOCK_TIMEOUT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+
+
+@pytest.fixture
+def overlay(tmp_path):
+    root = str(tmp_path / "overlay")
+    fs = fsspec.filesystem("file", auto_mkdir=True)
+    fs.makedirs(root, exist_ok=True)
+    return fs, root
+
+
+class CountingFetch:
+    def __init__(self, data=None):
+        self.calls = 0
+        self._data = data if data is not None else _sample_data()
+
+    def __call__(self):
+        self.calls += 1
+        return self._data
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_stable_and_sensitive():
+    fp1 = portal_cache.compute_fingerprint([10000, 10001], ["GO:1", "GO:2"])
+    fp2 = portal_cache.compute_fingerprint([10001, 10000], ["GO:2", "GO:1"])  # order-insensitive
+    assert fp1 == fp2
+    assert fp1 != portal_cache.compute_fingerprint([10000], ["GO:1", "GO:2"])
+    assert fp1 != portal_cache.compute_fingerprint([10000, 10001], ["GO:1"])
+
+
+def test_fingerprint_for_config_matches_manual():
+    cfg = FakeConfig("mem://x", dataset_ids=[10000], identifiers=["GO:2", "GO:1"])
+    assert portal_cache.fingerprint_for_config(cfg) == portal_cache.compute_fingerprint([10000], ["GO:1", "GO:2"])
+
+
+# ---------------------------------------------------------------------------
+# get_or_fetch: read/write, warm hit, force, disable
+# ---------------------------------------------------------------------------
+
+
+def _call(cfg, overlay, fetch, force=False):
+    fs, root = overlay
+    return portal_cache.get_or_fetch(
+        fingerprint=portal_cache.fingerprint_for_config(cfg),
+        dataset_ids=cfg.dataset_ids,
+        settings=portal_cache.settings_from_config(cfg),
+        fetch_fn=fetch,
+        fs_overlay=fs,
+        root_overlay=root,
+        force=force,
+    )
+
+
+def test_cold_then_warm(overlay):
+    cfg = FakeConfig(overlay[1])
+    fetch = CountingFetch()
+
+    first = _call(cfg, overlay, fetch)
+    assert first == fetch._data
+    assert fetch.calls == 1
+
+    # Warm: a second construction reads the disk cache and does not query.
+    second = _call(cfg, overlay, fetch)
+    assert second == fetch._data
+    assert fetch.calls == 1
+
+
+def test_force_refetches(overlay):
+    cfg = FakeConfig(overlay[1])
+    fetch = CountingFetch()
+    _call(cfg, overlay, fetch)
+    _call(cfg, overlay, fetch, force=True)
+    assert fetch.calls == 2
+
+
+def test_disabled_passthrough(overlay):
+    cfg = FakeConfig(overlay[1], enabled=False)
+    fetch = CountingFetch()
+    _call(cfg, overlay, fetch)
+    _call(cfg, overlay, fetch)
+    assert fetch.calls == 2  # no cache read or write when disabled
+
+    # And nothing was written to the overlay cache dir.
+    fs, root = overlay
+    assert not fs.exists(f"{root}/.copick_cache")
+
+
+def test_ttl_expiry(overlay):
+    cfg = FakeConfig(overlay[1], ttl=1)
+    fetch = CountingFetch()
+    _call(cfg, overlay, fetch)
+
+    # Rewrite the cache document with an old timestamp so it is considered stale.
+    fs, root = overlay
+    fp = portal_cache.fingerprint_for_config(cfg)
+    path = f"{root}/.copick_cache/portal_{fp}.json"
+    with fs.open(path, "r") as f:
+        doc = json.load(f)
+    doc["created"] = "2000-01-01T00:00:00+00:00"
+    with fs.open(path, "w") as f:
+        json.dump(doc, f)
+
+    _call(cfg, overlay, fetch)
+    assert fetch.calls == 2  # stale entry forced a refetch
+
+
+def test_corrupt_file_is_miss(overlay):
+    cfg = FakeConfig(overlay[1])
+    fetch = CountingFetch()
+    _call(cfg, overlay, fetch)
+
+    fs, root = overlay
+    fp = portal_cache.fingerprint_for_config(cfg)
+    path = f"{root}/.copick_cache/portal_{fp}.json"
+    with fs.open(path, "w") as f:
+        f.write("{ this is not valid json ]")
+
+    result = _call(cfg, overlay, fetch)
+    assert result == fetch._data
+    assert fetch.calls == 2  # corrupt cache treated as a miss and overwritten
+
+
+def test_fingerprint_change_is_miss(overlay):
+    fetch = CountingFetch()
+    _call(FakeConfig(overlay[1], identifiers=["GO:1"]), overlay, fetch)
+    # Different object set -> different fingerprint -> different file -> refetch.
+    _call(FakeConfig(overlay[1], identifiers=["GO:1", "GO:2"]), overlay, fetch)
+    assert fetch.calls == 2
+
+
+def test_date_field_round_trips(overlay):
+    import datetime
+
+    cfg = FakeConfig(overlay[1])
+    data = _sample_data()
+    data["tomograms"] = [{"id": 5, "tomogram_voxel_spacing_id": 11, "release_date": datetime.date(2020, 1, 1)}]
+    fetch = CountingFetch(data)
+
+    _call(cfg, overlay, fetch)  # store must not raise on the date field (default=str)
+    loaded = _call(cfg, overlay, fetch)
+    assert fetch.calls == 1
+    assert loaded["tomograms"][0]["release_date"] == "2020-01-01"  # coerced to string on disk
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: the lock + double-check collapses the herd to a single fetch
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_cold_start_fetches_once(overlay):
+    cfg = FakeConfig(overlay[1])
+
+    lock = threading.Lock()
+    calls = {"n": 0}
+
+    def fetch():
+        with lock:
+            calls["n"] += 1
+        import time
+
+        time.sleep(0.05)  # widen the window so threads genuinely contend
+        return _sample_data()
+
+    barrier = threading.Barrier(6)
+    results = []
+
+    def worker():
+        barrier.wait()
+        results.append(_call(cfg, overlay, fetch))
+
+    threads = [threading.Thread(target=worker) for _ in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert calls["n"] == 1  # exactly one thread queried; the rest read the published cache
+    assert all(r == _sample_data() for r in results)
+
+
+# ---------------------------------------------------------------------------
+# status_for_config / clear
+# ---------------------------------------------------------------------------
+
+
+def test_status_reports_fresh_then_missing(overlay):
+    fs, root = overlay
+    cfg = FakeConfig(root)
+    fetch = CountingFetch()
+
+    before = portal_cache.status_for_config(cfg, fs_overlay=fs, root_overlay=root)
+    assert all(not s.exists for s in before)
+
+    _call(cfg, overlay, fetch)
+    after = portal_cache.status_for_config(cfg, fs_overlay=fs, root_overlay=root)
+    assert after[0].exists and after[0].fresh
+
+
+def test_clear_removes_current_fingerprint(overlay):
+    fs, root = overlay
+    cfg = FakeConfig(root)
+    fetch = CountingFetch()
+    _call(cfg, overlay, fetch)
+
+    fp = portal_cache.fingerprint_for_config(cfg)
+    path = f"{root}/.copick_cache/portal_{fp}.json"
+    assert fs.exists(path)
+
+    removed = portal_cache.clear(cfg, fs_overlay=fs, root_overlay=root)
+    assert path in removed
+    assert not fs.exists(path)
+
+
+def test_clear_all_removes_every_portal_file(overlay):
+    fs, root = overlay
+    # Two different object sets -> two different cache files under the same overlay.
+    cfg_a = FakeConfig(root, identifiers=["GO:1"])
+    cfg_b = FakeConfig(root, identifiers=["GO:1", "GO:2"])
+    _call(cfg_a, overlay, CountingFetch())
+    _call(cfg_b, overlay, CountingFetch())
+
+    cache_dir = f"{root}/.copick_cache"
+    assert len(fs.glob(f"{cache_dir}/portal_*.json")) == 2
+
+    removed = portal_cache.clear(cfg_a, remove_all=True, fs_overlay=fs, root_overlay=root)
+    assert len(removed) == 2
+    assert fs.glob(f"{cache_dir}/portal_*.json") == []

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -798,6 +798,7 @@ dependencies = [
     { name = "distinctipy" },
     { name = "dynamotable" },
     { name = "emfile" },
+    { name = "filelock" },
     { name = "fsspec" },
     { name = "mlcroissant" },
     { name = "mrcfile" },
@@ -867,6 +868,7 @@ requires-dist = [
     { name = "distinctipy", specifier = ">=1.3.4" },
     { name = "dynamotable", specifier = ">=0.2.0" },
     { name = "emfile", specifier = "==0.3.0" },
+    { name = "filelock", specifier = ">=3.18.0" },
     { name = "fsspec", specifier = ">=2025.5.1" },
     { name = "ipython", marker = "extra == 'dev'", specifier = ">=8.18.1" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.29.1" },


### PR DESCRIPTION
When many processes initialize copick roots against the CryoET Data Portal at the same time (e.g. large parallel processing runs), the portal API can become overburdened and
  start returning HTTP 503, killing the jobs. To avoid this — and to speed up parallel processing — this introduces a caching mechanism for CryoET Data Portal metadata: only an
  initial process needs to query the metadata, which is then persisted and reused by all others.
  
  **How it works**
  - On portal-backed root init, the batched portal metadata queries are written to a small JSON cache in the overlay (`{overlay_root}/.copick_cache/portal_<fingerprint>.json`),
  keyed by a fingerprint of the dataset IDs + pickable objects (+ SDK/schema version). Later processes read the cache instead of re-querying.
  - Writes are atomic (unique temp file + rename) so a reader never sees a partial file; a `filelock` lock with double-checked reads collapses the cold-start stampede to a single
  portal query.
  - Time-limited (24h TTL by default) and configurable via `CopickConfigCDP` fields and `COPICK_PORTAL_CACHE*` env vars; degrades gracefully (any cache failure falls back to
  querying the portal — never breaks construction).
  - Two previously-uncached hot paths — `root.runs` and `run.voxel_spacings` — now serve from the cache too, removing the per-run portal calls that were a major contributor to the
  storm.
  - New `copick cache info` / `copick cache clear` CLI commands inspect and manually invalidate the cache.
