### PR TITLE
feat: canonicalize single-level Zarr exports

### DIFF
--- a/src/copick/ops/export.py
+++ b/src/copick/ops/export.py
@@ -13,7 +13,7 @@ import zarr
 from zarr.storage import LocalStore
 
 from copick.util.log import get_logger
-from copick.util.ome import get_level_path, write_single_level_ome_zarr_v2
+from copick.util.ome import get_level_path, write_single_level_ome_zarr
 from copick.util.zarr_copy import copy_zarr_store, zarr_store_is_empty
 
 if TYPE_CHECKING:
@@ -535,7 +535,7 @@ def _export_tomogram_zarr(
         copy_zarr_store(source, target, if_exists="raise")
     else:
         source_group = zarr.open(source, mode="r")
-        write_single_level_ome_zarr_v2(source_group, target)
+        write_single_level_ome_zarr(source_group, target)
 
     if log:
         logging.info(f"Exported tomogram to Zarr: {output_path}")
@@ -726,7 +726,7 @@ def _export_segmentation_zarr(
         copy_zarr_store(source, target, if_exists="raise")
     else:
         source_group = zarr.open(source, mode="r")
-        write_single_level_ome_zarr_v2(source_group, target)
+        write_single_level_ome_zarr(source_group, target)
 
     if log:
         logging.info(f"Exported segmentation to Zarr: {output_path}")

--- a/src/copick/util/ome.py
+++ b/src/copick/util/ome.py
@@ -1,13 +1,13 @@
 import copy
 import itertools
 import math
+import tempfile
 import warnings
 from typing import Any, Dict, Iterator, List, Tuple, Union
 
 import numpy as np
 import psutil
 import zarr
-from numcodecs import Blosc
 from zarr.abc.store import Store
 from zarr.codecs import Shuffle, ZstdCodec
 
@@ -243,6 +243,7 @@ def write_ome_zarr(
     overwrite: bool = True,
     metadata: Any = _DEFAULT_WRITER_METADATA,
     shard_size: Union[Tuple[int, ...], None] = None,
+    coordinate_transformations: Union[List[List[Dict[str, Any]]], None] = None,
 ) -> None:
     """Write an OME-Zarr 0.5 / Zarr v3 pyramid with the canonical layout."""
     # These imports are intentionally lazy because importing ome-zarr is
@@ -256,6 +257,8 @@ def write_ome_zarr(
     chunks = _shape_tuple(chunk_size, ndim, "chunk_size")
     if len(axes) != ndim:
         raise ValueError(f"axes must contain exactly {ndim} entries, got {len(axes)}")
+    if coordinate_transformations is not None and len(coordinate_transformations) != len(pyramid):
+        raise ValueError("coordinate_transformations must contain one entry per pyramid level")
 
     layouts = []
     for array in pyramid.values():
@@ -283,17 +286,17 @@ def write_ome_zarr(
             dimension_names=dimension_names,
             overwrite=overwrite,
         )
-        datasets.append(
-            {
-                "path": path,
-                "coordinateTransformations": [
-                    {
-                        "scale": [1.0] * (ndim - 3) + [voxel_size, voxel_size, voxel_size],
-                        "type": "scale",
-                    },
-                ],
-            },
+        transformations = (
+            coordinate_transformations[level]
+            if coordinate_transformations is not None
+            else [
+                {
+                    "scale": [1.0] * (ndim - 3) + [voxel_size, voxel_size, voxel_size],
+                    "type": "scale",
+                },
+            ]
         )
+        datasets.append({"path": path, "coordinateTransformations": copy.deepcopy(transformations)})
 
     write_multiscales_metadata(
         root_group,
@@ -355,12 +358,12 @@ def copy_array_chunkwise(source: zarr.Array, target: zarr.Array) -> None:
         target[selection] = source[selection]
 
 
-def write_single_level_ome_zarr_v2(source_group: zarr.Group, target_store: Store, level: int = 0) -> None:
-    """Semantically export one OME level as OME-Zarr 0.4 / Zarr v2.
+def write_single_level_ome_zarr(source_group: zarr.Group, target_store: Store, level: int = 0) -> None:
+    """Semantically export one OME level as canonical OME-Zarr 0.5 / Zarr v3.
 
-    The destination is rebuilt instead of copying group attributes across a
-    format boundary.  Source values are decoded one inner chunk at a time, so
-    a sharded v3 source intentionally becomes an unsharded v2 array.
+    Source values are decoded one inner chunk at a time into a local memory map.
+    The completed level is then handed to the canonical writer once, avoiding
+    repeated remote rewrites of its volume-sized shard.
     """
     multiscales = get_multiscales(source_group)
     if not multiscales:
@@ -372,32 +375,49 @@ def write_single_level_ome_zarr_v2(source_group: zarr.Group, target_store: Store
 
     source_path = get_level_path(source_group, level)
     source_array = source_group[source_path]
-    target_path = "0"
     if not zarr_store_is_empty(target_store):
         raise FileExistsError("Single-level Zarr export target is not empty")
-    target_group = zarr.group(store=target_store, overwrite=True, zarr_format=2)
-    target_array = target_group.create_array(
-        target_path,
-        shape=source_array.shape,
-        dtype=source_array.dtype,
-        chunks=source_array.chunks,
-        fill_value=source_array.fill_value,
-        compressor=Blosc(cname="lz4", clevel=5, shuffle=Blosc.SHUFFLE),
-        chunk_key_encoding={"name": "v2", "separator": "/"},
-        attributes=dict(source_array.attrs),
-    )
-    copy_array_chunkwise(source_array, target_array)
 
-    dataset = copy.deepcopy(datasets[level])
-    dataset["path"] = target_path
-    rebuilt = {
-        key: copy.deepcopy(value)
-        for key, value in source_multiscale.items()
-        if key in {"axes", "metadata", "name", "type"}
+    axes = copy.deepcopy(source_multiscale.get("axes"))
+    if not isinstance(axes, list) or len(axes) != source_array.ndim:
+        raise ValueError("Source OME-Zarr axes do not match the exported array")
+    transformations = copy.deepcopy(datasets[level].get("coordinateTransformations"))
+    if not isinstance(transformations, list):
+        raise ValueError("Source OME-Zarr dataset has no coordinate transformations")
+
+    with tempfile.TemporaryDirectory(prefix="copick-zarr-export-") as directory:
+        staging = np.memmap(
+            f"{directory}/level.dat",
+            dtype=source_array.dtype,
+            mode="w+",
+            shape=source_array.shape,
+        )
+        copy_array_chunkwise(source_array, staging)
+        staging.flush()
+
+        writer_kwargs = {}
+        if "metadata" in source_multiscale:
+            writer_kwargs["metadata"] = copy.deepcopy(source_multiscale["metadata"])
+        write_ome_zarr(
+            target_store,
+            {1.0: staging},
+            axes,
+            DEFAULT_SPATIAL_CHUNKS,
+            coordinate_transformations=[transformations],
+            **writer_kwargs,
+        )
+        del staging
+
+    target_group = zarr.open_group(target_store, mode="r+")
+    target_array = target_group[get_level_path(target_group, 0)]
+    target_array.attrs.update(dict(source_array.attrs))
+    preserved_fields = {
+        key: copy.deepcopy(source_multiscale[key]) for key in ("name", "type") if key in source_multiscale
     }
-    rebuilt["version"] = "0.4"
-    rebuilt["datasets"] = [dataset]
-    target_group.attrs["multiscales"] = [rebuilt]
+    if preserved_fields:
+        ome = copy.deepcopy(target_group.attrs["ome"])
+        ome["multiscales"][0].update(preserved_fields)
+        target_group.attrs["ome"] = ome
 
 
 def get_multiscales(zarr_group: zarr.Group) -> List[Dict[str, Any]]:

--- a/tests/test_feature_writer.py
+++ b/tests/test_feature_writer.py
@@ -7,12 +7,11 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 import zarr
-from ome_zarr_models.v05.image import Image
-from zarr.storage import MemoryStore
-
 from copick.models import CopickFeatures, CopickFeaturesMeta
 from copick.ops.add import add_features
 from copick.util.ome import DEFAULT_SPATIAL_CHUNKS, get_level_path, get_multiscales
+from ome_zarr_models.v05.image import Image
+from zarr.storage import MemoryStore
 
 
 class _MemoryFeatures(CopickFeatures):

--- a/tests/test_manage_zarr.py
+++ b/tests/test_manage_zarr.py
@@ -21,7 +21,21 @@ def _project(tmp_path):
         name="source",
         is_multilabel=True,
     )
-    source.from_numpy(np.arange(64, dtype=np.int16).reshape(4, 4, 4))
+    values = np.arange(64, dtype=np.int16).reshape(4, 4, 4)
+    group = zarr.group(store=source.zarr(), overwrite=True, zarr_format=2)
+    group.create_array("0", data=values, chunks=(2, 2, 2), chunk_key_encoding={"name": "v2", "separator": "/"})
+    group.attrs["multiscales"] = [
+        {
+            "version": "0.4",
+            "axes": [{"name": axis, "type": "space", "unit": "angstrom"} for axis in ("z", "y", "x")],
+            "datasets": [
+                {
+                    "path": "0",
+                    "coordinateTransformations": [{"type": "scale", "scale": [10.0, 10.0, 10.0]}],
+                },
+            ],
+        },
+    ]
     return root, run, source
 
 

--- a/tests/test_single_level_export.py
+++ b/tests/test_single_level_export.py
@@ -6,11 +6,12 @@ import tracemalloc
 import numpy as np
 import pytest
 import zarr
-from copick.util.ome import copy_array_chunkwise, get_level_path, get_multiscales, write_single_level_ome_zarr_v2
-from ome_zarr.format import FormatV04
+from copick.util.ome import copy_array_chunkwise, get_level_path, get_multiscales, write_single_level_ome_zarr
+from ome_zarr.format import FormatV05
 from ome_zarr.io import parse_url
 from ome_zarr.reader import Reader
-from zarr.storage import LocalStore
+from ome_zarr_models.v05.image import Image
+from zarr.storage import LocalStore, MemoryStore
 
 
 def _source_group(path, zarr_format):
@@ -51,17 +52,18 @@ def _source_group(path, zarr_format):
 
 
 @pytest.mark.parametrize("source_format", [2, 3])
-def test_single_level_export_rebuilds_v2_metadata_and_preserves_array_contract(tmp_path, source_format):
+def test_single_level_export_rebuilds_canonical_v3_metadata_and_preserves_values(tmp_path, source_format):
     source, values = _source_group(tmp_path / "source.zarr", source_format)
     target_path = tmp_path / "target.zarr"
 
-    write_single_level_ome_zarr_v2(source, LocalStore(target_path))
+    write_single_level_ome_zarr(source, LocalStore(target_path))
 
     target = zarr.open_group(LocalStore(target_path), mode="r")
-    assert target.metadata.zarr_format == 2
-    assert set(target.attrs) == {"multiscales"}
-    multiscale = target.attrs["multiscales"][0]
-    assert multiscale["version"] == "0.4"
+    assert target.metadata.zarr_format == 3
+    assert set(target.attrs) == {"ome"}
+    assert target.attrs["ome"]["version"] == "0.5"
+    assert Image.from_zarr(target).ome_zarr_version == "0.5"
+    multiscale = target.attrs["ome"]["multiscales"][0]
     assert multiscale["axes"] == get_multiscales(source)[0]["axes"]
     assert multiscale["datasets"] == [
         {
@@ -74,13 +76,19 @@ def test_single_level_export_rebuilds_v2_metadata_and_preserves_array_contract(t
     exported = target[get_level_path(target, 0)]
     assert exported.dtype == source["s0"].dtype
     assert exported.shape == source["s0"].shape
-    assert exported.chunks == source["s0"].chunks
-    assert exported.fill_value == source["s0"].fill_value
+    assert exported.chunks == (128, 128, 128)
+    assert exported.shards == (128, 128, 128)
+    assert exported.metadata.dimension_names == ("z", "y", "x")
+    assert exported.metadata.chunk_key_encoding.to_dict() == {"name": "v2", "configuration": {"separator": "/"}}
     assert dict(exported.attrs) == dict(source["s0"].attrs)
     np.testing.assert_array_equal(exported[:], values)
-    assert not (target_path / "zarr.json").exists()
+    assert (target_path / "zarr.json").exists()
+    assert not (target_path / ".zgroup").exists()
 
-    location = parse_url(target_path, mode="r", fmt=FormatV04())
+    codec_names = [codec["name"] for codec in exported.metadata.to_dict()["codecs"][0]["configuration"]["codecs"]]
+    assert codec_names == ["bytes", "zstd"]
+
+    location = parse_url(target_path, mode="r", fmt=FormatV05())
     assert location is not None
     nodes = list(Reader(location)())
     assert len(nodes) == 1
@@ -120,10 +128,10 @@ def test_chunkwise_copy_bounds_every_read_to_one_inner_chunk():
         assert math.prod(extents) <= math.prod(source.chunks)
 
 
-def test_single_level_export_keeps_peak_python_memory_below_volume_size(tmp_path):
+def test_single_level_export_bounds_peak_python_memory_with_memmap_staging(tmp_path):
     source_path = tmp_path / "large-source.zarr"
     source = zarr.group(store=LocalStore(source_path), zarr_format=2)
-    shape = (512, 512, 512)
+    shape = (256, 256, 256)
     chunks = (64, 64, 64)
     source.create_array("s0", shape=shape, chunks=chunks, dtype="u1", fill_value=0)
     source.attrs["multiscales"] = [
@@ -134,23 +142,50 @@ def test_single_level_export_keeps_peak_python_memory_below_volume_size(tmp_path
                 {"name": "y", "type": "space"},
                 {"name": "x", "type": "space"},
             ],
-            "datasets": [{"path": "s0"}],
+            "datasets": [
+                {
+                    "path": "s0",
+                    "coordinateTransformations": [{"type": "scale", "scale": [1.0, 1.0, 1.0]}],
+                },
+            ],
         },
     ]
 
     tracemalloc.start()
     try:
-        write_single_level_ome_zarr_v2(source, LocalStore(tmp_path / "large-target.zarr"))
+        write_single_level_ome_zarr(source, LocalStore(tmp_path / "large-target.zarr"))
         _, peak_bytes = tracemalloc.get_traced_memory()
     finally:
         tracemalloc.stop()
 
     logical_volume_bytes = math.prod(shape)
-    assert peak_bytes < 32 * 1024 * 1024
-    assert peak_bytes < logical_volume_bytes // 4
+    assert peak_bytes < 64 * 1024 * 1024
+    assert peak_bytes < logical_volume_bytes * 4
 
     target = zarr.open_group(LocalStore(tmp_path / "large-target.zarr"), mode="r")
     target_array = target[get_level_path(target, 0)]
     assert target_array.shape == shape
-    assert target_array.chunks == chunks
+    assert target_array.chunks == (128, 128, 128)
+    assert target_array.shards == shape
     assert target_array[0, 0, 0] == 0
+
+
+class _RecordingMemoryStore(MemoryStore):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.written_keys = []
+
+    async def set(self, key, value):
+        self.written_keys.append(key)
+        await super().set(key, value)
+
+
+def test_single_level_export_writes_completed_remote_shard_once(tmp_path):
+    source, values = _source_group(tmp_path / "source.zarr", 2)
+    target = _RecordingMemoryStore()
+
+    write_single_level_ome_zarr(source, target)
+
+    assert target.written_keys.count("0/0/0/0") == 1
+    group = zarr.open_group(target, mode="r")
+    np.testing.assert_array_equal(group[get_level_path(group, 0)][:], values)


### PR DESCRIPTION
## Summary

- make semantic single-level exports use the canonical OME-Zarr v3 writer
- stage large arrays through bounded-memory memmaps
- retain byte-preserving behavior for raw all-level store copies

## Stack

1. #414 — #371 centralized writer
2. #415 — #372 canonical layout policy
3. #416 — #52 feature layouts
4. **#417 — #373 semantic export (this PR)**
5. #418 — #375 layout-agnostic readers
6. #419 — #374 independent corpus parity

Part of #370. Depends on #416.
Closes #373