### PR TITLE
fix: separate Zarr location and materialization contracts

### DIFF
--- a/src/copick/impl/cryoet_data_portal.py
+++ b/src/copick/impl/cryoet_data_portal.py
@@ -38,6 +38,7 @@ from copick.models import (
     PickableObject,
 )
 from copick.util.log import get_logger
+from copick.util.ome import zarr_root_exists
 
 # Don't import Geometry at runtime to keep CLI snappy
 if TYPE_CHECKING:
@@ -1316,8 +1317,8 @@ class CopickObjectCDP(CopickObjectOverlay):
         if not self.is_particle:
             return None
 
-        # Return none if there is no density map
-        if not self.fs.exists(self.path):
+        # Read-only objects have no destination when their map is absent.
+        if self.read_only and not self.has_density_map():
             return None
 
         if self.read_only:
@@ -1335,6 +1336,10 @@ class CopickObjectCDP(CopickObjectOverlay):
             dimension_separator="/",
             create=create,
         )
+
+    def has_density_map(self) -> bool:
+        """Return whether this object's overlay path contains Zarr root metadata."""
+        return self.is_particle and zarr_root_exists(self.fs, self.path)
 
     def _delete_data(self) -> None:
         if self.fs.exists(self.path):

--- a/src/copick/impl/filesystem.py
+++ b/src/copick/impl/filesystem.py
@@ -29,6 +29,7 @@ from copick.models import (
     PickableObject,
 )
 from copick.util.log import get_logger
+from copick.util.ome import zarr_root_exists
 
 # Don't import Geometry at runtime to keep CLI snappy
 if TYPE_CHECKING:
@@ -869,6 +870,8 @@ class CopickObjectFSSpec(CopickObjectOverlay):
             return None
 
         if self.read_only:
+            if not self.has_density_map():
+                return None
             # For read-only access, use static filesystem and path
             fs = self.fs_static
             path = self.static_path
@@ -889,6 +892,15 @@ class CopickObjectFSSpec(CopickObjectOverlay):
             dimension_separator="/",
             create=create,
         )
+
+    def has_density_map(self) -> bool:
+        """Return whether the selected object source contains Zarr root metadata."""
+        if not self.is_particle:
+            return False
+
+        fs = self.fs_static if self.read_only else self.fs_overlay
+        path = self.static_path if self.read_only else self.overlay_path
+        return zarr_root_exists(fs, path)
 
 
 class CopickRootFSSpec(CopickRoot):
@@ -1030,8 +1042,8 @@ class CopickRootFSSpec(CopickRoot):
             else:
                 # If object exists in static but not overlay, it's read-only
                 # If object exists in overlay (regardless of static), it's writable
-                static_exists = self.fs_static.exists(static_path)
-                overlay_exists = self.fs_overlay.exists(overlay_path)
+                static_exists = zarr_root_exists(self.fs_static, static_path)
+                overlay_exists = zarr_root_exists(self.fs_overlay, overlay_path)
                 read_only = static_exists and not overlay_exists
 
             obj = clz(self, obj_meta, read_only=read_only)

--- a/src/copick/impl/mlcroissant.py
+++ b/src/copick/impl/mlcroissant.py
@@ -66,6 +66,7 @@ from copick.models import (
     PickableObject,
 )
 from copick.util.log import get_logger
+from copick.util.ome import zarr_root_exists
 
 if TYPE_CHECKING:
     from trimesh.parent import Geometry
@@ -2104,7 +2105,7 @@ class CopickObjectMLC(CopickObjectOverlay):
             return None
         if self.read_only:
             sp = self.static_path
-            if sp is None:
+            if sp is None or not self.has_density_map():
                 return None
             fs = self.fs_static
             return zarr.storage.FSStore(
@@ -2126,10 +2127,25 @@ class CopickObjectMLC(CopickObjectOverlay):
             dimension_separator="/",
             create=create,
         )
-        if create and self.root.mode == "A":
+        return store
+
+    def has_density_map(self) -> bool:
+        """Return whether the selected object source contains Zarr root metadata."""
+        if not self.is_particle:
+            return False
+
+        if self.read_only:
+            path = self.static_path
+            fs = self.fs_static
+            return path is not None and fs is not None and zarr_root_exists(fs, path)
+
+        return zarr_root_exists(self.fs_overlay, self.overlay_path)
+
+    def _on_density_map_written(self) -> None:
+        """Register a Mode-A density map only after its write succeeds."""
+        if self.root.mode == "A" and self._find_row() is None and self.has_density_map():
             rel = f"Objects/{self.name}.zarr"
             self._index.add_row("copick/objects", {"name": self.name, "url": rel})
-        return store
 
     def _delete_data(self) -> None:
         fs = self.fs_overlay
@@ -2297,8 +2313,11 @@ class CopickRootMLC(CopickRoot):
                 read_only = False
             else:
                 # Mode B: object is read-only if present in static only.
-                overlay_exists = self.fs_overlay.exists(f"{self.overlay_base_url}/Objects/{obj_meta.name}.zarr")
-                read_only = obj_meta.name in static_names and not overlay_exists
+                overlay_path = f"{self.overlay_base_url}/Objects/{obj_meta.name}.zarr"
+                overlay_exists = zarr_root_exists(self.fs_overlay, overlay_path)
+                static_obj = clz(self, obj_meta, read_only=True)
+                static_exists = obj_meta.name in static_names and static_obj.has_density_map()
+                read_only = static_exists and not overlay_exists
             objects.append(clz(self, obj_meta, read_only=read_only))
         self._objects = objects
 

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -6,7 +6,14 @@ import zarr
 from pydantic import AliasChoices, BaseModel, Field, field_validator
 
 from copick.util.escape import sanitize_name
-from copick.util.ome import fits_in_memory, get_level_path, segmentation_pyramid, volume_pyramid, write_ome_zarr_3d
+from copick.util.ome import (
+    fits_in_memory,
+    get_level_path,
+    initialize_zarr_v2,
+    segmentation_pyramid,
+    volume_pyramid,
+    write_ome_zarr_3d,
+)
 from copick.util.relion import picks_to_df_relion, relion_df_to_picks
 
 # Don't import Geometry at runtime to keep CLI snappy
@@ -306,6 +313,13 @@ class CopickObject:
 
         raise NotImplementedError("zarr method must be implemented for particle objects.")
 
+    def has_density_map(self) -> bool:
+        """Return whether this object has valid Zarr root metadata."""
+        if not self.is_particle:
+            return False
+
+        raise NotImplementedError("has_density_map must be implemented for particle objects.")
+
     def numpy(
         self,
         zarr_group: Optional[str] = None,
@@ -352,9 +366,17 @@ class CopickObject:
             dtype: Data type of the segmentation. Default is `np.float32`.
         """
         loc = self.zarr()
+        if loc is None:
+            raise ValueError(
+                f"Cannot write a density map for object {self.name!r}: no writable Zarr store is available.",
+            )
 
         pyramid = volume_pyramid(data, voxel_size, 1, dtype=dtype)
         write_ome_zarr_3d(loc, pyramid)
+        self._on_density_map_written()
+
+    def _on_density_map_written(self) -> None:
+        """Hook invoked after a density-map pyramid is written successfully."""
 
     def set_region(
         self,
@@ -374,6 +396,10 @@ class CopickObject:
             z: Slice for the z-axis.
         """
         loc = self.zarr()
+        if loc is None:
+            raise ValueError(
+                f"Cannot write a density map for object {self.name!r}: no writable Zarr store is available.",
+            )
         _open_zarr_array(loc, zarr_group, mode="r+")[z, y, x] = data
 
     def delete(self) -> None:
@@ -1332,8 +1358,8 @@ class CopickRun:
 
             self._segmentations.append(seg)
 
-            # Create the zarr store for this segmentation
-            _ = seg.zarr()
+            # Materialize the new entity as an explicit Zarr v2 group.
+            initialize_zarr_v2(seg.zarr())
 
         return seg
 
@@ -1608,8 +1634,8 @@ class CopickVoxelSpacing:
                 self._tomograms = []
             self._tomograms.append(tomo)
 
-            # Create the zarr store for this tomogram
-            _ = tomo.zarr()
+            # Materialize the new entity as an explicit Zarr v2 group.
+            initialize_zarr_v2(tomo.zarr())
 
         return tomo
 
@@ -1764,8 +1790,8 @@ class CopickTomogram:
 
             self._features.append(feat)
 
-            # Create the zarr store for this feature set
-            _ = feat.zarr()
+            # Materialize the new entity as an explicit Zarr v2 group.
+            initialize_zarr_v2(feat.zarr())
 
         return feat
 

--- a/src/copick/ops/croissant.py
+++ b/src/copick/ops/croissant.py
@@ -822,11 +822,7 @@ def _walk_project(
             continue
         if allowed_objects is not None and obj.name not in allowed_objects:
             continue
-        try:
-            z = obj.zarr()
-        except Exception:
-            z = None
-        if z is None:
+        if not obj.has_density_map():
             continue
         obj_url = _object_url(obj, copick_base_url, is_cdp)
         remapped_obj_name = _remap(obj.name, filters.object_name_map) or obj.name

--- a/src/copick/util/ome.py
+++ b/src/copick/util/ome.py
@@ -42,6 +42,29 @@ UNITFACTOR = {
 }
 
 
+def zarr_root_exists(fs: Any, path: str) -> bool:
+    """Return whether a path contains Zarr v2 or v3 root metadata.
+
+    A store's directory or prefix may exist before it contains a valid Zarr
+    hierarchy, so its presence alone is not sufficient to establish that a
+    density map exists.
+
+    Args:
+        fs: Filesystem containing the store.
+        path: Path to the root of the store.
+
+    Returns:
+        Whether the store contains a v2 ``.zgroup`` or v3 ``zarr.json`` root.
+    """
+    root = path.rstrip("/")
+    return fs.exists(f"{root}/.zgroup") or fs.exists(f"{root}/zarr.json")
+
+
+def initialize_zarr_v2(store: Union[str, MutableMapping]) -> None:
+    """Materialize an empty Zarr v2 group in a new entity store."""
+    zarr.group(store=store, overwrite=False, zarr_version=2)
+
+
 def _ome_zarr_axes() -> List[Dict[str, str]]:
     return [
         {

--- a/tests/test_delete_overwrite.py
+++ b/tests/test_delete_overwrite.py
@@ -2,7 +2,6 @@ from typing import Any, Dict
 
 import copick
 import pytest
-import zarr
 
 
 @pytest.fixture(params=pytest.common_cases)
@@ -83,7 +82,7 @@ def test_delete_tomogram(test_payload: Dict[str, Any]):
     # Create a new tomogram to delete
     tomo_type = "delete-test"
     tomogram = vs.new_tomogram(tomo_type=tomo_type)
-    zarr.create((5, 5, 5), store=tomogram.zarr())
+    assert ".zgroup" in tomogram.zarr()
     assert tomogram in vs.tomograms, "Tomogram not added to tomograms"
 
     # Check that tomogram exists in filesystem
@@ -119,7 +118,7 @@ def test_delete_features(test_payload: Dict[str, Any]):
     # Create a new feature to delete
     feature_type = "delete-test"
     feature = tomogram.new_features(feature_type=feature_type)
-    zarr.create((5, 5, 5), store=feature.zarr())
+    assert ".zgroup" in feature.zarr()
     assert feature in tomogram.features, "Feature not added to features"
 
     # Check that feature exists in filesystem
@@ -234,7 +233,7 @@ def test_delete_segmentation(test_payload: Dict[str, Any]):
         name=name,
         is_multilabel=is_multilabel,
     )
-    zarr.create((5, 5, 5), store=segmentation.zarr())
+    assert ".zgroup" in segmentation.zarr()
     assert segmentation in copick_run.segmentations, "Segmentation not added to segmentations"
 
     # Check that segmentation exists in filesystem
@@ -305,7 +304,7 @@ def test_exist_ok_tomogram(test_payload: Dict[str, Any]):
     # Create a new tomogram
     tomo_type = "exist-ok-test"
     tomo1 = vs.new_tomogram(tomo_type=tomo_type)
-    zarr.create((5, 5, 5), store=tomo1.zarr())
+    assert ".zgroup" in tomo1.zarr()
 
     # Attempt to create the same tomogram without exist_ok
     with pytest.raises(ValueError):
@@ -328,7 +327,7 @@ def test_exist_ok_features(test_payload: Dict[str, Any]):
     # Create a new feature
     feature_type = "exist-ok-test"
     feature1 = tomogram.new_features(feature_type=feature_type)
-    zarr.create((5, 5, 5), store=feature1.zarr())
+    assert ".zgroup" in feature1.zarr()
 
     # Attempt to create the same feature without exist_ok
     with pytest.raises(ValueError):
@@ -404,7 +403,7 @@ def test_exist_ok_segmentation(test_payload: Dict[str, Any]):
         name=name,
         is_multilabel=is_multilabel,
     )
-    zarr.create((5, 5, 5), store=seg1.zarr())
+    assert ".zgroup" in seg1.zarr()
 
     # Attempt to create the same segmentation without exist_ok
     with pytest.raises(ValueError):
@@ -460,7 +459,7 @@ def test_delete_collections(test_payload: Dict[str, Any]):
         name="ribosome",
         is_multilabel=False,
     )
-    zarr.create((5, 5, 5), store=seg1.zarr())
+    assert ".zgroup" in seg1.zarr()
 
     seg2 = copick_run.new_segmentation(
         voxel_size=10.000,
@@ -469,7 +468,7 @@ def test_delete_collections(test_payload: Dict[str, Any]):
         name="segment2",
         is_multilabel=True,
     )
-    zarr.create((5, 5, 5), store=seg2.zarr())
+    assert ".zgroup" in seg2.zarr()
 
     # Refresh to ensure all entities are tracked
     copick_run.refresh()

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1059,8 +1059,7 @@ def test_run_new_segmentations(test_payload: Dict[str, Any]):
             is_multilabel=False,
         )
 
-    # Adding the first segmentation inits the _segmentations attribute as list of segmentations
-    # For object stores we actually need to write to the zarr to create the "directory"
+    # Adding the first segmentation initializes and materializes its Zarr v2 group.
     seg4 = copick_run.new_segmentation(
         voxel_size=10.000,
         user_id="test.user",
@@ -1068,12 +1067,11 @@ def test_run_new_segmentations(test_payload: Dict[str, Any]):
         name="ribosome",
         is_multilabel=False,
     )
-    zarr.create((5, 5, 5), store=seg4.zarr())
+    assert ".zgroup" in seg4.zarr()
     assert copick_run._segmentations is not None, "Segmentations should be populated"
     assert seg4 in copick_run.segmentations, "Segmentation not added to segmentations"
 
-    # Adding another segmentation appends to the list after setting user id
-    # For object stores we actually need to write to the zarr to create the "directory"
+    # Adding another segmentation appends to the list after setting user id.
     copick_root.config.user_id = "user.test"
     seg5 = copick_run.new_segmentation(
         voxel_size=10.000,
@@ -1081,7 +1079,7 @@ def test_run_new_segmentations(test_payload: Dict[str, Any]):
         name="location",
         is_multilabel=True,
     )
-    zarr.create((5, 5, 5), store=seg5.zarr())
+    assert ".zgroup" in seg5.zarr()
     assert seg5 in copick_run.segmentations, "Segmentation not added to segmentations"
     assert (
         seg5
@@ -1123,6 +1121,51 @@ def test_run_new_segmentations(test_payload: Dict[str, Any]):
 
         for seg in ov:
             assert overlay_fs.exists(seg_path_overlay + seg), f"{seg} not found in overlay"
+
+
+def test_new_zarr_entities_reopen_and_delete_without_array_write(test_payload: Dict[str, Any]):
+    root = test_payload["root"]
+    run = root.get_run("TS_001")
+    voxel_spacing = run.get_voxel_spacing(10.0)
+
+    segmentation = run.new_segmentation(
+        voxel_size=10.0,
+        user_id="materialization-test",
+        session_id="0",
+        name="materialization-test",
+        is_multilabel=True,
+    )
+    tomogram = voxel_spacing.new_tomogram("materialization-test")
+    features = tomogram.new_features("materialization-test")
+
+    for entity in (segmentation, tomogram, features):
+        assert ".zgroup" in entity.zarr()
+
+    reopened = copick.from_file(test_payload["cfg_file"])
+    reopened_run = reopened.get_run("TS_001")
+    reopened_segmentation = reopened_run.get_segmentations(
+        voxel_size=10.0,
+        user_id="materialization-test",
+        session_id="0",
+        name="materialization-test",
+        is_multilabel=True,
+    )[0]
+    reopened_tomogram = reopened_run.get_voxel_spacing(10.0).get_tomograms("materialization-test")[0]
+    assert reopened_tomogram.get_features("materialization-test") is not None
+
+    reopened_segmentation.delete()
+    reopened_tomogram.delete()
+
+    reopened = copick.from_file(test_payload["cfg_file"])
+    reopened_run = reopened.get_run("TS_001")
+    assert not reopened_run.get_segmentations(
+        voxel_size=10.0,
+        user_id="materialization-test",
+        session_id="0",
+        name="materialization-test",
+        is_multilabel=True,
+    )
+    assert not reopened_run.get_voxel_spacing(10.0).get_tomograms("materialization-test")
 
 
 def test_run_refresh(test_payload: Dict[str, Any]):
@@ -1217,18 +1260,16 @@ def test_vs_new_tomogram(test_payload: Dict[str, Any]):
     with pytest.raises(ValueError):
         vs.new_tomogram(tomo_type="denoised")
 
-    # Adding the first tomogram inits the _tomograms attribute as list of tomograms
-    # For object stores we actually need to write to the zarr to create the "directory"
+    # Adding the first tomogram initializes and materializes its Zarr v2 group.
     tomogram = vs.new_tomogram(tomo_type="isonet")
-    zarr.create((5, 5, 5), store=tomogram.zarr())
+    assert ".zgroup" in tomogram.zarr()
 
     assert vs._tomograms is not None, "Tomograms should be populated"
     assert tomogram in vs.tomograms, "Tomogram not added to tomograms"
 
-    # Adding another tomogram appends to the list
-    # For object stores we actually need to write to the zarr to create the "directory"
+    # Adding another tomogram appends to the list.
     tomogram = vs.new_tomogram(tomo_type="SIRT")
-    zarr.create((5, 5, 5), store=tomogram.zarr())
+    assert ".zgroup" in tomogram.zarr()
 
     assert tomogram in vs.tomograms, "Tomogram not added to tomograms"
     assert tomogram == vs.get_tomogram(tomo_type="SIRT"), "Tomogram not found"
@@ -1349,18 +1390,16 @@ def test_tomogram_new_features(test_payload: Dict[str, Any]):
     with pytest.raises(ValueError):
         tomogram.new_features(feature_type="sobel")
 
-    # Adding the first feature inits the _features attribute as list of features
-    # For object stores we actually need to write to the zarr to create the "directory"
+    # Adding the first feature initializes and materializes its Zarr v2 group.
     feature = tomogram.new_features(feature_type="sift")
-    zarr.create((5, 5, 5), store=feature.zarr())
+    assert ".zgroup" in feature.zarr()
 
     assert tomogram._features is not None, "Features should be populated"
     assert feature in tomogram.features, "Feature not added to features"
 
-    # Adding another feature appends to the list
-    # For object stores we actually need to write to the zarr to create the "directory"
+    # Adding another feature appends to the list.
     feature = tomogram.new_features(feature_type="tomotwin")
-    zarr.create((5, 5, 5), store=feature.zarr())
+    assert ".zgroup" in feature.zarr()
 
     assert feature in tomogram.features, "Feature not added to features"
     assert feature == tomogram.get_features(feature_type="tomotwin"), "Feature not found"
@@ -1429,7 +1468,11 @@ def test_tomogram_zarr(test_payload: Dict[str, Any]):
 
     # Check zarr is writable
     tomo = vs.new_tomogram(tomo_type="test")
-    zarr.array(np.random.rand(64, 64, 64), store=tomo.zarr(), chunks=(32, 32, 32))
+    zarr.open_group(tomo.zarr(), mode="r+").create_dataset(
+        "0",
+        data=np.random.rand(64, 64, 64),
+        chunks=(32, 32, 32),
+    )
 
 
 def test_tomogram_read_numpy(test_payload: Dict[str, Any]):
@@ -1516,7 +1559,11 @@ def test_feature_zarr(test_payload: Dict[str, Any]):
 
     # Check zarr is writable
     feat = tomogram.new_features(feature_type="test")
-    zarr.array(np.random.rand(64, 64, 64), store=feat.zarr(), chunks=(32, 32, 32))
+    zarr.open_group(feat.zarr(), mode="r+").create_dataset(
+        "0",
+        data=np.random.rand(64, 64, 64),
+        chunks=(32, 32, 32),
+    )
 
 
 def test_feature_read_numpy(test_payload: Dict[str, Any]):

--- a/tests/test_mlcroissant.py
+++ b/tests/test_mlcroissant.py
@@ -390,17 +390,15 @@ def test_export_filter_nonexistent_run(multi_run_filesystem_project):
 
 
 def test_export_filter_objects(multi_run_filesystem_project):
-    """objects filter restricts only the objects CSV; config pickable_objects stays complete."""
+    """Missing density maps are neither exported nor materialized by an export probe."""
     import copick
     from copick.ops.croissant import export_croissant
 
     proj = multi_run_filesystem_project
     root = copick.from_file(str(proj / "filesystem.json"))
-    # The sample has no actual density-map zarrs under Objects/, so the
-    # objects CSV is expected to be empty whether or not filter is given.
-    # Here we verify the flag plumbing reaches the export and the overall
-    # manifest stays valid — picks for proteasome remain emitted even when
-    # objects=["ribosome"] is passed (filter applies to density maps only).
+    density_map_path = proj / "Objects" / "ribosome.zarr"
+    assert not density_map_path.exists()
+
     metadata_path = export_croissant(
         root,
         project_root=str(proj),
@@ -411,6 +409,9 @@ def test_export_filter_objects(multi_run_filesystem_project):
 
     ds = mlc.Dataset(jsonld=metadata_path)
     assert list(ds.metadata.ctx.issues.errors) == []
+
+    assert _read_csv(proj / "Croissant" / "objects.csv") == []
+    assert not density_map_path.exists()
 
     # Proteasome picks should still appear — --objects doesn't filter picks.
     picks_rows = _read_csv(proj / "Croissant" / "picks.csv")

--- a/tests/test_object_store_contracts.py
+++ b/tests/test_object_store_contracts.py
@@ -1,0 +1,187 @@
+"""Contract tests for object density-map stores and registration."""
+
+import json
+from types import SimpleNamespace
+
+import fsspec
+import numpy as np
+import pytest
+from copick.impl.cryoet_data_portal import CopickObjectCDP
+from copick.impl.filesystem import CopickConfigFSSpec, CopickObjectFSSpec, CopickRootFSSpec
+from copick.impl.mlcroissant import CopickObjectMLC
+from copick.models import CopickObject, PickableObject
+from copick.util.ome import zarr_root_exists
+
+
+def _metadata(path, name=".zgroup"):
+    path.mkdir(parents=True, exist_ok=True)
+    payload = {"zarr_format": 2} if name == ".zgroup" else {"zarr_format": 3, "node_type": "group"}
+    (path / name).write_text(json.dumps(payload))
+
+
+def _filesystem_root(tmp_path):
+    static = tmp_path / "static"
+    overlay = tmp_path / "overlay"
+    static.mkdir()
+    overlay.mkdir()
+    config = CopickConfigFSSpec(
+        pickable_objects=[
+            PickableObject(name="particle", is_particle=True),
+            PickableObject(name="surface", is_particle=False),
+        ],
+        static_root=f"local://{static}",
+        static_fs_args={"auto_mkdir": False},
+        overlay_root=f"local://{overlay}",
+        overlay_fs_args={"auto_mkdir": True},
+    )
+    return CopickRootFSSpec(config), static, overlay
+
+
+def test_empty_store_directory_is_not_a_density_map(tmp_path):
+    root, static, overlay = _filesystem_root(tmp_path)
+    (static / "Objects" / "particle.zarr").mkdir(parents=True)
+
+    particle = root.get_object("particle")
+    assert particle.read_only is False
+    assert particle.has_density_map() is False
+    assert particle.zarr() is not None
+    assert particle.has_density_map() is False
+    assert (overlay / "Objects" / "particle.zarr").is_dir()
+
+    surface = root.get_object("surface")
+    assert surface.has_density_map() is False
+    assert surface.zarr() is None
+
+
+@pytest.mark.parametrize("root_metadata", [".zgroup", "zarr.json"])
+def test_static_root_metadata_selects_read_only_store(tmp_path, root_metadata):
+    root, static, overlay = _filesystem_root(tmp_path)
+    _metadata(static / "Objects" / "particle.zarr", root_metadata)
+    (overlay / "Objects" / "particle.zarr").mkdir(parents=True)
+
+    particle = root.get_object("particle")
+    assert particle.read_only is True
+    assert particle.has_density_map() is True
+    assert particle.zarr() is not None
+
+
+def test_overlay_root_metadata_selects_writable_store(tmp_path):
+    root, static, overlay = _filesystem_root(tmp_path)
+    _metadata(static / "Objects" / "particle.zarr")
+    _metadata(overlay / "Objects" / "particle.zarr")
+
+    particle = root.get_object("particle")
+    assert particle.read_only is False
+    assert particle.has_density_map() is True
+    assert particle.zarr() is not None
+
+
+def test_absent_read_only_density_map_returns_none(tmp_path):
+    root, static, _ = _filesystem_root(tmp_path)
+    (static / "Objects" / "particle.zarr").mkdir(parents=True)
+    particle = CopickObjectFSSpec(root, root.config.pickable_objects[0], read_only=True)
+
+    assert particle.has_density_map() is False
+    assert particle.zarr() is None
+
+
+def test_http_zarr_root_metadata_is_detected(monkeypatch):
+    fs = fsspec.filesystem("http")
+    path = "https://data.example.org/particle.zarr"
+    requested = []
+
+    def exists(candidate):
+        requested.append(candidate)
+        return candidate == f"{path}/.zgroup"
+
+    monkeypatch.setattr(fs, "exists", exists)
+
+    assert zarr_root_exists(fs, path) is True
+    assert requested == [f"{path}/.zgroup"]
+
+
+class _ObjectWithoutStore(CopickObject):
+    def zarr(self):
+        return None
+
+    def has_density_map(self):
+        return False
+
+
+def test_object_writes_reject_missing_destination():
+    obj = _ObjectWithoutStore(SimpleNamespace(), PickableObject(name="particle", is_particle=True))
+    data = np.ones((2, 2, 2), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="no writable Zarr store"):
+        obj.from_numpy(data, voxel_size=10.0)
+    with pytest.raises(ValueError, match="no writable Zarr store"):
+        obj.set_region(data)
+
+
+def test_cdp_object_write_uses_absent_overlay_as_destination(tmp_path):
+    fs = fsspec.filesystem("file", auto_mkdir=True)
+    root = SimpleNamespace(root_overlay=str(tmp_path), fs_overlay=fs)
+    obj = CopickObjectCDP(root, PickableObject(name="particle", is_particle=True), read_only=False)
+    data = np.arange(27, dtype=np.float32).reshape(3, 3, 3)
+
+    assert obj.has_density_map() is False
+    assert obj.zarr() is not None
+    obj.from_numpy(data, voxel_size=10.0)
+
+    assert obj.has_density_map() is True
+    np.testing.assert_array_equal(obj.numpy(), data)
+
+
+class _CroissantIndex:
+    def __init__(self, base_url):
+        self.base_url = base_url
+        self.static_fs_args = {}
+        self.objects = []
+        self.added_rows = []
+
+    def add_row(self, record_set, row):
+        assert record_set == "copick/objects"
+        self.added_rows.append(row)
+        self.objects.append(row)
+
+    def remove_row(self, record_set, row):
+        self.objects.remove(row)
+
+
+def _mlc_object(tmp_path):
+    index = _CroissantIndex(str(tmp_path))
+    root = SimpleNamespace(
+        index=index,
+        mode="A",
+        overlay_base_url=None,
+        fs_overlay=fsspec.filesystem("file", auto_mkdir=True),
+    )
+    obj = CopickObjectMLC(root, PickableObject(name="particle", is_particle=True), read_only=False)
+    return obj, index
+
+
+def test_mode_a_object_registration_follows_first_successful_write(tmp_path):
+    obj, index = _mlc_object(tmp_path)
+    data = np.ones((3, 3, 3), dtype=np.float32)
+
+    assert obj.zarr() is not None
+    assert index.added_rows == []
+
+    obj.from_numpy(data, voxel_size=10.0)
+    obj.from_numpy(data * 2, voxel_size=10.0)
+
+    assert index.added_rows == [{"name": "particle", "url": "Objects/particle.zarr"}]
+
+
+def test_mode_a_object_registration_is_skipped_after_failed_write(tmp_path, monkeypatch):
+    obj, index = _mlc_object(tmp_path)
+
+    def fail_write(*args, **kwargs):
+        raise RuntimeError("write failed")
+
+    monkeypatch.setattr("copick.models.write_ome_zarr_3d", fail_write)
+    with pytest.raises(RuntimeError, match="write failed"):
+        obj.from_numpy(np.ones((2, 2, 2), dtype=np.float32), voxel_size=10.0)
+
+    assert index.added_rows == []
+    assert obj.has_density_map() is False

--- a/tests/test_object_store_contracts.py
+++ b/tests/test_object_store_contracts.py
@@ -1,6 +1,9 @@
 """Contract tests for object density-map stores and registration."""
 
 import json
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
 from types import SimpleNamespace
 
 import fsspec
@@ -85,19 +88,33 @@ def test_absent_read_only_density_map_returns_none(tmp_path):
     assert particle.zarr() is None
 
 
-def test_http_zarr_root_metadata_is_detected(monkeypatch):
-    fs = fsspec.filesystem("http")
-    path = "https://data.example.org/particle.zarr"
-    requested = []
+class _QuietHTTPHandler(SimpleHTTPRequestHandler):
+    def log_message(self, format, *args):
+        pass
 
-    def exists(candidate):
-        requested.append(candidate)
-        return candidate == f"{path}/.zgroup"
 
-    monkeypatch.setattr(fs, "exists", exists)
+def test_http_zarr_root_metadata_is_detected(tmp_path):
+    _metadata(tmp_path / "v2.zarr", ".zgroup")
+    _metadata(tmp_path / "v3.zarr", "zarr.json")
+    (tmp_path / "empty.zarr").mkdir()
 
-    assert zarr_root_exists(fs, path) is True
-    assert requested == [f"{path}/.zgroup"]
+    handler = partial(_QuietHTTPHandler, directory=str(tmp_path))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        fs = fsspec.filesystem("http")
+        base_url = f"http://127.0.0.1:{server.server_port}"
+
+        assert fs.exists(f"{base_url}/empty.zarr") is True
+        assert zarr_root_exists(fs, f"{base_url}/empty.zarr") is False
+        assert zarr_root_exists(fs, f"{base_url}/v2.zarr") is True
+        assert zarr_root_exists(fs, f"{base_url}/v3.zarr") is True
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
 
 
 class _ObjectWithoutStore(CopickObject):


### PR DESCRIPTION
> [!NOTE]
> This PR is the next layer in the native GitHub stack after #399.

## Summary

- Define density-map existence by Zarr root metadata (`.zgroup` or `zarr.json`) instead of directory/prefix existence.
- Preserve particle/non-particle and read-only/writable object-store contracts across filesystem, CryoET Data Portal, and ML Croissant backends.
- Add `has_density_map()` and use it for Croissant export without materializing a store as an existence probe.
- Reject object writes when no writable destination exists and defer Mode-A ML Croissant registration until a density-map write succeeds.
- Explicitly materialize new segmentations, tomograms, and features as empty Zarr v2 groups so they can be reopened and deleted before any array write.

## Breaking change for 2.0

New Copick volume entities already contain a root Zarr group when returned. Code which previously initialized the entire store with `zarr.create(store=entity.zarr())` will now receive `ContainsGroupError`; create arrays inside the existing group or use the Copick write APIs instead.

## Validation

- `pre-commit run --show-diff-on-failure --color=always --all-files`
- Focused object-store and Croissant suite: 65 passed.
- A real loopback HTTP server verifies that metadata-bearing v2/v3 stores are detected while a remotely visible empty `.zarr` directory is rejected.
- Croissant export now has a regression proving that a missing density map creates neither an `objects.csv` row nor an empty store directory.
- Full final-stack suite: 2,629 passed and 4 skipped; four initial SSH fixture connections hit container startup before sshd was ready, and all four passed on immediate rerun.

Closes #359
Part of #356
