### PR TITLE
feat!: support configurable feature array layouts

### DIFF
--- a/docs/api_reference/copick_utils/features_pickers.md
+++ b/docs/api_reference/copick_utils/features_pickers.md
@@ -58,3 +58,9 @@ features = compute_skimage_features(
     texture=True,
 )
 ```
+
+`compute_skimage_features` returns feature-major data shaped `(feature, z, y, x)`. Copick stores that output through
+the same centralized OME-Zarr writer used by `CopickFeatures.from_numpy()` and `copick.ops.add_features()`. Existing 3D
+feature volumes remain `(z, y, x)`. By default, 4D arrays use one feature per inner chunk and one padded spatial shard
+per feature volume; pass a spatial 3-tuple or an explicit 4D tuple through `chunks`, and an explicit dimension-matched
+tuple through `shards`, to override the layout.

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -8,11 +8,15 @@ from zarr.abc.store import Store
 
 from copick.util.escape import sanitize_name
 from copick.util.ome import (
+    DEFAULT_SPATIAL_CHUNKS,
     fits_in_memory,
     get_level_path,
     initialize_zarr_v2,
+    ome_zarr_axes,
+    padded_shard_shape,
     segmentation_pyramid,
     volume_pyramid,
+    write_ome_zarr,
     write_ome_zarr_3d,
 )
 from copick.util.relion import picks_to_df_relion, relion_df_to_picks
@@ -2003,6 +2007,54 @@ class CopickFeatures:
 
         return np.array(group[slices])
 
+    def from_numpy(
+        self,
+        data: np.ndarray,
+        *,
+        chunks: Optional[Tuple[int, ...]] = None,
+        shards: Optional[Tuple[int, ...]] = None,
+        dtype: Optional[np.dtype] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Write a 3D or feature-major 4D feature array.
+
+        Args:
+            data: Feature data shaped ``(z, y, x)`` or ``(feature, z, y, x)``.
+            chunks: Optional inner chunk shape. A 3-tuple for 4D data is expanded with a leading extent of one.
+            shards: Optional dimension-matched shard shape.
+            dtype: Optional dtype conversion applied before writing.
+            metadata: Optional OME multiscale metadata payload.
+        """
+        array = np.asarray(data, dtype=dtype)
+        if array.ndim not in (3, 4):
+            raise ValueError(f"Feature data must be 3D (z, y, x) or 4D (feature, z, y, x), got shape {array.shape!r}")
+
+        spatial_chunks = DEFAULT_SPATIAL_CHUNKS if chunks is None else chunks
+        if array.ndim == 3:
+            effective_chunks = spatial_chunks
+            effective_shards = shards
+        else:
+            if len(spatial_chunks) == 3:
+                effective_chunks = (1, *spatial_chunks)
+            elif len(spatial_chunks) == 4:
+                effective_chunks = spatial_chunks
+            else:
+                raise ValueError(
+                    f"chunks must contain 3 spatial dimensions or all 4 dimensions, got {spatial_chunks!r}",
+                )
+            effective_shards = shards
+            if effective_shards is None:
+                effective_shards = (1, *padded_shard_shape(array.shape[1:], effective_chunks[1:]))
+
+        write_ome_zarr(
+            self.zarr(),
+            {self.tomogram.voxel_spacing.voxel_size: array},
+            ome_zarr_axes(array.ndim),
+            effective_chunks,
+            metadata=metadata,
+            shard_size=effective_shards,
+        )
+
     def set_region(
         self,
         data: np.ndarray,
@@ -2018,6 +2070,11 @@ class CopickFeatures:
             slices: Tuple of slices for the axes.
         """
         loc = self.zarr()
+        if slices is None:
+            array = _open_zarr_array(loc, zarr_group, mode="r+")
+            slices = tuple(slice(None) for _ in array.shape)
+            array[slices] = data
+            return
         _open_zarr_array(loc, zarr_group, mode="r+")[slices] = data
 
 

--- a/src/copick/ops/add.py
+++ b/src/copick/ops/add.py
@@ -338,19 +338,26 @@ def add_features(
     chunks: Tuple[int, int, int] = (128, 128, 128),
     meta: Dict[str, Any] = None,
     log: bool = False,
+    shards: Optional[Tuple[int, ...]] = None,
 ) -> CopickFeatures:
     """Add features to a copick run.
 
     Args:
         root (CopickRoot): The copick root object.
-        features (Dict[str, Any]): The features to add.
+        features_vol: A 3D ``(z, y, x)`` volume or 4D ``(feature, z, y, x)`` array.
         run (str): The run the features are part of.
+        voxel_spacing: Voxel spacing of the associated tomogram and spatial feature axes.
+        tomo_type: Type of the associated tomogram.
+        feature_type: Name of the feature map.
         exist_ok (bool, optional): If True, do not raise an error if the features already exist. Defaults to False.
         overwrite (bool, optional): Overwrite the object if it exists. Defaults to False.
+        chunks: Inner chunks. A spatial 3-tuple is expanded with a leading one for 4D data.
+        meta: Optional OME multiscale metadata.
         log (bool, optional): Log the operation. Defaults to False.
+        shards: Optional dimension-matched shard shape.
     """
     runobj = get_or_create_run(root, run, create=False)
-    vsobj = get_or_create_voxelspacing(runobj, 1.0, create=False)
+    vsobj = get_or_create_voxelspacing(runobj, voxel_spacing, create=False)
     tomogram = vsobj.get_tomogram(tomo_type)
 
     if tomogram is None:
@@ -359,16 +366,17 @@ def add_features(
             logging.exception(e)
         raise e
 
+    existing_features = tomogram.get_features(feature_type)
+
     # Create the features
     features = tomogram.new_features(feature_type, exist_ok=exist_ok)
+    if existing_features is not None and not overwrite:
+        return features
 
-    # Get the store
-    loc = features.zarr()
-    write_ome_zarr_3d(
-        loc,
-        {voxel_spacing: features_vol},
-        chunk_size=chunks,
-        overwrite=overwrite,
+    features.from_numpy(
+        features_vol,
+        chunks=chunks,
+        shards=shards,
         metadata=meta,
     )
 

--- a/src/copick/util/ome.py
+++ b/src/copick/util/ome.py
@@ -95,6 +95,15 @@ def _ome_zarr_axes() -> List[Dict[str, str]]:
     ]
 
 
+def ome_zarr_axes(ndim: int = 3) -> List[Dict[str, str]]:
+    """Return copick's supported OME-Zarr axes for 3D or feature-major 4D arrays."""
+    if ndim == 3:
+        return _ome_zarr_axes()
+    if ndim == 4:
+        return [{"name": "feature"}, *_ome_zarr_axes()]
+    raise ValueError(f"OME-Zarr feature arrays must be 3D or 4D, got {ndim} dimensions")
+
+
 def _ome_zarr_transforms(voxel_size: float) -> Dict[str, Any]:
     return {
         "scale": [voxel_size, voxel_size, voxel_size],
@@ -226,6 +235,79 @@ def canonical_v3_compressors(dtype: np.dtype) -> Tuple[Any, ...]:
     raise TypeError(f"Canonical OME-Zarr output does not support dtype {dtype}")
 
 
+def write_ome_zarr(
+    store: Union[str, Store],
+    pyramid: Dict[float, np.ndarray],
+    axes: List[Dict[str, str]],
+    chunk_size: Tuple[int, ...],
+    overwrite: bool = True,
+    metadata: Any = _DEFAULT_WRITER_METADATA,
+    shard_size: Union[Tuple[int, ...], None] = None,
+) -> None:
+    """Write an OME-Zarr 0.5 / Zarr v3 pyramid with the canonical layout."""
+    # These imports are intentionally lazy because importing ome-zarr is
+    # expensive and writes are already non-trivial operations.
+    from ome_zarr.format import FormatV05
+    from ome_zarr.writer import write_multiscales_metadata
+
+    if not pyramid:
+        raise ValueError("pyramid must contain at least one level")
+    ndim = next(iter(pyramid.values())).ndim
+    chunks = _shape_tuple(chunk_size, ndim, "chunk_size")
+    if len(axes) != ndim:
+        raise ValueError(f"axes must contain exactly {ndim} entries, got {len(axes)}")
+
+    layouts = []
+    for array in pyramid.values():
+        if array.ndim != ndim:
+            raise ValueError("all pyramid levels must have the same dimensionality")
+        shards = padded_shard_shape(array.shape, chunks) if shard_size is None else _validate_shards(shard_size, chunks)
+        _preflight_shard_size(shards, array.dtype)
+        layouts.append((shards, canonical_v3_compressors(array.dtype)))
+
+    root_group = zarr.group(store=store, overwrite=overwrite, zarr_format=3)
+    writer_metadata = {} if metadata is _DEFAULT_WRITER_METADATA else metadata
+    ome_zarr_metadata = writer_metadata if isinstance(writer_metadata, dict) else {}
+
+    datasets = []
+    dimension_names = tuple(axis["name"] for axis in axes)
+    for level, ((voxel_size, array), (shards, compressors)) in enumerate(zip(pyramid.items(), layouts, strict=True)):
+        path = str(level)
+        root_group.create_array(
+            path,
+            data=array,
+            chunks=chunks,
+            shards=shards,
+            compressors=compressors,
+            chunk_key_encoding={"name": "v2", "separator": "/"},
+            dimension_names=dimension_names,
+            overwrite=overwrite,
+        )
+        datasets.append(
+            {
+                "path": path,
+                "coordinateTransformations": [
+                    {
+                        "scale": [1.0] * (ndim - 3) + [voxel_size, voxel_size, voxel_size],
+                        "type": "scale",
+                    },
+                ],
+            },
+        )
+
+    write_multiscales_metadata(
+        root_group,
+        datasets,
+        fmt=FormatV05(),
+        axes=axes,
+        metadata=ome_zarr_metadata,
+    )
+    if metadata is not _DEFAULT_WRITER_METADATA:
+        ome = copy.deepcopy(root_group.attrs["ome"])
+        ome["multiscales"][0]["metadata"] = copy.deepcopy(writer_metadata)
+        root_group.attrs["ome"] = ome
+
+
 def write_ome_zarr_3d(
     store: Union[str, Store],
     pyramid: Dict[float, np.ndarray],
@@ -244,59 +326,18 @@ def write_ome_zarr_3d(
         metadata: Additional OME multiscale metadata. When omitted, preserve the existing empty metadata mapping.
         shard_size: Optional explicit shard shape. By default, one padded logical shard is used per level.
     """
-    # This is a super heavy import, so we do it here to avoid loading it before it's needed.
-    # Writing is slow anyway.
-    from ome_zarr.format import FormatV05
-    from ome_zarr.writer import write_multiscales_metadata
-
-    chunks = _shape_tuple(chunk_size, 3, "chunk_size")
-    if not pyramid:
-        raise ValueError("pyramid must contain at least one level")
-    layouts = []
     for array in pyramid.values():
         if array.ndim != 3:
             raise ValueError(f"write_ome_zarr_3d expects 3D arrays, got shape {array.shape!r}")
-        shards = padded_shard_shape(array.shape, chunks) if shard_size is None else _validate_shards(shard_size, chunks)
-        _preflight_shard_size(shards, array.dtype)
-        layouts.append((shards, canonical_v3_compressors(array.dtype)))
-
-    ome_meta = ome_metadata(pyramid)
-    root_group = zarr.group(store=store, overwrite=overwrite, zarr_format=3)
-    writer_metadata = {} if metadata is _DEFAULT_WRITER_METADATA else metadata
-    ome_zarr_metadata = writer_metadata if isinstance(writer_metadata, dict) else {}
-
-    datasets = []
-    dimension_names = tuple(axis["name"] for axis in ome_meta["axes"])
-    for level, ((voxel_size, array), (shards, compressors)) in enumerate(zip(pyramid.items(), layouts, strict=True)):
-        path = str(level)
-        root_group.create_array(
-            path,
-            data=array,
-            chunks=chunks,
-            shards=shards,
-            compressors=compressors,
-            chunk_key_encoding={"name": "v2", "separator": "/"},
-            dimension_names=dimension_names,
-            overwrite=overwrite,
-        )
-        datasets.append(
-            {
-                "path": path,
-                "coordinateTransformations": [_ome_zarr_transforms(voxel_size)],
-            },
-        )
-
-    write_multiscales_metadata(
-        root_group,
-        datasets,
-        fmt=FormatV05(),
-        axes=ome_meta["axes"],
-        metadata=ome_zarr_metadata,
+    write_ome_zarr(
+        store,
+        pyramid,
+        ome_zarr_axes(),
+        chunk_size,
+        overwrite=overwrite,
+        metadata=metadata,
+        shard_size=shard_size,
     )
-    if metadata is not _DEFAULT_WRITER_METADATA:
-        ome = copy.deepcopy(root_group.attrs["ome"])
-        ome["multiscales"][0]["metadata"] = copy.deepcopy(writer_metadata)
-        root_group.attrs["ome"] = ome
 
 
 def iter_chunk_slices(shape: Tuple[int, ...], chunks: Tuple[int, ...]) -> Iterator[Tuple[slice, ...]]:

--- a/tests/test_feature_writer.py
+++ b/tests/test_feature_writer.py
@@ -1,0 +1,131 @@
+"""Contracts for backward-compatible 3D and feature-major 4D feature writes."""
+
+import inspect
+import math
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import zarr
+from ome_zarr_models.v05.image import Image
+from zarr.storage import MemoryStore
+
+from copick.models import CopickFeatures, CopickFeaturesMeta
+from copick.ops.add import add_features
+from copick.util.ome import DEFAULT_SPATIAL_CHUNKS, get_level_path, get_multiscales
+
+
+class _MemoryFeatures(CopickFeatures):
+    def __init__(self, voxel_size=10.0):
+        tomogram = SimpleNamespace(voxel_spacing=SimpleNamespace(voxel_size=voxel_size))
+        super().__init__(tomogram, CopickFeaturesMeta(tomo_type="test", feature_type="features"))
+        self.store = MemoryStore()
+
+    def zarr(self):
+        return self.store
+
+    def _delete_data(self):
+        raise NotImplementedError
+
+
+def _written_array(features):
+    group = zarr.open_group(features.zarr(), mode="r")
+    return group, group[get_level_path(group, 0)]
+
+
+@pytest.mark.parametrize("shape", [(4, 5, 6), (3, 4, 5, 6)])
+def test_feature_from_numpy_round_trips_supported_shapes(shape):
+    features = _MemoryFeatures(voxel_size=7.5)
+    values = np.arange(math.prod(shape), dtype=np.float32).reshape(shape)
+
+    features.from_numpy(values)
+
+    group, array = _written_array(features)
+    np.testing.assert_array_equal(features.numpy(), values)
+    assert Image.from_zarr(group).ome_zarr_version == "0.5"
+    if len(shape) == 3:
+        assert array.chunks == DEFAULT_SPATIAL_CHUNKS
+        assert array.shards == DEFAULT_SPATIAL_CHUNKS
+        assert array.metadata.dimension_names == ("z", "y", "x")
+        expected_axes = ["z", "y", "x"]
+        expected_scale = [7.5, 7.5, 7.5]
+    else:
+        assert array.chunks == (1, *DEFAULT_SPATIAL_CHUNKS)
+        assert array.shards == (1, *DEFAULT_SPATIAL_CHUNKS)
+        assert array.metadata.dimension_names == ("feature", "z", "y", "x")
+        expected_axes = ["feature", "z", "y", "x"]
+        expected_scale = [1.0, 7.5, 7.5, 7.5]
+        data_keys = {key for key in features.store._store_dict if not key.endswith("zarr.json")}
+        assert data_keys == {f"0/{feature}/0/0/0" for feature in range(shape[0])}
+
+    multiscale = get_multiscales(group)[0]
+    assert [axis["name"] for axis in multiscale["axes"]] == expected_axes
+    assert multiscale["datasets"][0]["coordinateTransformations"] == [{"type": "scale", "scale": expected_scale}]
+
+
+@pytest.mark.parametrize(
+    ("shape", "chunks", "shards", "expected_chunks", "expected_shards"),
+    [
+        ((3, 5, 7), (2, 3, 4), (4, 6, 8), (2, 3, 4), (4, 6, 8)),
+        ((3, 3, 5, 7), (2, 3, 4), None, (1, 2, 3, 4), (1, 4, 6, 8)),
+        ((3, 3, 5, 7), (2, 2, 3, 4), (2, 4, 6, 8), (2, 2, 3, 4), (2, 4, 6, 8)),
+    ],
+)
+def test_feature_from_numpy_honors_chunk_and_shard_overrides(
+    shape,
+    chunks,
+    shards,
+    expected_chunks,
+    expected_shards,
+):
+    features = _MemoryFeatures()
+    values = np.arange(math.prod(shape), dtype=np.int16).reshape(shape)
+
+    features.from_numpy(values, chunks=chunks, shards=shards)
+
+    _, array = _written_array(features)
+    assert array.chunks == expected_chunks
+    assert array.shards == expected_shards
+    np.testing.assert_array_equal(array[:], values)
+
+
+@pytest.mark.parametrize("shape", [(2, 3), (1, 2, 3, 4, 5)])
+def test_feature_from_numpy_rejects_unsupported_dimensions(shape):
+    features = _MemoryFeatures()
+    with pytest.raises(ValueError, match="must be 3D .* or 4D"):
+        features.from_numpy(np.zeros(shape))
+    assert not features.store._store_dict
+
+
+@pytest.mark.parametrize(
+    ("shape", "chunks", "shards", "message"),
+    [
+        ((2, 3, 4), (2, 2), None, "chunk"),
+        ((2, 3, 4, 5), (2, 2), None, "chunk"),
+        ((2, 3, 4, 5), (1, 2, 2, 2), (2, 4, 4), "shards"),
+    ],
+)
+def test_feature_from_numpy_rejects_dimension_mismatched_layouts(shape, chunks, shards, message):
+    features = _MemoryFeatures()
+    with pytest.raises(ValueError, match=message):
+        features.from_numpy(np.zeros(shape), chunks=chunks, shards=shards)
+    assert not features.store._store_dict
+
+
+def test_feature_from_numpy_dtype_override_and_region_write():
+    features = _MemoryFeatures()
+    values = np.arange(2 * 3 * 4 * 5).reshape(2, 3, 4, 5)
+    features.from_numpy(values, chunks=(2, 2, 2), dtype=np.float32)
+
+    replacement = np.full((1, 2, 2, 2), 99, dtype=np.float32)
+    selection = (slice(1, 2), slice(1, 3), slice(1, 3), slice(1, 3))
+    features.set_region(replacement, slices=selection)
+
+    result = features.numpy()
+    assert result.dtype == np.float32
+    np.testing.assert_array_equal(result[selection], replacement)
+
+
+def test_add_features_appends_shards_after_existing_parameters():
+    parameters = list(inspect.signature(add_features).parameters)
+    assert parameters[-1] == "shards"

--- a/tests/test_ops_add.py
+++ b/tests/test_ops_add.py
@@ -10,6 +10,7 @@ import mrcfile
 import numpy as np
 import pytest
 import zarr
+from copick.models import CopickFeatures
 from copick.ops.add import (
     add_features,
     add_object,
@@ -240,6 +241,47 @@ class TestAddFeatures:
         features_vol = np.random.randn(8, 8, 8).astype(np.float32)
         feat = add_features(root, "TS_001", 1.0, "feat-test-tomo", "sobel-test", features_vol, exist_ok=True)
         assert feat.feature_type == "sobel-test"
+        np.testing.assert_array_equal(feat.numpy(), features_vol)
+
+    def test_add_features_delegates_feature_major_write(self, test_payload, monkeypatch):
+        """The ops API preserves 4D feature-major data and delegates to the model API."""
+        root = test_payload["root"]
+        add_tomogram(
+            root,
+            "TS_001",
+            "feat-4d-tomo",
+            np.zeros((4, 5, 6), dtype=np.float32),
+            voxel_spacing=1.0,
+            exist_ok=True,
+        )
+        values = np.arange(2 * 4 * 5 * 6, dtype=np.float32).reshape(2, 4, 5, 6)
+        calls = []
+        original = CopickFeatures.from_numpy
+
+        def recording_from_numpy(self, data, **kwargs):
+            calls.append((data.shape, kwargs))
+            return original(self, data, **kwargs)
+
+        monkeypatch.setattr(CopickFeatures, "from_numpy", recording_from_numpy)
+        features = add_features(
+            root,
+            "TS_001",
+            1.0,
+            "feat-4d-tomo",
+            "multi",
+            values,
+            exist_ok=True,
+            chunks=(2, 3, 4),
+            shards=(1, 4, 6, 8),
+        )
+
+        assert calls == [
+            (
+                values.shape,
+                {"chunks": (2, 3, 4), "shards": (1, 4, 6, 8), "metadata": None},
+            ),
+        ]
+        np.testing.assert_array_equal(features.numpy(), values)
 
     def test_add_features_missing_tomogram_raises(self, test_payload):
         """Missing tomogram raises ValueError."""


### PR DESCRIPTION
## Summary

- route feature writes through the centralized OME-Zarr v3 writer
- support compatible 3D and 4D feature arrays
- expose opt-in layout overrides while keeping canonical defaults
- resolve feature maps at the voxel spacing supplied by the caller instead of always using 1.0

## Breaking change

Existing `add_features` calls with `voxel_spacing != 1.0` now place features under the requested tomogram. This fixes the previous routing bug but changes where those callers' output is stored.

## Stack

1. #414 — #371 centralized writer
2. #415 — #372 canonical layout policy
3. **#416 — #52 feature layouts (this PR)**
4. #417 — #373 semantic export
5. #418 — #375 layout-agnostic readers
6. #419 — #374 independent corpus parity

Part of #370. Depends on #415.
Closes #52

BREAKING CHANGE: `add_features` now resolves the voxel spacing supplied by the caller instead of always using 1.0, so non-1.0 calls write beneath their requested tomogram.
