### PR TITLE
feat: centralize OME-Zarr v2 pyramid writer

### DIFF
--- a/src/copick/ops/add.py
+++ b/src/copick/ops/add.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Optional, Tuple, Union
 import mrcfile
 import numpy as np
 import zarr
-from ome_zarr.writer import write_multiscale
 
 from copick.models import (
     CopickFeatures,
@@ -16,7 +15,7 @@ from copick.models import (
     CopickTomogram,
     CopickVoxelSpacing,
 )
-from copick.util.ome import get_level_path, get_voxel_size_from_zarr, ome_metadata, volume_pyramid
+from copick.util.ome import get_level_path, get_voxel_size_from_zarr, volume_pyramid, write_ome_zarr_3d
 
 
 def add_run(
@@ -191,9 +190,6 @@ def add_tomogram(
     # Optional: create multiscale pyramid
     pyramid = volume_pyramid(volume[voxel_spacing], voxel_spacing, pyramid_levels) if create_pyramid else volume
 
-    # Multiscale metadata
-    ome_meta = ome_metadata(pyramid)
-
     # Attempt to get run and voxel spacing
     runobj = get_or_create_run(root, run, create=create)
     vsobj = get_or_create_voxelspacing(runobj, voxel_spacing, create=create)
@@ -203,16 +199,11 @@ def add_tomogram(
 
     # Get the store
     loc = tomogram.zarr()
-    root_group = zarr.group(loc, overwrite=overwrite)
-
-    # Write the pyramid
-    write_multiscale(
-        list(pyramid.values()),
-        group=root_group,
-        axes=ome_meta["axes"],
-        coordinate_transformations=ome_meta["coordinate_transformations"],
-        storage_options=dict(chunks=chunks, overwrite=overwrite),
-        compute=True,
+    write_ome_zarr_3d(
+        loc,
+        pyramid,
+        chunk_size=chunks,
+        overwrite=overwrite,
         metadata=meta,
     )
 
@@ -371,20 +362,13 @@ def add_features(
     # Create the features
     features = tomogram.new_features(feature_type, exist_ok=exist_ok)
 
-    # Multiscale metadata
-    ome_meta = ome_metadata({voxel_spacing: features_vol})
-
     # Get the store
     loc = features.zarr()
-    root_group = zarr.group(loc, overwrite=overwrite)
-
-    write_multiscale(
-        [features_vol],
-        group=root_group,
-        axes=ome_meta["axes"],
-        coordinate_transformations=ome_meta["coordinate_transformations"],
-        storage_options=dict(chunks=chunks, overwrite=overwrite),
-        compute=True,
+    write_ome_zarr_3d(
+        loc,
+        {voxel_spacing: features_vol},
+        chunk_size=chunks,
+        overwrite=overwrite,
         metadata=meta,
     )
 

--- a/src/copick/util/handlers/volume/zarr.py
+++ b/src/copick/util/handlers/volume/zarr.py
@@ -6,7 +6,7 @@ import numpy as np
 import zarr
 
 from copick.util.handlers import FormatCapabilities
-from copick.util.ome import get_level_path, get_multiscales, get_voxel_size_from_zarr
+from copick.util.ome import get_level_path, get_multiscales, get_voxel_size_from_zarr, write_ome_zarr_3d
 
 
 class ZarrVolumeHandler:
@@ -99,30 +99,7 @@ class ZarrVolumeHandler:
         Returns:
             Path to the written store
         """
-        store = zarr.open(path, mode="w")
-
-        # Create OME-NGFF compliant structure
-        store.create_dataset("0", data=volume, chunks=chunks, dtype=volume.dtype)
-
-        # Add OME-NGFF metadata
-        store.attrs["multiscales"] = [
-            {
-                "version": "0.4",
-                "axes": [
-                    {"name": "z", "type": "space", "unit": "angstrom"},
-                    {"name": "y", "type": "space", "unit": "angstrom"},
-                    {"name": "x", "type": "space", "unit": "angstrom"},
-                ],
-                "datasets": [
-                    {
-                        "path": "0",
-                        "coordinateTransformations": [
-                            {"type": "scale", "scale": [voxel_size, voxel_size, voxel_size]},
-                        ],
-                    },
-                ],
-            },
-        ]
+        write_ome_zarr_3d(path, {voxel_size: volume}, chunk_size=chunks)
         return path
 
 

--- a/src/copick/util/ome.py
+++ b/src/copick/util/ome.py
@@ -1,12 +1,15 @@
-from typing import Any, Dict, List, MutableMapping, Tuple
+from typing import Any, Dict, List, MutableMapping, Tuple, Union
 
 import numpy as np
 import psutil
 import zarr
+from numcodecs import Blosc
 
 from copick.util.log import get_logger
 
 logger = get_logger(__name__)
+
+_DEFAULT_WRITER_METADATA = object()
 
 # Unit conversion factors to Angstrom
 UNITFACTOR = {
@@ -142,32 +145,45 @@ def ome_metadata(pyramid: Dict[float, np.ndarray]) -> Dict[str, Any]:
 
 
 def write_ome_zarr_3d(
-    store: MutableMapping,
+    store: Union[str, MutableMapping],
     pyramid: Dict[float, np.ndarray],
     chunk_size: Tuple[int, ...] = (256, 256, 256),
+    overwrite: bool = True,
+    metadata: Any = _DEFAULT_WRITER_METADATA,
 ) -> None:
-    """Write a 3D pyramid to an OME-Zarr store.
+    """Write a 3D pyramid as OME-Zarr 0.4 / Zarr v2.
 
     Args:
-        store: The store to write to.
+        store: A path string or mutable Zarr store to write to.
         pyramid: The pyramid to write.
         chunk_size: The chunk size to use for the Zarr store. Default is (256, 256, 256).
+        overwrite: Whether to overwrite an existing group and arrays.
+        metadata: Additional OME multiscale metadata. When omitted, preserve the existing empty metadata mapping.
     """
     # This is a super heavy import, so we do it here to avoid loading it before it's needed.
     # Writing is slow anyway.
+    from ome_zarr.format import FormatV04
     from ome_zarr.writer import write_multiscale
 
     ome_meta = ome_metadata(pyramid)
-    root_group = zarr.group(store=store, overwrite=True)
+    root_group = zarr.group(store=store, overwrite=overwrite, zarr_version=2)
+    compressor = Blosc(cname="lz4", clevel=5, shuffle=Blosc.SHUFFLE)
+    writer_metadata = {} if metadata is _DEFAULT_WRITER_METADATA else metadata
 
     write_multiscale(
         list(pyramid.values()),
         group=root_group,
+        fmt=FormatV04(),
         axes=ome_meta["axes"],
         coordinate_transformations=ome_meta["coordinate_transformations"],
-        storage_options=dict(chunks=chunk_size, overwrite=True),
+        storage_options={
+            "chunks": chunk_size,
+            "compressor": compressor,
+            "dimension_separator": "/",
+            "overwrite": overwrite,
+        },
         compute=True,
-        metadata={},
+        metadata=writer_metadata,
     )
 
 

--- a/tests/test_ome_writer.py
+++ b/tests/test_ome_writer.py
@@ -1,0 +1,129 @@
+"""Golden contracts for the centralized OME-Zarr 0.4 / Zarr v2 writer."""
+
+import ast
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import zarr
+from copick.util.handlers.volume.zarr import ZarrVolumeHandler
+from copick.util.ome import write_ome_zarr_3d
+
+
+@pytest.fixture
+def writer_pyramid():
+    return {
+        10.0: np.arange(64, dtype=np.float32).reshape(4, 4, 4),
+        20.0: np.full((2, 2, 2), 7, dtype=np.float32),
+    }
+
+
+@pytest.mark.parametrize("target_kind", ["path", "store"])
+def test_writer_preserves_v2_golden_contract(tmp_path, writer_pyramid, target_kind):
+    path = tmp_path / f"{target_kind}.zarr"
+    target = str(path) if target_kind == "path" else zarr.DirectoryStore(str(path))
+
+    write_ome_zarr_3d(target, writer_pyramid, chunk_size=(2, 2, 2))
+
+    store = zarr.DirectoryStore(str(path))
+    group = zarr.open_group(store, mode="r")
+    assert json.loads(store[".zgroup"])["zarr_format"] == 2
+
+    multiscale = group.attrs["multiscales"][0]
+    assert multiscale == {
+        "version": "0.4",
+        "datasets": [
+            {
+                "path": "0",
+                "coordinateTransformations": [{"scale": [10.0, 10.0, 10.0], "type": "scale"}],
+            },
+            {
+                "path": "1",
+                "coordinateTransformations": [{"scale": [20.0, 20.0, 20.0], "type": "scale"}],
+            },
+        ],
+        "name": "/",
+        "metadata": {},
+        "axes": [
+            {"name": "z", "type": "space", "unit": "angstrom"},
+            {"name": "y", "type": "space", "unit": "angstrom"},
+            {"name": "x", "type": "space", "unit": "angstrom"},
+        ],
+    }
+
+    assert [multiscale_dataset["path"] for multiscale_dataset in multiscale["datasets"]] == ["0", "1"]
+    for level, expected in enumerate(writer_pyramid.values()):
+        array = group[str(level)]
+        assert array.chunks == (2, 2, 2)
+        assert array.compressor.get_config() == {
+            "id": "blosc",
+            "cname": "lz4",
+            "clevel": 5,
+            "shuffle": 1,
+            "blocksize": 0,
+        }
+        assert json.loads(store[f"{level}/.zarray"])["dimension_separator"] == "/"
+        np.testing.assert_array_equal(array[:], expected)
+
+    assert "0/0/0/0" in store
+    assert "0/0.0.0" not in store
+    assert hashlib.sha256(store["0/0/0/0"]).hexdigest() == (
+        "c7a26c789036035c6e7ab41ca5f84ead654aca7654df2321229d3b9a688e8a16"
+    )
+
+
+@pytest.mark.parametrize("metadata", [None, {"source": "golden-test"}])
+def test_writer_preserves_explicit_metadata_value(tmp_path, writer_pyramid, metadata):
+    path = str(tmp_path / "metadata.zarr")
+    write_ome_zarr_3d(path, writer_pyramid, metadata=metadata)
+
+    group = zarr.open_group(path, mode="r")
+    assert group.attrs["multiscales"][0]["metadata"] == metadata
+
+
+def test_writer_preserves_default_chunk_shape(tmp_path, writer_pyramid):
+    path = str(tmp_path / "default-chunks.zarr")
+
+    write_ome_zarr_3d(path, writer_pyramid)
+
+    group = zarr.open_group(path, mode="r")
+    assert group["0"].chunks == (256, 256, 256)
+    assert group["1"].chunks == (256, 256, 256)
+
+
+def test_zarr_handler_uses_canonical_writer_contract(tmp_path, writer_pyramid):
+    path = str(tmp_path / "handler.zarr")
+    volume = writer_pyramid[10.0]
+
+    ZarrVolumeHandler().write(path, volume, 10.0, chunks=(2, 2, 2))
+
+    store = zarr.DirectoryStore(path)
+    group = zarr.open_group(store, mode="r")
+    assert group.attrs["multiscales"][0]["version"] == "0.4"
+    assert group.attrs["multiscales"][0]["datasets"][0]["path"] == "0"
+    assert "0/0/0/0" in store
+    np.testing.assert_array_equal(group["0"][:], volume)
+
+
+def test_shared_helper_is_the_only_write_multiscale_callsite():
+    source_root = Path(__file__).parents[1] / "src" / "copick"
+    callsites = []
+    imports = []
+
+    for source_path in source_root.rglob("*.py"):
+        tree = ast.parse(source_path.read_text())
+        relative_path = source_path.relative_to(source_root)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "write_multiscale":
+                callsites.append(relative_path)
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.module == "ome_zarr.writer"
+                and any(alias.name == "write_multiscale" for alias in node.names)
+            ):
+                imports.append(relative_path)
+
+    assert callsites == [Path("util/ome.py")]
+    assert imports == [Path("util/ome.py")]

--- a/tests/test_ome_writer.py
+++ b/tests/test_ome_writer.py
@@ -113,7 +113,7 @@ def test_shared_helper_is_the_only_write_multiscale_callsite():
     imports = []
 
     for source_path in source_root.rglob("*.py"):
-        tree = ast.parse(source_path.read_text())
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
         relative_path = source_path.relative_to(source_root)
         for node in ast.walk(tree):
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "write_multiscale":


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is stacked on #397. Merge #397 first, then retarget this PR to `v2.0`.

## Summary

- Make `write_ome_zarr_3d` the single implementation for writing 3D OME-Zarr pyramids.
- Route `add_tomogram`, `add_features`, and `ZarrVolumeHandler.write` through the shared writer.
- Accept both path strings and mutable Zarr stores while preserving overwrite and metadata behavior.
- Pin output to OME-Zarr 0.4 / Zarr v2 using `FormatV04()` and `zarr_version=2`.
- Preserve numeric dataset paths (`0`, `1`, ...), configured chunk shapes, explicit Blosc-LZ4 compression, and `/` chunk separators.

## Compatibility

- Remains compatible with the locked Zarr 2.18.7 runtime and uses no Zarr v3-only APIs.
- Newly written stores remain OME-Zarr 0.4 / Zarr v2 with canonical numeric dataset paths (`0`, `1`, ...); `s0`/`s1` are accepted reader inputs, not writer defaults.
- Existing writer entry points retain their current default chunking and decoded array values.
- The P0 dependency range intentionally remains `ome-zarr>=0.10.2`: the simultaneous `zarr<3` constraint prevents `ome-zarr>=0.14` from resolving, and the unlocked constraints select the numeric-writing 0.11 series. P2A will add the planned explicit `ome-zarr<0.14` cap while running on Zarr 3; P2B will replace this writer implementation.

## Testing

- Added golden-contract coverage for paths, store objects, OME metadata, numeric levels, chunk shapes, codec configuration, slash-separated chunk keys, decoded values, and raw chunk payloads.
- Focused OME/writer/add suite: 219 passed with SSH variants excluded.
- Docker-backed SSH coverage for the changed tomogram and feature writer paths: 4 passed; 2 additional SSH smoke cases passed.
- Full final-stack suite: 2,629 passed and 4 skipped; four initial SSH fixture connections hit container startup before sshd was ready, and all four passed on immediate rerun.
- Black and Ruff pre-commit hooks pass.

Closes #358
Part of #356
