### PR TITLE
feat: resolve OME-Zarr levels from metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ To test with the example dataset:
     import zarr
 
     from copick.impl.filesystem import CopickRootFSSpec
+    from copick.util.ome import get_level_path
     root = CopickRootFSSpec.from_file('path/to/filesystem_overlay_only.json')
 
     # Get a run by name
@@ -117,9 +118,8 @@ To test with the example dataset:
     tomogram = run.get_voxel_spacing(10).get_tomogram("wbp")
 
     # Access the data
-    group = zarr.open(tomogram.zarr())
-    arrays = list(group.arrays())
-    _, array = arrays[0]
+    group = zarr.open(tomogram.zarr(), mode="r")
+    array = group[get_level_path(group, 0)]
     ```
 
 ## Contributing

--- a/docs/snippets/features_read_image.py
+++ b/docs/snippets/features_read_image.py
@@ -1,8 +1,6 @@
 """Read a feature map from a zarr-store into a numpy array."""
 
 import copick
-import numpy as np
-import zarr
 
 # Initialize the root object from a configuration file
 root = copick.from_file("path/to/config.json")
@@ -20,5 +18,4 @@ tomogram = voxel_spacing.get_tomogram("wbp")
 feature_map = tomogram.get_features("sobel")
 
 # Read the feature map from its zarr-store
-zarr_array = zarr.open(feature_map.zarr())["0"]
-feature_map_data = np.array(zarr_array)
+feature_map_data = feature_map.numpy()

--- a/docs/snippets/object_read_map.py
+++ b/docs/snippets/object_read_map.py
@@ -1,8 +1,6 @@
 """Read a density map from an object's zarr-store into a numpy array."""
 
 import copick
-import numpy as np
-import zarr
 
 # Initialize the root object from a configuration file
 root = copick.from_file("path/to/config.json")
@@ -11,5 +9,4 @@ root = copick.from_file("path/to/config.json")
 proteasome = root.get_object("proteasome")
 
 # Read the density map for the object from its zarr-store
-zarr_array = zarr.open(proteasome.zarr())["0"]
-density_map = np.array(zarr_array)
+density_map = proteasome.numpy()

--- a/docs/snippets/segmentation_read_image.py
+++ b/docs/snippets/segmentation_read_image.py
@@ -1,8 +1,6 @@
 """Read a segmentation from a CopickSegmentation object."""
 
 import copick
-import numpy as np
-import zarr
 
 # Initialize the root object from a configuration file
 root = copick.from_file("path/to/config.json")
@@ -14,5 +12,4 @@ run = root.runs[0]
 segmentation = run.get_segmentations(name="proteasome", user_id="alice")[0]
 
 # Get the segmentation array from the segmentation
-seg_zarr = zarr.open(segmentation.zarr())["0"]
-seg = np.array(seg_zarr)
+seg = segmentation.numpy()

--- a/docs/snippets/solution_random_points.py
+++ b/docs/snippets/solution_random_points.py
@@ -83,10 +83,9 @@ def run():
     # Imports
     from typing import List, Sequence
 
+    import copick
     import numpy as np
     import zarr
-
-    import copick
     from copick.models import CopickLocation, CopickPoint
     from copick.util.ome import get_level_path
 

--- a/docs/snippets/solution_random_points.py
+++ b/docs/snippets/solution_random_points.py
@@ -83,10 +83,12 @@ def run():
     # Imports
     from typing import List, Sequence
 
-    import copick
     import numpy as np
     import zarr
+
+    import copick
     from copick.models import CopickLocation, CopickPoint
+    from copick.util.ome import get_level_path
 
     # Parse arguments
     args = get_args()
@@ -129,7 +131,8 @@ def run():
         # Get the physical tomogram dimensions
         vs = run.get_voxel_spacing(voxel_spacing)
         tomo = vs.get_tomogram(tomo_type)
-        pixel_max_dim = zarr.open(tomo.zarr())["0"].shape[::-1]
+        zarr_group = zarr.open(tomo.zarr(), mode="r")
+        pixel_max_dim = zarr_group[get_level_path(zarr_group, 0)].shape[::-1]
         max_dim = np.array([d * voxel_spacing for d in pixel_max_dim])
 
         # If picks of the same type already exist, we will get and overwrite them

--- a/docs/snippets/tomogram_read_image.py
+++ b/docs/snippets/tomogram_read_image.py
@@ -1,9 +1,8 @@
 """Read a tomogram from a zarr-store into a numpy array."""
 
+import copick
 import numpy as np
 import zarr
-
-import copick
 from copick.util.ome import get_level_path
 
 # Initialize the root object from a configuration file

--- a/docs/snippets/tomogram_read_image.py
+++ b/docs/snippets/tomogram_read_image.py
@@ -1,8 +1,10 @@
 """Read a tomogram from a zarr-store into a numpy array."""
 
-import copick
 import numpy as np
 import zarr
+
+import copick
+from copick.util.ome import get_level_path
 
 # Initialize the root object from a configuration file
 root = copick.from_file("path/to/config.json")
@@ -17,10 +19,11 @@ voxel_spacing = run.get_voxel_spacing(10.000)
 tomogram = voxel_spacing.get_tomogram("wbp")
 
 # Read the tomogram from its zarr-store
-# Scale "0" is the unbinned tomogram
-zarr_array = zarr.open(tomogram.zarr())["0"]
+# Scale 0 is the unbinned tomogram
+zarr_group = zarr.open(tomogram.zarr(), mode="r")
+zarr_array = zarr_group[get_level_path(zarr_group, 0)]
 tomogram_data = np.array(zarr_array)
 
-# Scale "1" is the tomogram binned by 2
-zarr_array_bin2 = zarr.open(tomogram.zarr())["1"]
+# Scale 1 is the tomogram binned by 2
+zarr_array_bin2 = zarr_group[get_level_path(zarr_group, 1)]
 tomogram_data_bin2 = np.array(zarr_array_bin2)

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -6,13 +6,20 @@ import zarr
 from pydantic import AliasChoices, BaseModel, Field, field_validator
 
 from copick.util.escape import sanitize_name
-from copick.util.ome import fits_in_memory, segmentation_pyramid, volume_pyramid, write_ome_zarr_3d
+from copick.util.ome import fits_in_memory, get_level_path, segmentation_pyramid, volume_pyramid, write_ome_zarr_3d
 from copick.util.relion import picks_to_df_relion, relion_df_to_picks
 
 # Don't import Geometry at runtime to keep CLI snappy
 if TYPE_CHECKING:
     import pandas as pd
     from trimesh.parent import Geometry
+
+
+def _open_zarr_array(loc: MutableMapping, zarr_group: Optional[str], mode: str) -> zarr.Array:
+    """Open an explicitly named array or resolve the first OME pyramid level."""
+    root_group = zarr.open(loc, mode=mode)
+    array_path = zarr_group if zarr_group is not None else get_level_path(root_group, 0)
+    return root_group[array_path]
 
 
 class PickableObject(BaseModel):
@@ -301,7 +308,7 @@ class CopickObject:
 
     def numpy(
         self,
-        zarr_group: str = "0",
+        zarr_group: Optional[str] = None,
         x: slice = slice(None, None),
         y: slice = slice(None, None),
         z: slice = slice(None, None),
@@ -310,7 +317,7 @@ class CopickObject:
         supported.
 
         Args:
-            zarr_group: Zarr group to access.
+            zarr_group: Explicit Zarr array path. By default, resolve level 0 from OME metadata.
             x: Slice for the x-axis.
             y: Slice for the y-axis.
             z: Slice for the z-axis.
@@ -323,7 +330,7 @@ class CopickObject:
         if loc is None:
             return None
 
-        group = zarr.open(loc)[zarr_group]
+        group = _open_zarr_array(loc, zarr_group, mode="r")
 
         fits, req, avail = fits_in_memory(group, (x, y, z))
         if not fits:
@@ -352,7 +359,7 @@ class CopickObject:
     def set_region(
         self,
         data: np.ndarray,
-        zarr_group: str = "0",
+        zarr_group: Optional[str] = None,
         x: slice = slice(None, None),
         y: slice = slice(None, None),
         z: slice = slice(None, None),
@@ -361,13 +368,13 @@ class CopickObject:
 
         Args:
             data: The object's subregion as a numpy array.
-            zarr_group: Zarr group to access.
+            zarr_group: Explicit Zarr array path. By default, resolve level 0 from OME metadata.
             x: Slice for the x-axis.
             y: Slice for the y-axis.
             z: Slice for the z-axis.
         """
         loc = self.zarr()
-        zarr.open(loc)[zarr_group][z, y, x] = data
+        _open_zarr_array(loc, zarr_group, mode="r+")[z, y, x] = data
 
     def delete(self) -> None:
         """Delete the object."""
@@ -1809,7 +1816,7 @@ class CopickTomogram:
 
     def numpy(
         self,
-        zarr_group: str = "0",
+        zarr_group: Optional[str] = None,
         x: slice = slice(None, None),
         y: slice = slice(None, None),
         z: slice = slice(None, None),
@@ -1818,7 +1825,7 @@ class CopickTomogram:
         supported.
 
         Args:
-            zarr_group: Zarr group to access.
+            zarr_group: Explicit Zarr array path. By default, resolve level 0 from OME metadata.
             x: Slice for the x-axis.
             y: Slice for the y-axis.
             z: Slice for the z-axis.
@@ -1828,13 +1835,13 @@ class CopickTomogram:
         """
 
         loc = self.zarr()
-        group = zarr.open(loc)[zarr_group]
+        group = _open_zarr_array(loc, zarr_group, mode="r")
 
         fits, req, avail = fits_in_memory(group, (x, y, z))
         if not fits:
             raise ValueError(f"Requested region does not fit in memory. Requested: {req}, Available: {avail}.")
 
-        return np.array(zarr.open(loc)[zarr_group][z, y, x])
+        return np.array(group[z, y, x])
 
     def from_numpy(
         self,
@@ -1857,7 +1864,7 @@ class CopickTomogram:
     def set_region(
         self,
         data: np.ndarray,
-        zarr_group: str = "0",
+        zarr_group: Optional[str] = None,
         x: slice = slice(None, None),
         y: slice = slice(None, None),
         z: slice = slice(None, None),
@@ -1866,13 +1873,13 @@ class CopickTomogram:
 
         Args:
             data: The tomogram's subregion as a numpy array.
-            zarr_group: Zarr group to access.
+            zarr_group: Explicit Zarr array path. By default, resolve level 0 from OME metadata.
             x: Slice for the x-axis.
             y: Slice for the y-axis.
             z: Slice for the z-axis.
         """
         loc = self.zarr()
-        zarr.open(loc)[zarr_group][z, y, x] = data
+        _open_zarr_array(loc, zarr_group, mode="r+")[z, y, x] = data
 
 
 class CopickFeaturesMeta(BaseModel):
@@ -1937,14 +1944,14 @@ class CopickFeatures:
 
     def numpy(
         self,
-        zarr_group: str = "0",
+        zarr_group: Optional[str] = None,
         slices: Tuple[slice, ...] = None,
     ) -> np.ndarray:
         """Returns the content of the Zarr-File for this feature map as a numpy array. Multiscale group and slices are
         supported.
 
         Args:
-            zarr_group: Zarr group to access.
+            zarr_group: Explicit Zarr array path. By default, resolve level 0 from OME metadata.
             slices: Tuple of slices for the axes.
 
         Returns:
@@ -1952,7 +1959,7 @@ class CopickFeatures:
         """
 
         loc = self.zarr()
-        group = zarr.open(loc)[zarr_group]
+        group = _open_zarr_array(loc, zarr_group, mode="r")
         ndim = len(group.shape)
 
         if slices is None:
@@ -1967,7 +1974,7 @@ class CopickFeatures:
     def set_region(
         self,
         data: np.ndarray,
-        zarr_group: str = "0",
+        zarr_group: Optional[str] = None,
         slices: Tuple[slice, ...] = None,
     ) -> None:
         """Set the content of the Zarr-File for this feature map from a numpy array. Multiscale group and slices are
@@ -1975,11 +1982,11 @@ class CopickFeatures:
 
         Args:
             data: The data to set.
-            zarr_group: Zarr group to access.
+            zarr_group: Explicit Zarr array path. By default, resolve level 0 from OME metadata.
             slices: Tuple of slices for the axes.
         """
         loc = self.zarr()
-        zarr.open(loc)[zarr_group][slices] = data
+        _open_zarr_array(loc, zarr_group, mode="r+")[slices] = data
 
 
 class CopickPicksFile(BaseModel):
@@ -2424,7 +2431,7 @@ class CopickSegmentation:
 
     def numpy(
         self,
-        zarr_group: str = "0",
+        zarr_group: Optional[str] = None,
         x: slice = slice(None, None),
         y: slice = slice(None, None),
         z: slice = slice(None, None),
@@ -2433,7 +2440,7 @@ class CopickSegmentation:
         supported.
 
         Args:
-            zarr_group: Zarr group to access.
+            zarr_group: Explicit Zarr array path. By default, resolve level 0 from OME metadata.
             x: Slice for the x-axis.
             y: Slice for the y-axis.
             z: Slice for the z-axis.
@@ -2443,13 +2450,13 @@ class CopickSegmentation:
         """
 
         loc = self.zarr()
-        group = zarr.open(loc)[zarr_group]
+        group = _open_zarr_array(loc, zarr_group, mode="r")
 
         fits, req, avail = fits_in_memory(group, (x, y, z))
         if not fits:
             raise ValueError(f"Requested region does not fit in memory. Requested: {req}, Available: {avail}.")
 
-        return np.array(zarr.open(loc)[zarr_group][z, y, x])
+        return np.array(group[z, y, x])
 
     def from_numpy(
         self,
@@ -2472,7 +2479,7 @@ class CopickSegmentation:
     def set_region(
         self,
         data: np.ndarray,
-        zarr_group: str = "0",
+        zarr_group: Optional[str] = None,
         x: slice = slice(None, None),
         y: slice = slice(None, None),
         z: slice = slice(None, None),
@@ -2481,13 +2488,13 @@ class CopickSegmentation:
 
         Args:
             data: The segmentation's subregion as a numpy array.
-            zarr_group: Zarr group to access.
+            zarr_group: Explicit Zarr array path. By default, resolve level 0 from OME metadata.
             x: Slice for the x-axis.
             y: Slice for the y-axis.
             z: Slice for the z-axis.
         """
         loc = self.zarr()
-        zarr.open(loc)[zarr_group][z, y, x] = data
+        _open_zarr_array(loc, zarr_group, mode="r+")[z, y, x] = data
 
 
 COPICK_TYPES = (

--- a/src/copick/ops/add.py
+++ b/src/copick/ops/add.py
@@ -16,7 +16,7 @@ from copick.models import (
     CopickTomogram,
     CopickVoxelSpacing,
 )
-from copick.util.ome import get_voxel_size_from_zarr, ome_metadata, volume_pyramid
+from copick.util.ome import get_level_path, get_voxel_size_from_zarr, ome_metadata, volume_pyramid
 
 
 def add_run(
@@ -308,9 +308,9 @@ def _add_tomogram_zarr(
         flip (str, optional): Flip axes. E.g., '0' to flip Z, '0,2' to flip Z and X. Default: None.
     """
 
-    zarr_group = zarr.open(volume_file)
+    zarr_group = zarr.open(volume_file, mode="r")
     # Get the first level data (level 0)
-    volume = np.array(zarr_group["0"])
+    volume = np.array(zarr_group[get_level_path(zarr_group, 0)])
     voxel_size = get_voxel_size_from_zarr(zarr_group)
 
     if voxel_spacing:

--- a/src/copick/ops/export.py
+++ b/src/copick/ops/export.py
@@ -12,6 +12,7 @@ import numpy as np
 import zarr
 
 from copick.util.log import get_logger
+from copick.util.ome import get_level_path
 
 if TYPE_CHECKING:
     from copick.models import (
@@ -448,8 +449,8 @@ def _export_tomogram_mrc(
     import mrcfile
 
     # Get the data
-    zarr_group = zarr.open(tomogram.zarr())
-    volume = np.array(zarr_group[str(level)])
+    zarr_group = zarr.open(tomogram.zarr(), mode="r")
+    volume = np.array(zarr_group[get_level_path(zarr_group, level)])
 
     # Get voxel size (scales with pyramid level)
     voxel_size = tomogram.voxel_spacing.voxel_size * (2**level)
@@ -488,8 +489,8 @@ def _export_tomogram_tiff(
     from copick.util.formats import write_tiff_volume
 
     # Get the data
-    zarr_group = zarr.open(tomogram.zarr())
-    volume = np.array(zarr_group[str(level)])
+    zarr_group = zarr.open(tomogram.zarr(), mode="r")
+    volume = np.array(zarr_group[get_level_path(zarr_group, level)])
 
     # Write TIFF file
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
@@ -539,7 +540,8 @@ def _export_tomogram_zarr(
         # Copy only level 0
         source_group = zarr.open(source, mode="r")
         dest_group = zarr.open(output_path, mode="w")
-        zarr.copy(source_group["0"], dest_group, name="0")
+        level_path = get_level_path(source_group, 0)
+        zarr.copy(source_group[level_path], dest_group, name=level_path)
         # Copy metadata
         dest_group.attrs.update(source_group.attrs)
 
@@ -611,8 +613,8 @@ def _export_segmentation_mrc(
     import mrcfile
 
     # Get the data
-    zarr_group = zarr.open(segmentation.zarr())
-    volume = np.array(zarr_group[str(level)])
+    zarr_group = zarr.open(segmentation.zarr(), mode="r")
+    volume = np.array(zarr_group[get_level_path(zarr_group, level)])
 
     # Get voxel size (scales with pyramid level)
     voxel_size = segmentation.voxel_size * (2**level)
@@ -655,8 +657,8 @@ def _export_segmentation_tiff(
     from copick.util.formats import write_tiff_volume
 
     # Get the data
-    zarr_group = zarr.open(segmentation.zarr())
-    volume = np.array(zarr_group[str(level)])
+    zarr_group = zarr.open(segmentation.zarr(), mode="r")
+    volume = np.array(zarr_group[get_level_path(zarr_group, level)])
 
     # Write TIFF file
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
@@ -688,8 +690,8 @@ def _export_segmentation_em(
     from copick.util.formats import write_em_volume
 
     # Get the data
-    zarr_group = zarr.open(segmentation.zarr())
-    volume = np.array(zarr_group[str(level)])
+    zarr_group = zarr.open(segmentation.zarr(), mode="r")
+    volume = np.array(zarr_group[get_level_path(zarr_group, level)])
 
     # Write EM file
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
@@ -739,7 +741,8 @@ def _export_segmentation_zarr(
         # Copy only level 0
         source_group = zarr.open(source, mode="r")
         dest_group = zarr.open(output_path, mode="w")
-        zarr.copy(source_group["0"], dest_group, name="0")
+        level_path = get_level_path(source_group, 0)
+        zarr.copy(source_group[level_path], dest_group, name=level_path)
         # Copy metadata
         dest_group.attrs.update(source_group.attrs)
 

--- a/src/copick/util/formats.py
+++ b/src/copick/util/formats.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import numpy as np
 
 from copick.util.log import get_logger
+from copick.util.ome import get_level_path
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -1229,7 +1230,7 @@ def get_tomogram_centers_from_copick(
 
         zarr_store = tomo.zarr()
         group = zarr.open(zarr_store, mode="r")
-        shape = group["0"].shape  # (z, y, x)
+        shape = group[get_level_path(group, 0)].shape  # (z, y, x)
 
         # Compute center in Angstrom
         center_z = (shape[0] / 2) * voxel_spacing

--- a/src/copick/util/handlers/volume/zarr.py
+++ b/src/copick/util/handlers/volume/zarr.py
@@ -6,7 +6,7 @@ import numpy as np
 import zarr
 
 from copick.util.handlers import FormatCapabilities
-from copick.util.ome import get_voxel_size_from_zarr
+from copick.util.ome import get_level_path, get_multiscales, get_voxel_size_from_zarr
 
 
 class ZarrVolumeHandler:
@@ -42,34 +42,40 @@ class ZarrVolumeHandler:
         store = zarr.open(path, mode="r")
 
         # Try to read from OME-NGFF structure (multiscales)
-        if isinstance(store, zarr.hierarchy.Group):
+        if isinstance(store, zarr.Group):
             # Check for OME-NGFF multiscales
-            if ".zattrs" in store.store and "multiscales" in store.attrs:
-                multiscales = store.attrs["multiscales"][0]
-                datasets = multiscales.get("datasets", [])
-                if level < len(datasets):
-                    dataset_path = datasets[level]["path"]
-                    volume = np.array(store[dataset_path])
-
-                    # Get voxel size with proper unit conversion using ome.py utility
-                    try:
-                        voxel_size = get_voxel_size_from_zarr(store)
-                        # Scale voxel size for pyramid levels
-                        if level > 0:
-                            voxel_size = voxel_size * (2**level)
-                    except (KeyError, ValueError):
-                        voxel_size = None
-
-                    return volume, voxel_size
-                else:
-                    raise ValueError(f"Level {level} not found in Zarr store (max: {len(datasets) - 1})")
+            try:
+                get_multiscales(store)
+            except KeyError:
+                has_multiscales = False
             else:
+                has_multiscales = True
+
+            if not has_multiscales:
                 # Simple group, try to find array
+                if level != 0:
+                    raise ValueError(f"Level {level} not found in Zarr store (max: 0)")
                 for key in store:
-                    if isinstance(store[key], zarr.core.Array):
+                    if isinstance(store[key], zarr.Array):
                         return np.array(store[key]), None
                 raise ValueError("No arrays found in Zarr group")
-        elif isinstance(store, zarr.core.Array):
+
+            dataset_path = get_level_path(store, level)
+            volume = np.array(store[dataset_path])
+
+            # Get voxel size with proper unit conversion using ome.py utility
+            try:
+                voxel_size = get_voxel_size_from_zarr(store)
+                # Scale voxel size for pyramid levels
+                if level > 0:
+                    voxel_size = voxel_size * (2**level)
+            except (KeyError, ValueError):
+                voxel_size = None
+
+            return volume, voxel_size
+        elif isinstance(store, zarr.Array):
+            if level != 0:
+                raise ValueError(f"Level {level} not found in Zarr store (max: 0)")
             return np.array(store), None
         else:
             raise ValueError(f"Unexpected Zarr store type: {type(store)}")

--- a/src/copick/util/ome.py
+++ b/src/copick/util/ome.py
@@ -171,6 +171,53 @@ def write_ome_zarr_3d(
     )
 
 
+def get_multiscales(zarr_group: zarr.Group) -> List[Dict[str, Any]]:
+    """Return OME multiscale metadata from either the 0.4 or 0.5 layout.
+
+    OME-Zarr 0.4 stores ``multiscales`` at the root of the group's
+    attributes. OME-Zarr 0.5 nests it below the ``ome`` attribute.
+
+    Args:
+        zarr_group: The Zarr group containing OME-Zarr metadata.
+
+    Returns:
+        The OME multiscale metadata entries.
+
+    Raises:
+        KeyError: If neither supported metadata layout is present.
+    """
+    if "multiscales" in zarr_group.attrs:
+        return zarr_group.attrs["multiscales"]
+
+    ome = zarr_group.attrs.get("ome")
+    if isinstance(ome, dict) and "multiscales" in ome:
+        return ome["multiscales"]
+
+    raise KeyError("OME-Zarr multiscales metadata not found")
+
+
+def get_level_path(zarr_group: zarr.Group, level: int) -> str:
+    """Resolve a bounded pyramid level to its metadata-defined dataset path.
+
+    Args:
+        zarr_group: The Zarr group containing OME-Zarr metadata.
+        level: Zero-based pyramid level.
+
+    Returns:
+        The dataset path declared for ``level``.
+
+    Raises:
+        ValueError: If ``level`` is negative or outside the declared pyramid.
+        KeyError: If required OME-Zarr metadata is absent.
+    """
+    multiscales = get_multiscales(zarr_group)
+    datasets = multiscales[0]["datasets"]
+    if level < 0 or level >= len(datasets):
+        raise ValueError(f"Level {level} not found in Zarr store (max: {len(datasets) - 1})")
+
+    return datasets[level]["path"]
+
+
 def get_voxel_size_from_zarr(zarr_group: zarr.Group) -> float:
     """Extract voxel size from OME-Zarr coordinate transformations.
 
@@ -180,7 +227,7 @@ def get_voxel_size_from_zarr(zarr_group: zarr.Group) -> float:
     Returns:
         The voxel size in Angstrom from the coordinate transformations.
     """
-    multiscales = zarr_group.attrs["multiscales"]
+    multiscales = get_multiscales(zarr_group)
 
     # Get unit from axes (should be consistent across spatial axes)
     axes = multiscales[0]["axes"]
@@ -209,7 +256,7 @@ def get_voxel_size_from_zarr(zarr_group: zarr.Group) -> float:
     raise ValueError("No scale transformation found in coordinate transformations")
 
 
-def fits_in_memory(array: zarr.Group, slices: Tuple[slice, ...]) -> Tuple[bool, int, int]:
+def fits_in_memory(array: zarr.Array, slices: Tuple[slice, ...]) -> Tuple[bool, int, int]:
     """Check if the array fits in memory after slicing.
 
     Args:
@@ -227,7 +274,7 @@ def fits_in_memory(array: zarr.Group, slices: Tuple[slice, ...]) -> Tuple[bool, 
     for dim, sl in zip(array.shape, slices, strict=True):
         num_elem.append(len(range(*sl.indices(dim))))
 
-    requested = np.prod(np.array(num_elem)) * array.itemsize
+    requested = np.prod(np.array(num_elem)) * array.dtype.itemsize
     available = psutil.virtual_memory().available
     fits = requested < available
 

--- a/src/copick/util/path_util.py
+++ b/src/copick/util/path_util.py
@@ -6,7 +6,7 @@ import mrcfile
 import numpy as np
 import zarr
 
-from copick.util.ome import get_voxel_size_from_zarr
+from copick.util.ome import get_level_path, get_voxel_size_from_zarr
 
 
 def get_format_from_extension(path: str) -> Union[str, None]:
@@ -24,7 +24,7 @@ def get_format_from_extension(path: str) -> Union[str, None]:
         "zarr": "zarr",
         "map": "mrc",
     }
-    return formats.get(path.split(".")[-1], None)
+    return formats.get(path.split(".")[-1])
 
 
 def get_data_from_file(path: str, file_format: str) -> Tuple[np.ndarray, float]:
@@ -43,8 +43,8 @@ def get_data_from_file(path: str, file_format: str) -> Tuple[np.ndarray, float]:
             volume_data = mrc.data
             voxel_spacing = float(mrc.voxel_size.y)  # Assuming isotropic voxel size
     elif file_format == "zarr":
-        zarr_group = zarr.open(path)
-        volume_data = zarr_group["0"][:]
+        zarr_group = zarr.open(path, mode="r")
+        volume_data = zarr_group[get_level_path(zarr_group, 0)][:]
         voxel_spacing = get_voxel_size_from_zarr(zarr_group)
     else:
         raise ValueError(f"Unsupported file format: {file_format}")

--- a/src/copick/util/relion.py
+++ b/src/copick/util/relion.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING, Tuple, Union
 import numpy as np
 import zarr
 
+from copick.util.ome import get_level_path
+
 if TYPE_CHECKING:
     import pandas as pd
 
@@ -79,7 +81,8 @@ def get_tomogram_spacing_and_dimensions(
             UserWarning,
             stacklevel=2,
         )
-    tomogram_z, tomogram_y, tomogram_x = zarr.open(tomogram.zarr())["0"].shape
+    zarr_group = zarr.open(tomogram.zarr(), mode="r")
+    tomogram_z, tomogram_y, tomogram_x = zarr_group[get_level_path(zarr_group, 0)].shape
 
     return voxel_spacing.voxel_size, tomogram_x, tomogram_y, tomogram_z
 

--- a/tests/test_ome.py
+++ b/tests/test_ome.py
@@ -24,8 +24,8 @@ def _write_named_pyramid(path, metadata_layout="0.4"):
     group = zarr.open(path, mode="w")
     level_zero = np.arange(64, dtype=np.float32).reshape(4, 4, 4)
     level_one = np.full((2, 2, 2), 7, dtype=np.float32)
-    group.create_dataset("s0", data=level_zero, chunks=(2, 2, 2))
-    group.create_dataset("s1", data=level_one, chunks=(2, 2, 2))
+    group.create_dataset("s0", data=level_zero, chunks=(2, 2, 2), dimension_separator="/")
+    group.create_dataset("s1", data=level_one, chunks=(2, 2, 2), dimension_separator="/")
 
     multiscales = [
         {
@@ -74,6 +74,8 @@ def test_multiscales_and_level_paths_support_both_metadata_layouts(tmp_path, met
     assert get_level_path(group, 0) == "s0"
     assert get_level_path(group, 1) == "s1"
     assert get_voxel_size_from_zarr(group) == 10.0
+    assert "s0/0/0/0" in group.store
+    assert "s0/0.0.0" not in group.store
 
 
 def test_level_path_rejects_invalid_levels_before_array_access():

--- a/tests/test_ome.py
+++ b/tests/test_ome.py
@@ -1,0 +1,150 @@
+"""Tests for OME-Zarr metadata-driven level access."""
+
+import inspect
+from types import SimpleNamespace
+
+import mrcfile
+import numpy as np
+import pytest
+import zarr
+
+from copick.models import (
+    CopickFeatures,
+    CopickObject,
+    CopickSegmentation,
+    CopickTomogram,
+    CopickTomogramMeta,
+)
+from copick.ops.export import export_tomogram
+from copick.util.handlers.volume.zarr import ZarrVolumeHandler
+from copick.util.ome import get_level_path, get_multiscales, get_voxel_size_from_zarr
+from copick.util.path_util import get_data_from_file
+
+
+def _write_named_pyramid(path, metadata_layout="0.4"):
+    group = zarr.open(path, mode="w")
+    level_zero = np.arange(64, dtype=np.float32).reshape(4, 4, 4)
+    level_one = np.full((2, 2, 2), 7, dtype=np.float32)
+    group.create_dataset("s0", data=level_zero, chunks=(2, 2, 2))
+    group.create_dataset("s1", data=level_one, chunks=(2, 2, 2))
+
+    multiscales = [
+        {
+            "version": metadata_layout,
+            "axes": [
+                {"name": "z", "type": "space", "unit": "angstrom"},
+                {"name": "y", "type": "space", "unit": "angstrom"},
+                {"name": "x", "type": "space", "unit": "angstrom"},
+            ],
+            "datasets": [
+                {
+                    "path": "s0",
+                    "coordinateTransformations": [{"type": "scale", "scale": [10.0, 10.0, 10.0]}],
+                },
+                {
+                    "path": "s1",
+                    "coordinateTransformations": [{"type": "scale", "scale": [20.0, 20.0, 20.0]}],
+                },
+            ],
+        },
+    ]
+    if metadata_layout == "0.4":
+        group.attrs["multiscales"] = multiscales
+    else:
+        group.attrs["ome"] = {"version": metadata_layout, "multiscales": multiscales}
+
+    return level_zero, level_one
+
+
+class _TomogramWithStore(CopickTomogram):
+    def __init__(self, store):
+        super().__init__(SimpleNamespace(voxel_size=10.0), CopickTomogramMeta(tomo_type="test"))
+        self._store = store
+
+    def zarr(self):
+        return self._store
+
+
+@pytest.mark.parametrize("metadata_layout", ["0.4", "0.5"])
+def test_multiscales_and_level_paths_support_both_metadata_layouts(tmp_path, metadata_layout):
+    path = str(tmp_path / f"named-{metadata_layout}.zarr")
+    _write_named_pyramid(path, metadata_layout)
+    group = zarr.open(path, mode="r")
+
+    assert get_multiscales(group)[0]["version"] == metadata_layout
+    assert get_level_path(group, 0) == "s0"
+    assert get_level_path(group, 1) == "s1"
+    assert get_voxel_size_from_zarr(group) == 10.0
+
+
+def test_level_path_rejects_invalid_levels_before_array_access():
+    metadata_only_group = SimpleNamespace(
+        attrs={
+            "multiscales": [
+                {
+                    "datasets": [
+                        {"path": "s0"},
+                    ],
+                },
+            ],
+        },
+    )
+
+    with pytest.raises(ValueError, match=r"Level -1 .*max: 0"):
+        get_level_path(metadata_only_group, -1)
+    with pytest.raises(ValueError, match=r"Level 1 .*max: 0"):
+        get_level_path(metadata_only_group, 1)
+
+
+def test_public_volume_apis_default_to_metadata_level_zero():
+    for cls in (CopickObject, CopickTomogram, CopickFeatures, CopickSegmentation):
+        assert inspect.signature(cls.numpy).parameters["zarr_group"].default is None
+        assert inspect.signature(cls.set_region).parameters["zarr_group"].default is None
+
+
+def test_tomogram_numpy_and_region_write_use_named_metadata_path(tmp_path):
+    path = str(tmp_path / "tomogram.zarr")
+    level_zero, level_one = _write_named_pyramid(path)
+    tomogram = _TomogramWithStore(path)
+
+    np.testing.assert_array_equal(tomogram.numpy(), level_zero)
+    np.testing.assert_array_equal(tomogram.numpy(zarr_group="s1"), level_one)
+
+    replacement = np.full((2, 2, 2), 99, dtype=np.float32)
+    tomogram.set_region(replacement, x=slice(1, 3), y=slice(1, 3), z=slice(1, 3))
+
+    group = zarr.open(path, mode="r")
+    np.testing.assert_array_equal(group["s0"][1:3, 1:3, 1:3], replacement)
+
+
+def test_named_level_works_in_handler_path_helper_and_export(tmp_path):
+    path = str(tmp_path / "named.zarr")
+    level_zero, level_one = _write_named_pyramid(path)
+
+    handler_volume, voxel_size = ZarrVolumeHandler().read(path, level=1)
+    np.testing.assert_array_equal(handler_volume, level_one)
+    assert voxel_size == 20.0
+
+    path_volume, path_voxel_size = get_data_from_file(path, "zarr")
+    np.testing.assert_array_equal(path_volume, level_zero)
+    assert path_voxel_size == 10.0
+
+    output_path = str(tmp_path / "level-one.mrc")
+    export_tomogram(_TomogramWithStore(path), output_path, "mrc", level=1)
+    with mrcfile.open(output_path) as output:
+        np.testing.assert_array_equal(output.data, level_one)
+
+    single_level_path = str(tmp_path / "single-level.zarr")
+    export_tomogram(_TomogramWithStore(path), single_level_path, "zarr", copy_all_levels=False)
+    single_level_group = zarr.open(single_level_path, mode="r")
+    assert get_level_path(single_level_group, 0) == "s0"
+    np.testing.assert_array_equal(single_level_group["s0"], level_zero)
+
+
+@pytest.mark.parametrize("level", [-1, 2])
+def test_handler_rejects_invalid_named_levels(tmp_path, level):
+    path = str(tmp_path / "named.zarr")
+    _write_named_pyramid(path)
+
+    with pytest.raises(ValueError, match=rf"Level {level} .*max: 1"):
+        ZarrVolumeHandler().read(path, level=level)

--- a/tests/test_ome.py
+++ b/tests/test_ome.py
@@ -7,7 +7,6 @@ import mrcfile
 import numpy as np
 import pytest
 import zarr
-
 from copick.models import (
     CopickFeatures,
     CopickObject,


### PR DESCRIPTION
## Summary

- Add shared helpers for resolving OME multiscale metadata and bounded dataset paths across both the OME-Zarr 0.4 and 0.5 attribute layouts.
- Resolve default volume reads and region writes from metadata instead of assuming the first array is named `0` or relying on `Group.arrays()` ordering.
- Change the eight public `zarr_group` defaults to `None`, while preserving explicit string path overrides.
- Use explicit `mode="r"` for reads and `mode="r+"` for region writes.
- Update import/export utilities, RELION helpers, the Zarr volume handler, README examples, and snippets to use metadata-defined paths.
- Use version-neutral `zarr.Array` and `zarr.Group` annotations and `array.dtype.itemsize`.

## Compatibility

- Remains compatible with the locked Zarr 2.18.7 runtime.
- Continues writing OME-Zarr 0.4 / Zarr v2 stores with numeric paths (`0`, `1`, ...).
- Readers now accept numeric paths as well as valid alternatives such as `s0`.
- Existing callers that explicitly pass `zarr_group="0"` continue to work.

## Testing

- Added focused coverage for numeric and `s0` paths, OME-Zarr 0.4/0.5 metadata layouts, invalid levels, region writes, handler reads, and single-level exports.
- Affected local suites: 296 passed.
- Full local suite: 816 passed and 1 skipped; the sole network-dependent Data Portal test passed when rerun with network access.
- Ruff and `git diff --check` pass for the changed files.

Closes #357
Part of #356
