### PR TITLE
test: add Zarr migration structural guards

### DIFF
--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -22,9 +22,14 @@ if TYPE_CHECKING:
     from trimesh.parent import Geometry
 
 
-def _open_zarr_array(loc: MutableMapping, zarr_group: Optional[str], mode: str) -> zarr.Array:
+def _open_zarr_array(loc: MutableMapping, zarr_group: Optional[str], mode: Literal["r", "r+"]) -> zarr.Array:
     """Open an explicitly named array or resolve the first OME pyramid level."""
-    root_group = zarr.open(loc, mode=mode)
+    if mode == "r":
+        root_group = zarr.open(loc, mode="r")
+    elif mode == "r+":
+        root_group = zarr.open(loc, mode="r+")
+    else:
+        raise ValueError(f"Unsupported Zarr array access mode: {mode}")
     array_path = zarr_group if zarr_group is not None else get_level_path(root_group, 0)
     return root_group[array_path]
 

--- a/src/copick/ops/export.py
+++ b/src/copick/ops/export.py
@@ -539,7 +539,7 @@ def _export_tomogram_zarr(
     else:
         # Copy only level 0
         source_group = zarr.open(source, mode="r")
-        dest_group = zarr.open(output_path, mode="w")
+        dest_group = zarr.open(output_path, mode="w", zarr_version=2)
         level_path = get_level_path(source_group, 0)
         zarr.copy(source_group[level_path], dest_group, name=level_path)
         # Copy metadata
@@ -740,7 +740,7 @@ def _export_segmentation_zarr(
     else:
         # Copy only level 0
         source_group = zarr.open(source, mode="r")
-        dest_group = zarr.open(output_path, mode="w")
+        dest_group = zarr.open(output_path, mode="w", zarr_version=2)
         level_path = get_level_path(source_group, 0)
         zarr.copy(source_group[level_path], dest_group, name=level_path)
         # Copy metadata

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,7 +86,7 @@ def sample_zarr_file_nanometer():
         volume = np.random.randn(64, 64, 64).astype(np.float32)
 
         # Create OME-Zarr file manually with nanometer units
-        store = zarr.open(str(zarr_path), mode="w")
+        store = zarr.open(str(zarr_path), mode="w", zarr_version=2)
         store.attrs["multiscales"] = [
             {
                 "axes": [

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import zarr
 from copick.models import CopickPicksFile
-from copick.util.ome import write_ome_zarr_3d
+from copick.util.ome import get_level_path, write_ome_zarr_3d
 from scipy.spatial.transform import Rotation
 from trimesh.parent import Geometry
 
@@ -170,8 +170,8 @@ def test_object_zarr(test_payload: Dict[str, Any]):
     copick_object = copick_root.get_object("proteasome")
 
     # Check zarr is readable
-    arrays = list(zarr.open(copick_object.zarr(), "r").arrays())
-    _, array = arrays[0]
+    group = zarr.open(copick_object.zarr(), mode="r")
+    array = group[get_level_path(group, 0)]
     assert array.shape == (42, 36, 36), "Error reading Zarr, (incorrect shape)"
     assert np.sum(array) == pytest.approx(
         1029.2904052734375,
@@ -776,8 +776,8 @@ def test_segmentation_zarr(test_payload: Dict[str, Any]):
     segmentation = copick_run.get_segmentations(name="membrane")[0]
 
     # Check zarr is readable
-    arrays = list(zarr.open(segmentation.zarr(), "r").arrays())
-    _, array = arrays[0]
+    group = zarr.open(segmentation.zarr(), mode="r")
+    array = group[get_level_path(group, 0)]
     assert array.shape == (64, 64, 64), "Error reading Zarr, (incorrect shape)"
     assert np.sum(array) == pytest.approx(
         24576,
@@ -833,8 +833,8 @@ def test_segmentation_write_numpy(test_payload: Dict[str, Any]):
     segmentation.from_numpy(array)
 
     # Check zarr contents
-    arrays = list(zarr.open(segmentation.zarr(), "r").arrays())
-    _, array2 = arrays[0]
+    group = zarr.open(segmentation.zarr(), mode="r")
+    array2 = group[get_level_path(group, 0)]
     assert np.allclose(array, array2), "Error writing numpy array"
 
     # Write subregion
@@ -844,8 +844,8 @@ def test_segmentation_write_numpy(test_payload: Dict[str, Any]):
     segmentation.set_region(sub_array, x=slice(10, 40), y=slice(10, 40), z=slice(10, 40))
 
     # Check zarr contents
-    arrays = list(zarr.open(segmentation.zarr(), "r").arrays())
-    _, array2 = arrays[0]
+    group = zarr.open(segmentation.zarr(), mode="r")
+    array2 = group[get_level_path(group, 0)]
     assert np.allclose(franken_array, array2), "Error writing numpy array subregion"
 
 
@@ -1458,8 +1458,8 @@ def test_tomogram_zarr(test_payload: Dict[str, Any]):
     tomogram = vs.get_tomogram(tomo_type="denoised")
 
     # Check zarr is readable
-    arrays = list(zarr.open(tomogram.zarr(), "r").arrays())
-    _, array = arrays[0]
+    group = zarr.open(tomogram.zarr(), mode="r")
+    array = group[get_level_path(group, 0)]
     assert array.shape == (64, 64, 64), "Error reading Zarr, (incorrect shape)"
     assert np.sum(array) == pytest.approx(
         8192.0,
@@ -1511,8 +1511,8 @@ def test_tomogram_write_numpy(test_payload: Dict[str, Any]):
     tomogram.from_numpy(array)
 
     # Check zarr contents
-    arrays = list(zarr.open(tomogram.zarr(), "r").arrays())
-    _, array2 = arrays[0]
+    group = zarr.open(tomogram.zarr(), mode="r")
+    array2 = group[get_level_path(group, 0)]
     assert np.allclose(array, array2), "Error writing numpy array"
 
     # Write subregion
@@ -1522,8 +1522,8 @@ def test_tomogram_write_numpy(test_payload: Dict[str, Any]):
     tomogram.set_region(sub_array, x=slice(10, 40), y=slice(10, 40), z=slice(10, 40))
 
     # Check zarr contents
-    arrays = list(zarr.open(tomogram.zarr(), "r").arrays())
-    _, array2 = arrays[0]
+    group = zarr.open(tomogram.zarr(), mode="r")
+    array2 = group[get_level_path(group, 0)]
     assert np.allclose(franken_array, array2), "Error writing numpy array subregion"
 
 
@@ -1549,8 +1549,8 @@ def test_feature_zarr(test_payload: Dict[str, Any]):
     feature = tomogram.get_features(feature_type="sobel")
 
     # Check zarr is readable
-    arrays = list(zarr.open(feature.zarr(), "r").arrays())
-    _, array = arrays[0]
+    group = zarr.open(feature.zarr(), mode="r")
+    array = group[get_level_path(group, 0)]
     assert array.shape == (64, 64, 64), "Error reading Zarr, (incorrect shape)"
     assert np.sum(array) == pytest.approx(
         20619.8125,
@@ -1611,8 +1611,8 @@ def test_feature_write_numpy(test_payload: Dict[str, Any]):
     feat.set_region(sub_array, slices=(slice(10, 40), slice(10, 40), slice(10, 40)))
 
     # Check zarr contents
-    arrays = list(zarr.open(feat.zarr(), "r").arrays())
-    _, array2 = arrays[0]
+    group = zarr.open(feat.zarr(), mode="r")
+    array2 = group[get_level_path(group, 0)]
     assert np.allclose(franken_array, array2), "Error writing numpy array subregion"
 
 

--- a/tests/test_ome.py
+++ b/tests/test_ome.py
@@ -24,7 +24,7 @@ from copick.util.path_util import get_data_from_file
 
 
 def _write_named_pyramid(path, metadata_layout="0.4"):
-    group = zarr.open(path, mode="w")
+    group = zarr.open(path, mode="w", zarr_version=2)
     level_zero = np.arange(64, dtype=np.float32).reshape(4, 4, 4)
     level_one = np.full((2, 2, 2), 7, dtype=np.float32)
     group.create_dataset("s0", data=level_zero, chunks=(2, 2, 2), dimension_separator="/")

--- a/tests/test_ops_add.py
+++ b/tests/test_ops_add.py
@@ -22,6 +22,7 @@ from copick.ops.add import (
     get_or_create_run,
     get_or_create_voxelspacing,
 )
+from copick.util.ome import get_level_path
 
 
 @pytest.fixture(params=pytest.common_cases)
@@ -155,9 +156,8 @@ class TestAddTomogram:
         assert tomo.tomo_type == "test-tomo-np"
 
         # Verify data is stored
-        zarr_group = zarr.open(tomo.zarr())
-        assert "0" in zarr_group
-        assert zarr_group["0"].shape == (8, 8, 8)
+        zarr_group = zarr.open(tomo.zarr(), mode="r")
+        assert zarr_group[get_level_path(zarr_group, 0)].shape == (8, 8, 8)
 
     def test_add_tomogram_dict_pyramid(self, test_payload):
         """Adding a tomogram from a dict pyramid writes multiple levels."""
@@ -193,16 +193,16 @@ class TestAddTomogram:
             transpose="2,1,0",
             exist_ok=True,
         )
-        zarr_group = zarr.open(tomo.zarr())
-        assert zarr_group["0"].shape == (8, 6, 4)
+        zarr_group = zarr.open(tomo.zarr(), mode="r")
+        assert zarr_group[get_level_path(zarr_group, 0)].shape == (8, 6, 4)
 
     def test_add_tomogram_flip(self, test_payload):
         """Flip reverses specified axis."""
         root = test_payload["root"]
         volume = np.arange(8).reshape(2, 2, 2).astype(np.float32)
         tomo = add_tomogram(root, "TS_001", "test-tomo-flip", volume, voxel_spacing=10.0, flip="0", exist_ok=True)
-        zarr_group = zarr.open(tomo.zarr())
-        stored = np.array(zarr_group["0"])
+        zarr_group = zarr.open(tomo.zarr(), mode="r")
+        stored = np.array(zarr_group[get_level_path(zarr_group, 0)])
         expected = np.flip(volume, axis=0)
         np.testing.assert_array_equal(stored, expected)
 
@@ -220,9 +220,9 @@ class TestAddTomogram:
             pyramid_levels=2,
             exist_ok=True,
         )
-        zarr_group = zarr.open(tomo.zarr())
-        assert "0" in zarr_group
-        assert "1" in zarr_group
+        zarr_group = zarr.open(tomo.zarr(), mode="r")
+        assert get_level_path(zarr_group, 0) in zarr_group
+        assert get_level_path(zarr_group, 1) in zarr_group
 
 
 class TestAddFeatures:
@@ -271,8 +271,8 @@ class TestAddSegmentation:
         assert seg.user_id == "test-user"
 
         # Verify data is stored
-        zarr_group = zarr.open(seg.zarr())
-        assert zarr_group["0"].shape == (8, 8, 8)
+        zarr_group = zarr.open(seg.zarr(), mode="r")
+        assert zarr_group[get_level_path(zarr_group, 0)].shape == (8, 8, 8)
 
     def test_add_segmentation_unsupported_format_raises(self, test_payload, tmp_path):
         """Unsupported file format raises ValueError."""
@@ -301,8 +301,8 @@ class TestAddSegmentation:
                     transpose="2,1,0",
                     exist_ok=True,
                 )
-                zarr_group = zarr.open(seg.zarr())
-                assert zarr_group["0"].shape == (8, 6, 4)
+                zarr_group = zarr.open(seg.zarr(), mode="r")
+                assert zarr_group[get_level_path(zarr_group, 0)].shape == (8, 6, 4)
             finally:
                 with contextlib.suppress(PermissionError, OSError):
                     os.unlink(tmp.name)

--- a/tests/test_ops_export.py
+++ b/tests/test_ops_export.py
@@ -177,7 +177,7 @@ class TestExportTomogram:
         output_path = str(tmp_path / "tomo.zarr")
         result = export_tomogram(tomo, output_path, "zarr", copy_all_levels=True)
         assert os.path.exists(result)
-        out_group = zarr.open(result)
+        out_group = zarr.open(result, mode="r")
         assert "0" in out_group
 
     def test_export_tomogram_zarr_single_level(self, test_payload, tmp_path):
@@ -189,7 +189,7 @@ class TestExportTomogram:
         output_path = str(tmp_path / "tomo_single.zarr")
         result = export_tomogram(tomo, output_path, "zarr", copy_all_levels=False)
         assert os.path.exists(result)
-        out_group = zarr.open(result)
+        out_group = zarr.open(result, mode="r")
         assert "0" in out_group
 
     def test_export_tomogram_unsupported_format_raises(self, test_payload, tmp_path):
@@ -255,7 +255,7 @@ class TestExportSegmentation:
         output_path = str(tmp_path / "seg_single.zarr")
         result = export_segmentation(seg, output_path, "zarr", copy_all_levels=False)
         assert os.path.exists(result)
-        out_group = zarr.open(result)
+        out_group = zarr.open(result, mode="r")
         assert "0" in out_group
 
     def test_export_segmentation_unsupported_format_raises(self, test_payload, tmp_path):

--- a/tests/test_zarr_structural_guards.py
+++ b/tests/test_zarr_structural_guards.py
@@ -1,0 +1,334 @@
+"""AST guards for the Zarr v2 hardening phase."""
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parents[1]
+ZARR_ENTRY_POINTS = {
+    "open",
+    "open_group",
+    "open_array",
+    "group",
+    "create",
+    "array",
+    "create_group",
+    "create_array",
+}
+ZARR_OPEN_ENTRY_POINTS = {"open", "open_group", "open_array"}
+ZARR_CREATION_MODES = {"a", "w", "w-", "x"}
+
+# These tests intentionally assert copick's canonical numeric writer output.
+# Every entry must correspond to a violation observed by the repository scan,
+# which prevents stale or overly broad exemptions.
+ALLOWED_VIOLATIONS = {
+    ("tests/test_ome_writer.py", "test_writer_preserves_v2_golden_contract", "metadata_level_path"),
+    ("tests/test_ome_writer.py", "test_writer_preserves_default_chunk_shape", "metadata_level_path"),
+    ("tests/test_ome_writer.py", "test_zarr_handler_uses_canonical_writer_contract", "metadata_level_path"),
+}
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: str
+    scope: str
+    line: int
+    rule: str
+    message: str
+
+    @property
+    def allowlist_key(self):
+        return self.path, self.scope, self.rule
+
+    def __str__(self):
+        return f"{self.path}:{self.line} ({self.scope}) [{self.rule}] {self.message}"
+
+
+def _dotted_name(node):
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _dotted_name(node.value)
+        if prefix:
+            return f"{prefix}.{node.attr}"
+    return None
+
+
+def _constant_string(node):
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _is_constant(node, value):
+    return isinstance(node, ast.Constant) and node.value == value
+
+
+class ZarrStructuralGuard(ast.NodeVisitor):
+    """Find structural migration-policy violations in one Python module."""
+
+    def __init__(self, path):
+        self.path = path
+        self.scope = ["<module>"]
+        self.module_aliases = {}
+        self.function_aliases = {}
+        self.zarr_group_names = set()
+        self.array_listing_names = set()
+        self.violations = []
+
+    def _add(self, node, rule, message):
+        self.violations.append(Violation(self.path, self.scope[-1], node.lineno, rule, message))
+
+    def _canonical_call_name(self, call):
+        raw_name = _dotted_name(call.func)
+        if raw_name is None:
+            return None
+        if raw_name in self.function_aliases:
+            return self.function_aliases[raw_name]
+
+        head, separator, tail = raw_name.partition(".")
+        if head in self.module_aliases:
+            canonical = self.module_aliases[head]
+            return f"{canonical}.{tail}" if separator else canonical
+        return raw_name
+
+    @staticmethod
+    def _keyword(call, name):
+        return next((keyword.value for keyword in call.keywords if keyword.arg == name), None)
+
+    def _mode(self, call):
+        keyword_mode = self._keyword(call, "mode")
+        if keyword_mode is not None:
+            return keyword_mode
+        return call.args[1] if len(call.args) > 1 else None
+
+    def _has_v2_format(self, call):
+        return _is_constant(self._keyword(call, "zarr_version"), 2)
+
+    def _is_zarr_group_expression(self, node):
+        if isinstance(node, ast.Name):
+            return node.id in self.zarr_group_names or node.id == "group" or node.id.endswith("_group")
+        if isinstance(node, ast.Attribute):
+            return node.attr == "group" or node.attr.endswith("_group")
+        if isinstance(node, ast.Call):
+            name = self._canonical_call_name(node)
+            return name in {f"zarr.{entry}" for entry in ZARR_OPEN_ENTRY_POINTS | {"group"}}
+        return False
+
+    @staticmethod
+    def _is_array_listing(node):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name) or node.func.id != "list":
+            return False
+        if len(node.args) != 1 or not isinstance(node.args[0], ast.Call):
+            return False
+        return isinstance(node.args[0].func, ast.Attribute) and node.args[0].func.attr == "arrays"
+
+    def visit_Import(self, node):
+        for alias in node.names:
+            if alias.name == "zarr" or alias.name == "ome_zarr.writer":
+                if alias.asname:
+                    self.module_aliases[alias.asname] = alias.name
+                else:
+                    self.module_aliases[alias.name.split(".")[0]] = alias.name.split(".")[0]
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node):
+        if node.module in {"zarr", "ome_zarr.writer"}:
+            for alias in node.names:
+                local_name = alias.asname or alias.name
+                self.function_aliases[local_name] = f"{node.module}.{alias.name}"
+        elif node.module == "ome_zarr":
+            for alias in node.names:
+                if alias.name == "writer":
+                    self.module_aliases[alias.asname or alias.name] = "ome_zarr.writer"
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node):
+        self.scope.append(node.name)
+        self.generic_visit(node)
+        self.scope.pop()
+
+    def visit_AsyncFunctionDef(self, node):
+        self.visit_FunctionDef(node)
+
+    def visit_Assign(self, node):
+        if isinstance(node.value, ast.Call):
+            call_name = self._canonical_call_name(node.value)
+            if call_name in {f"zarr.{entry}" for entry in ZARR_OPEN_ENTRY_POINTS | {"group"}}:
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        self.zarr_group_names.add(target.id)
+        if self._is_array_listing(node.value):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    self.array_listing_names.add(target.id)
+        self.generic_visit(node)
+
+    def visit_Call(self, node):
+        call_name = self._canonical_call_name(node)
+        if call_name and call_name.startswith("zarr."):
+            entry_point = call_name.removeprefix("zarr.")
+            if entry_point in ZARR_ENTRY_POINTS:
+                mode_node = self._mode(node) if entry_point in ZARR_OPEN_ENTRY_POINTS else None
+                mode = _constant_string(mode_node)
+
+                if entry_point in ZARR_OPEN_ENTRY_POINTS and mode_node is None:
+                    self._add(node, "explicit_open_mode", f"zarr.{entry_point} requires an explicit mode")
+
+                creates = entry_point not in ZARR_OPEN_ENTRY_POINTS or mode_node is None or mode in ZARR_CREATION_MODES
+                if creates and not self._has_v2_format(node):
+                    self._add(
+                        node,
+                        "explicit_zarr_format",
+                        f"creation through zarr.{entry_point} requires zarr_version=2",
+                    )
+
+        if call_name == "ome_zarr.writer.write_multiscale" and self._keyword(node, "fmt") is None:
+            self._add(
+                node,
+                "explicit_write_multiscale_format",
+                "write_multiscale requires an explicit fmt keyword",
+            )
+
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node):
+        if not isinstance(node.ctx, ast.Load):
+            self.generic_visit(node)
+            return
+
+        if _is_constant(node.slice, "0") and self._is_zarr_group_expression(node.value):
+            self._add(node, "metadata_level_path", 'read a level through metadata instead of literal path "0"')
+
+        if (
+            isinstance(node.slice, ast.Call)
+            and isinstance(node.slice.func, ast.Name)
+            and node.slice.func.id == "str"
+            and len(node.slice.args) == 1
+            and isinstance(node.slice.args[0], ast.Name)
+            and "level" in node.slice.args[0].id
+        ):
+            self._add(node, "metadata_level_path", "read a level through metadata instead of str(level)")
+
+        reads_first_array = _is_constant(node.slice, 0) and (
+            self._is_array_listing(node.value)
+            or isinstance(node.value, ast.Name)
+            and node.value.id in self.array_listing_names
+        )
+        if reads_first_array:
+            self._add(node, "metadata_level_path", "do not select a level using Group.arrays() iteration order")
+
+        self.generic_visit(node)
+
+
+def find_violations(source, path="<fixture>"):
+    guard = ZarrStructuralGuard(path)
+    guard.visit(ast.parse(source))
+    return guard.violations
+
+
+def _repository_python_files():
+    roots = (PROJECT_ROOT / "src" / "copick", PROJECT_ROOT / "tests", PROJECT_ROOT / "docs" / "snippets")
+    for root in roots:
+        yield from root.rglob("*.py")
+
+
+def test_repository_obeys_zarr_structural_guards():
+    violations = []
+    for source_path in _repository_python_files():
+        relative_path = source_path.relative_to(PROJECT_ROOT).as_posix()
+        violations.extend(find_violations(source_path.read_text(), relative_path))
+
+    observed_allowlist = {violation.allowlist_key for violation in violations} & ALLOWED_VIOLATIONS
+    assert observed_allowlist == ALLOWED_VIOLATIONS, "Structural-guard allow-list contains stale entries"
+
+    unexpected = [violation for violation in violations if violation.allowlist_key not in ALLOWED_VIOLATIONS]
+    assert not unexpected, "Unexpected Zarr structural violations:\n" + "\n".join(map(str, unexpected))
+
+
+@pytest.mark.parametrize("entry_point", sorted(ZARR_ENTRY_POINTS))
+def test_guard_rejects_creation_without_explicit_v2_format(entry_point):
+    arguments = "store, mode='w'" if entry_point in ZARR_OPEN_ENTRY_POINTS else "data"
+    violations = find_violations(f"import zarr\nzarr.{entry_point}({arguments})\n")
+
+    assert "explicit_zarr_format" in {violation.rule for violation in violations}
+
+
+def test_guard_rejects_wrong_creation_format():
+    violations = find_violations("import zarr\nzarr.group(store, zarr_version=3)\n")
+
+    assert "explicit_zarr_format" in {violation.rule for violation in violations}
+
+
+@pytest.mark.parametrize("entry_point", sorted(ZARR_OPEN_ENTRY_POINTS))
+def test_guard_rejects_open_without_explicit_mode(entry_point):
+    violations = find_violations(f"import zarr\nzarr.{entry_point}(store, zarr_version=2)\n")
+
+    assert "explicit_open_mode" in {violation.rule for violation in violations}
+
+
+def test_guard_rejects_write_multiscale_without_explicit_format():
+    source = "from ome_zarr.writer import write_multiscale\nwrite_multiscale(images, group=group)\n"
+
+    assert "explicit_write_multiscale_format" in {violation.rule for violation in find_violations(source)}
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        'array = group["0"]',
+        "array = group[str(level)]",
+        "array = list(group.arrays())[0]",
+        "arrays = list(group.arrays())\narray = arrays[0]",
+    ],
+)
+def test_guard_rejects_level_reads_that_bypass_metadata(statement):
+    violations = find_violations(f"def read(group, level):\n    {statement.replace(chr(10), chr(10) + '    ')}\n")
+
+    assert "metadata_level_path" in {violation.rule for violation in violations}
+
+
+def test_guard_accepts_explicit_v2_creation_and_metadata_level_resolution():
+    source = """
+import zarr
+from ome_zarr.writer import write_multiscale
+
+zarr.open(store, mode="w", zarr_version=2)
+zarr.open_group(store, mode="w", zarr_version=2)
+zarr.open_array(store, mode="w", zarr_version=2)
+zarr.group(store, zarr_version=2)
+zarr.create(shape, zarr_version=2)
+zarr.array(data, zarr_version=2)
+zarr.create_group(store, zarr_version=2)
+zarr.create_array(store, zarr_version=2)
+write_multiscale(images, group=group, fmt=fmt)
+array = group[get_level_path(group, level)]
+"""
+
+    assert find_violations(source) == []
+
+
+def test_guard_resolves_import_aliases():
+    source = """
+import zarr as zr
+from ome_zarr.writer import write_multiscale as write
+from zarr import open as zopen
+
+zr.create(shape)
+zopen(store)
+write(images, group=group)
+"""
+
+    assert {violation.rule for violation in find_violations(source)} == {
+        "explicit_open_mode",
+        "explicit_write_multiscale_format",
+        "explicit_zarr_format",
+    }
+
+
+def test_guard_resolves_dotted_writer_import():
+    source = "import ome_zarr.writer\nome_zarr.writer.write_multiscale(images, group=group)\n"
+
+    assert "explicit_write_multiscale_format" in {violation.rule for violation in find_violations(source)}

--- a/tests/test_zarr_structural_guards.py
+++ b/tests/test_zarr_structural_guards.py
@@ -239,7 +239,7 @@ def test_repository_obeys_zarr_structural_guards():
     violations = []
     for source_path in _repository_python_files():
         relative_path = source_path.relative_to(PROJECT_ROOT).as_posix()
-        violations.extend(find_violations(source_path.read_text(), relative_path))
+        violations.extend(find_violations(source_path.read_text(encoding="utf-8"), relative_path))
 
     observed_allowlist = {violation.allowlist_key for violation in violations} & ALLOWED_VIOLATIONS
     assert observed_allowlist == ALLOWED_VIOLATIONS, "Structural-guard allow-list contains stale entries"

--- a/tests/test_zarr_structural_guards.py
+++ b/tests/test_zarr_structural_guards.py
@@ -18,7 +18,12 @@ ZARR_ENTRY_POINTS = {
     "create_array",
 }
 ZARR_OPEN_ENTRY_POINTS = {"open", "open_group", "open_array"}
-ZARR_CREATION_MODES = {"a", "w", "w-", "x"}
+ZARR_NON_CREATING_MODES = {"r", "r+"}
+ZARR_CALL_ALIASES = {
+    "zarr.convenience.open": "zarr.open",
+    "zarr.hierarchy.open_group": "zarr.open_group",
+}
+REPOSITORY_SCAN_ROOTS = (PROJECT_ROOT / "src" / "copick", PROJECT_ROOT / "tests", PROJECT_ROOT / "docs" / "snippets")
 
 # These tests intentionally assert copick's canonical numeric writer output.
 # Every entry must correspond to a violation observed by the repository scan,
@@ -74,7 +79,6 @@ class ZarrStructuralGuard(ast.NodeVisitor):
         self.scope = ["<module>"]
         self.module_aliases = {}
         self.function_aliases = {}
-        self.zarr_group_names = set()
         self.array_listing_names = set()
         self.violations = []
 
@@ -85,14 +89,10 @@ class ZarrStructuralGuard(ast.NodeVisitor):
         raw_name = _dotted_name(call.func)
         if raw_name is None:
             return None
-        if raw_name in self.function_aliases:
-            return self.function_aliases[raw_name]
-
         head, separator, tail = raw_name.partition(".")
-        if head in self.module_aliases:
-            canonical = self.module_aliases[head]
-            return f"{canonical}.{tail}" if separator else canonical
-        return raw_name
+        canonical = self.function_aliases.get(head, self.module_aliases.get(head, head))
+        resolved = f"{canonical}.{tail}" if separator else canonical
+        return ZARR_CALL_ALIASES.get(resolved, resolved)
 
     @staticmethod
     def _keyword(call, name):
@@ -107,15 +107,10 @@ class ZarrStructuralGuard(ast.NodeVisitor):
     def _has_v2_format(self, call):
         return _is_constant(self._keyword(call, "zarr_version"), 2)
 
-    def _is_zarr_group_expression(self, node):
-        if isinstance(node, ast.Name):
-            return node.id in self.zarr_group_names or node.id == "group" or node.id.endswith("_group")
-        if isinstance(node, ast.Attribute):
-            return node.attr == "group" or node.attr.endswith("_group")
-        if isinstance(node, ast.Call):
-            name = self._canonical_call_name(node)
-            return name in {f"zarr.{entry}" for entry in ZARR_OPEN_ENTRY_POINTS | {"group"}}
-        return False
+    @staticmethod
+    def _is_typing_literal(node):
+        name = _dotted_name(node)
+        return name == "Literal" or name in {"typing.Literal", "typing_extensions.Literal"}
 
     @staticmethod
     def _is_array_listing(node):
@@ -127,7 +122,7 @@ class ZarrStructuralGuard(ast.NodeVisitor):
 
     def visit_Import(self, node):
         for alias in node.names:
-            if alias.name == "zarr" or alias.name == "ome_zarr.writer":
+            if alias.name == "zarr" or alias.name.startswith("zarr.") or alias.name == "ome_zarr.writer":
                 if alias.asname:
                     self.module_aliases[alias.asname] = alias.name
                 else:
@@ -135,7 +130,9 @@ class ZarrStructuralGuard(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node):
-        if node.module in {"zarr", "ome_zarr.writer"}:
+        if node.module and (
+            node.module == "zarr" or node.module.startswith("zarr.") or node.module == "ome_zarr.writer"
+        ):
             for alias in node.names:
                 local_name = alias.asname or alias.name
                 self.function_aliases[local_name] = f"{node.module}.{alias.name}"
@@ -154,12 +151,6 @@ class ZarrStructuralGuard(ast.NodeVisitor):
         self.visit_FunctionDef(node)
 
     def visit_Assign(self, node):
-        if isinstance(node.value, ast.Call):
-            call_name = self._canonical_call_name(node.value)
-            if call_name in {f"zarr.{entry}" for entry in ZARR_OPEN_ENTRY_POINTS | {"group"}}:
-                for target in node.targets:
-                    if isinstance(target, ast.Name):
-                        self.zarr_group_names.add(target.id)
         if self._is_array_listing(node.value):
             for target in node.targets:
                 if isinstance(target, ast.Name):
@@ -177,7 +168,7 @@ class ZarrStructuralGuard(ast.NodeVisitor):
                 if entry_point in ZARR_OPEN_ENTRY_POINTS and mode_node is None:
                     self._add(node, "explicit_open_mode", f"zarr.{entry_point} requires an explicit mode")
 
-                creates = entry_point not in ZARR_OPEN_ENTRY_POINTS or mode_node is None or mode in ZARR_CREATION_MODES
+                creates = entry_point not in ZARR_OPEN_ENTRY_POINTS or mode not in ZARR_NON_CREATING_MODES
                 if creates and not self._has_v2_format(node):
                     self._add(
                         node,
@@ -199,7 +190,7 @@ class ZarrStructuralGuard(ast.NodeVisitor):
             self.generic_visit(node)
             return
 
-        if _is_constant(node.slice, "0") and self._is_zarr_group_expression(node.value):
+        if _is_constant(node.slice, "0") and not self._is_typing_literal(node.value):
             self._add(node, "metadata_level_path", 'read a level through metadata instead of literal path "0"')
 
         if (
@@ -229,15 +220,16 @@ def find_violations(source, path="<fixture>"):
     return guard.violations
 
 
-def _repository_python_files():
-    roots = (PROJECT_ROOT / "src" / "copick", PROJECT_ROOT / "tests", PROJECT_ROOT / "docs" / "snippets")
-    for root in roots:
-        yield from root.rglob("*.py")
-
-
 def test_repository_obeys_zarr_structural_guards():
+    source_paths = []
+    for root in REPOSITORY_SCAN_ROOTS:
+        assert root.is_dir(), f"Structural-guard scan root does not exist: {root}"
+        root_sources = list(root.rglob("*.py"))
+        assert root_sources, f"Structural-guard scan root contains no Python files: {root}"
+        source_paths.extend(root_sources)
+
     violations = []
-    for source_path in _repository_python_files():
+    for source_path in source_paths:
         relative_path = source_path.relative_to(PROJECT_ROOT).as_posix()
         violations.extend(find_violations(source_path.read_text(encoding="utf-8"), relative_path))
 
@@ -263,6 +255,13 @@ def test_guard_rejects_wrong_creation_format():
 
 
 @pytest.mark.parametrize("entry_point", sorted(ZARR_OPEN_ENTRY_POINTS))
+def test_guard_treats_dynamic_open_modes_as_creation_capable(entry_point):
+    violations = find_violations(f"import zarr\nzarr.{entry_point}(store, mode=mode)\n")
+
+    assert "explicit_zarr_format" in {violation.rule for violation in violations}
+
+
+@pytest.mark.parametrize("entry_point", sorted(ZARR_OPEN_ENTRY_POINTS))
 def test_guard_rejects_open_without_explicit_mode(entry_point):
     violations = find_violations(f"import zarr\nzarr.{entry_point}(store, zarr_version=2)\n")
 
@@ -276,16 +275,34 @@ def test_guard_rejects_write_multiscale_without_explicit_format():
 
 
 @pytest.mark.parametrize(
+    "source",
+    [
+        "import zarr.convenience as zc\nzc.open(store, mode='w')\n",
+        "from zarr.convenience import open as zopen\nzopen(store, mode='w')\n",
+        "import zarr.hierarchy as zh\nzh.open_group(store, mode='w')\n",
+        "from zarr.hierarchy import open_group as zopen_group\nzopen_group(store, mode='w')\n",
+        "from zarr import convenience as zc\nzc.open(store, mode='w')\n",
+    ],
+)
+def test_guard_rejects_legacy_zarr_import_paths_without_explicit_v2_format(source):
+    violations = find_violations(source)
+
+    assert "explicit_zarr_format" in {violation.rule for violation in violations}
+
+
+@pytest.mark.parametrize(
     "statement",
     [
-        'array = group["0"]',
+        'array = grp["0"]',
         "array = group[str(level)]",
         "array = list(group.arrays())[0]",
         "arrays = list(group.arrays())\narray = arrays[0]",
     ],
 )
 def test_guard_rejects_level_reads_that_bypass_metadata(statement):
-    violations = find_violations(f"def read(group, level):\n    {statement.replace(chr(10), chr(10) + '    ')}\n")
+    violations = find_violations(
+        f"def read(group, grp, level):\n    {statement.replace(chr(10), chr(10) + '    ')}\n",
+    )
 
     assert "metadata_level_path" in {violation.rule for violation in violations}
 
@@ -305,6 +322,8 @@ zarr.create_group(store, zarr_version=2)
 zarr.create_array(store, zarr_version=2)
 write_multiscale(images, group=group, fmt=fmt)
 array = group[get_level_path(group, level)]
+group.create_dataset("0", data=data)
+assert "0" in group
 """
 
     assert find_violations(source) == []


### PR DESCRIPTION
## Summary

- Add a repository-wide AST guard for the eight Zarr open/create/group/array entry points in the phase-zero contract.
- Require explicit open modes, explicit Zarr v2 creation formats, explicit `write_multiscale` formats, and metadata-driven level resolution.
- Normalize legacy and aliased calls through `zarr.convenience.open` and `zarr.hierarchy.open_group`.
- Treat dynamic open modes as creation-capable and constrain the shared model helper to its actual literal `r`/`r+` modes.
- Replace receiver-name guessing with a fail-closed literal-level rule, while retaining an exact stale-checked allowlist for intentional writer-contract reads.
- Assert that source, test, and documentation scan roots each exist and contain Python files.

## Intentional guard boundaries

- Numeric writer assertions such as `"0" in group` remain allowed because they verify the canonical output contract rather than select data for reading.
- `Group.create_dataset()` remains allowed because the group already determines the Zarr format; the method has no independent format-selection argument.
- Writers continue to produce numeric paths (`0`, `1`, ...). `s0`/`s1` fixtures verify reader compatibility only.

## Stack

This PR is based on and should be merged after #401.

## Validation

- `pre-commit run --show-diff-on-failure --color=always --all-files`: passed.
- Structural-guard suite: 29 passed.
- Integrated structural and OME/CLI suites: 38 passed.
- Full local/backend matrix: 2,629 passed and 4 skipped. The first four SSH cases connected while the freshly recreated OpenSSH container was still starting and reported `ConnectionResetError`; all four passed on immediate rerun against the ready service.
- No assertion or implementation failures occurred on local, ML Croissant, S3, or SSH backends.

Closes #360
Part of #356
