### PR TITLE
fix!: harden the Zarr v3 cutover and corpus gates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,6 @@ on:
       - "LICENSE"
       - ".gitignore"
   pull_request:
-    branches:
-      - main
-      - v2.0
     paths-ignore:
       - "docs/**"
       - "*.md"
@@ -117,7 +114,7 @@ jobs:
           flags: local
 
   test-minimum-zarr:
-    name: ubuntu local py3.11 zarr3.1.6
+    name: ubuntu local py3.11 zarr3.1.6 ome-zarr0.12.2
     needs: prepare-test-corpus
     runs-on: ubuntu-latest
     env:
@@ -144,20 +141,77 @@ jobs:
       - name: Install copick
         run: uv sync --locked --extra test --extra dev
 
-      - name: Pin minimum Zarr
-        run: uv pip install --python .venv/bin/python "zarr==3.1.6"
+      - name: Pin minimum Zarr and ome-zarr
+        run: uv pip install --python .venv/bin/python "zarr==3.1.6" "ome-zarr==0.12.2"
 
-      - name: Verify Python and Zarr versions
+      - name: Verify Python, Zarr, and ome-zarr versions
         run: >
           uv run --no-sync python -c
-          "import sys, zarr; v = sys.version_info;
+          "import importlib.metadata, sys, zarr; v = sys.version_info;
           assert (v.major, v.minor) == (3, 11), sys.version;
           assert v.releaselevel == 'final', sys.version;
           assert zarr.__version__ == '3.1.6', zarr.__version__;
-          print(sys.version); print('zarr', zarr.__version__)"
+          ome_zarr_version = importlib.metadata.version('ome-zarr');
+          assert ome_zarr_version == '0.12.2', ome_zarr_version;
+          print(sys.version); print('zarr', zarr.__version__); print('ome-zarr', ome_zarr_version)"
 
       - name: Run tests
         run: uv run --no-sync pytest -vvv -p no:warnings --color=yes -n auto tests
+
+      - name: Run v3 corpus parity on dependency floors
+        env:
+          COPICK_TEST_ZARR_FORMAT: v3
+          RUN_ALL: 1
+        run: >
+          uv run --no-sync pytest -vvv -p no:warnings --color=yes
+          -m corpus_parity -n 0 tests/test_corpus_parity.py
+
+  test-latest-ome-zarr:
+    name: ubuntu local py3.13 ome-zarr0.18.0
+    needs: prepare-test-corpus
+    runs-on: ubuntu-latest
+    env:
+      BACKEND: local
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download shared test corpus
+        uses: actions/download-artifact@v7
+        with:
+          name: copick-test-corpus
+          path: ${{ env.COPICK_TEST_DATA_CACHE }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          version: "0.12.4"
+          python-version: "3.13"
+
+      - name: Check lockfile
+        run: uv lock --check
+
+      - name: Install copick
+        run: uv sync --locked --extra test --extra dev
+
+      - name: Pin ome-zarr 0.18.0
+        run: uv pip install --python .venv/bin/python "ome-zarr==0.18.0"
+
+      - name: Verify Python and ome-zarr versions
+        run: >
+          uv run --no-sync python -c
+          "import importlib.metadata, sys; v = sys.version_info;
+          assert (v.major, v.minor) == (3, 13), sys.version;
+          assert v.releaselevel == 'final', sys.version;
+          ome_zarr_version = importlib.metadata.version('ome-zarr');
+          assert ome_zarr_version == '0.18.0', ome_zarr_version;
+          print(sys.version); print('ome-zarr', ome_zarr_version)"
+
+      - name: Run ome-zarr compatibility tests
+        run: >
+          uv run --no-sync pytest -vvv -p no:warnings --color=yes -n auto
+          tests/test_ome_writer.py tests/test_feature_writer.py
+          tests/test_single_level_export.py tests/test_layout_agnostic_readers.py
 
   test-v3-corpus-parity:
     name: ubuntu ${{ matrix.backend }} v3 corpus py3.13
@@ -472,6 +526,16 @@ jobs:
         env:
           PLATFORM: ${{ matrix.platform }}
 
+      - name: Run v3 corpus parity on macOS
+        if: matrix.python-version == '3.13'
+        env:
+          BACKEND: local
+          COPICK_TEST_ZARR_FORMAT: v3
+          RUN_ALL: 1
+        run: >
+          uv run --no-sync pytest -vvv -p no:warnings --color=yes
+          -m corpus_parity -n 0 tests/test_corpus_parity.py
+
       - name: Coverage
         uses: codecov/codecov-action@v7
 
@@ -527,6 +591,16 @@ jobs:
         run: uv run pytest -vvv -p no:warnings --color=yes --cov --cov-branch --cov-report=xml --cov-report=term-missing -n auto tests
         env:
           PLATFORM: ${{ matrix.platform }}
+
+      - name: Run v3 corpus parity on Windows
+        if: matrix.python-version == '3.13'
+        env:
+          BACKEND: local
+          COPICK_TEST_ZARR_FORMAT: v3
+          RUN_ALL: 1
+        run: >
+          uv run --no-sync pytest -vvv -p no:warnings --color=yes
+          -m corpus_parity -n 0 tests/test_corpus_parity.py
 
       - name: Coverage
         uses: codecov/codecov-action@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,45 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  COPICK_TEST_DATA_CACHE: ${{ github.workspace }}/.test-data-cache
+
 jobs:
+  prepare-test-corpus:
+    name: prepare shared test corpus
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          version: "0.12.4"
+          python-version: "3.13"
+
+      - name: Restore verified corpus cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.COPICK_TEST_DATA_CACHE }}/sample_project.zip
+          key: copick-test-corpus-${{ hashFiles('tests/corpus_registry.py') }}
+
+      - name: Fetch and verify test corpus once
+        run: >
+          uv run --no-project --with pooch python
+          tests/scripts/fetch_test_corpus.py --cache "$COPICK_TEST_DATA_CACHE"
+
+      - name: Share test corpus with matrix jobs
+        uses: actions/upload-artifact@v7
+        with:
+          name: copick-test-corpus
+          path: ${{ env.COPICK_TEST_DATA_CACHE }}/sample_project.zip
+          if-no-files-found: error
+          retention-days: 1
+
   test-ubuntu-local:
     name: ubuntu local py${{ matrix.python-version }}
+    needs: prepare-test-corpus
     runs-on: ubuntu-latest
     env:
       BACKEND: local
@@ -44,6 +80,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Download shared test corpus
+        uses: actions/download-artifact@v7
+        with:
+          name: copick-test-corpus
+          path: ${{ env.COPICK_TEST_DATA_CACHE }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
@@ -76,12 +118,19 @@ jobs:
 
   test-minimum-zarr:
     name: ubuntu local py3.11 zarr3.1.6
+    needs: prepare-test-corpus
     runs-on: ubuntu-latest
     env:
       BACKEND: local
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Download shared test corpus
+        uses: actions/download-artifact@v7
+        with:
+          name: copick-test-corpus
+          path: ${{ env.COPICK_TEST_DATA_CACHE }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
@@ -110,14 +159,80 @@ jobs:
       - name: Run tests
         run: uv run --no-sync pytest -vvv -p no:warnings --color=yes -n auto tests
 
+  test-v3-corpus-parity:
+    name: ubuntu ${{ matrix.backend }} v3 corpus py3.13
+    needs: prepare-test-corpus
+    runs-on: ubuntu-latest
+    env:
+      BACKEND: ${{ matrix.backend }}
+      COPICK_TEST_ZARR_FORMAT: v3
+      RUN_ALL: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - backend: local
+            marker: corpus_parity
+            workers: auto
+          - backend: s3
+            marker: remote_corpus_parity
+            workers: 0
+          - backend: ssh
+            marker: remote_corpus_parity
+            workers: 0
+          - backend: mlcroissant
+            marker: remote_corpus_parity
+            workers: 0
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download shared test corpus
+        uses: actions/download-artifact@v7
+        with:
+          name: copick-test-corpus
+          path: ${{ env.COPICK_TEST_DATA_CACHE }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          version: "0.12.4"
+          python-version: "3.13"
+
+      - name: Check lockfile
+        run: uv lock --check
+
+      - name: Install copick
+        run: uv sync --locked --extra test --extra dev
+
+      - name: Verify Python version
+        run: >
+          uv run --no-sync python -c
+          "import sys; v = sys.version_info;
+          assert (v.major, v.minor) == (3, 13), sys.version;
+          assert v.releaselevel == 'final', sys.version;
+          print(sys.version)"
+
+      - name: Run selected-corpus parity tests
+        run: >
+          uv run --no-sync pytest -vvv -p no:warnings --color=yes
+          -m ${{ matrix.marker }} -n ${{ matrix.workers }} tests
+
   test-portal:
     name: ubuntu live portal py3.13
+    needs: prepare-test-corpus
     runs-on: ubuntu-latest
     env:
       BACKEND: local
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Download shared test corpus
+        uses: actions/download-artifact@v7
+        with:
+          name: copick-test-corpus
+          path: ${{ env.COPICK_TEST_DATA_CACHE }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
@@ -144,6 +259,7 @@ jobs:
 
   test-ubuntu-s3:
     name: ubuntu s3 py${{ matrix.python-version }}
+    needs: prepare-test-corpus
     runs-on: ubuntu-latest
     env:
       BACKEND: s3
@@ -159,6 +275,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Download shared test corpus
+        uses: actions/download-artifact@v7
+        with:
+          name: copick-test-corpus
+          path: ${{ env.COPICK_TEST_DATA_CACHE }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
@@ -191,6 +313,7 @@ jobs:
 
   test-ubuntu-ssh:
     name: ubuntu ssh py${{ matrix.python-version }}
+    needs: prepare-test-corpus
     runs-on: ubuntu-latest
     env:
       BACKEND: ssh
@@ -206,6 +329,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Download shared test corpus
+        uses: actions/download-artifact@v7
+        with:
+          name: copick-test-corpus
+          path: ${{ env.COPICK_TEST_DATA_CACHE }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
@@ -238,6 +367,7 @@ jobs:
 
   test-ubuntu-mlcroissant:
     name: ubuntu mlcroissant py${{ matrix.python-version }}
+    needs: prepare-test-corpus
     runs-on: ubuntu-latest
     env:
       BACKEND: mlcroissant
@@ -253,6 +383,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Download shared test corpus
+        uses: actions/download-artifact@v7
+        with:
+          name: copick-test-corpus
+          path: ${{ env.COPICK_TEST_DATA_CACHE }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
@@ -285,6 +421,7 @@ jobs:
 
   test-macos:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
+    needs: prepare-test-corpus
     runs-on: ${{ matrix.platform }}
     env:
       RUN_ALL: 0
@@ -302,6 +439,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Download shared test corpus
+        uses: actions/download-artifact@v7
+        with:
+          name: copick-test-corpus
+          path: ${{ env.COPICK_TEST_DATA_CACHE }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
@@ -334,6 +477,7 @@ jobs:
 
   test-windows:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
+    needs: prepare-test-corpus
     runs-on: ${{ matrix.platform }}
     env:
       RUN_ALL: 0
@@ -351,6 +495,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Download shared test corpus
+        uses: actions/download-artifact@v7
+        with:
+          name: copick-test-corpus
+          path: ${{ env.COPICK_TEST_DATA_CACHE }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pip install "copick[all]"
 
 ## Example dataset
 
-An example dataset can be obtained from [Zenodo](https://doi.org/10.5281/zenodo.19686100).
+An example dataset can be obtained from [Zenodo](https://doi.org/10.5281/zenodo.21939821).
 
 To test with the example dataset:
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,15 @@ pip install "copick[all]"
 > [!NOTE]
 > `copick>=1.2.0` will fail to install with `pip~=25.1.0`. We recommend using `pip>=25.2` or  [`uv pip`](https://docs.astral.sh/uv/pip/) when installing copick.
 
+> [!IMPORTANT]
+> copick 2.0 creates and rebuilds image pyramids as OME-Zarr 0.5 backed by Zarr v3. Existing Zarr v2 projects remain
+> readable, and whole-store copy operations preserve their original format and layout.
+
 
 ## Example dataset
 
-An example dataset can be obtained from [Zenodo](https://doi.org/10.5281/zenodo.21939821).
+An example dataset can be obtained from [Zenodo](https://doi.org/10.5281/zenodo.21939821). The migration-test archive
+contains both the legacy Zarr v2 project and its Zarr v3 twin, so it is larger than the earlier single-format example.
 
 To test with the example dataset:
 

--- a/docs/api_reference/functional/add.md
+++ b/docs/api_reference/functional/add.md
@@ -34,6 +34,10 @@ The `copick.ops.add` module provides functions for adding data to Copick project
         show_root_heading: true
         show_root_full_path: true
 
+`voxel_spacing` selects the tomogram that owns the feature map; it is not normalized to `1.0`. When a matching feature
+already exists, pass both `exist_ok=True` and `overwrite=True` to replace its array. With `exist_ok=True` and
+`overwrite=False`, `add_features` raises `FileExistsError` and leaves the stored data unchanged.
+
 ## Usage Examples
 
 ### Adding a Run
@@ -82,6 +86,8 @@ features = add_features(
     tomo_type="wbp",
     feature_type="membrane_segmentation",
     features_vol=segmentation_volume,
+    exist_ok=True,
+    overwrite=True,
     log=True
 )
 ```

--- a/docs/examples/setup/aws_s3.md
+++ b/docs/examples/setup/aws_s3.md
@@ -6,6 +6,10 @@
 
 In copick, a project has an overlay and (optionally) a static part. The overlay is where all user-created entities are stored and is writable. The static part is read-only and contains the input data. There are four ways of setting up local **copick** projects via AWS or local S3 buckets (e.g. MinIO):
 
+Writable S3 overlays must allow creation of every object prefix needed below `overlay_root`. Copick materializes Zarr v3
+groups and arrays directly in that prefix, so credentials and endpoint policies must permit creating parent prefixes as
+well as writing and deleting object keys.
+
 <div class="grid cards" markdown>
 
 -   :fontawesome-solid-hard-drive:{ .lg .middle }   __Option 1__: S3 overlay-only

--- a/docs/examples/setup/ssh.md
+++ b/docs/examples/setup/ssh.md
@@ -6,6 +6,10 @@
 
 In copick, a project has an overlay and (optionally) a static part. The overlay is where all user-created entities are stored and is writable. The static part is read-only and contains the input data. There are four ways of setting up SSH-based **copick** projects:
 
+Writable SSH overlays must permit creation of intermediate directories below `overlay_root`. Copick materializes Zarr
+v3 groups and arrays there, so write access to an existing root directory alone is insufficient when parent-directory
+creation is disabled.
+
 <div class="grid cards" markdown>
 
 -   :fontawesome-solid-hard-drive:{ .lg .middle }   __Option 1__: SSH overlay-only

--- a/docs/templates/instructions/s3_overlay.md
+++ b/docs/templates/instructions/s3_overlay.md
@@ -2,6 +2,9 @@
 
 This S3 URI will contain all newly created data for your project.
 
+The credentials and bucket policy must allow copick to create all object prefixes below `overlay_root`, and to write and
+delete the Zarr metadata and data keys stored there.
+
 Make sure the intended S3 bucket is writable:
 ```bash
 echo "Hello, World!" > test.txt

--- a/docs/templates/instructions/ssh_overlay.md
+++ b/docs/templates/instructions/ssh_overlay.md
@@ -2,6 +2,9 @@
 
 This directory will contain all newly created data for your project.
 
+The SSH account must be able to create intermediate directories below `overlay_root`; Zarr v3 entities cannot be
+materialized if only the already-existing root directory is writable.
+
 !!! note "SSH authentication"
     Copick will work best via SSH if you have set up passwordless SSH authentication. Refer to the
     [SSH documentation](https://www.ssh.com/ssh/copy-id) for more information. In general, adding plain text passwords

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,9 @@ minversion = "6.0"
 testpaths = ["tests"]
 addopts = "-m 'not portal'"
 markers = [
+    "corpus_parity: tests whose behavior depends on the selected v2/v3 test corpus",
     "portal: live CryoET Data Portal integration tests",
+    "remote_corpus_parity: focused selected-corpus tests for remote backend parity",
 ]
 
 [tool.coverage.report]

--- a/src/copick/models.py
+++ b/src/copick/models.py
@@ -11,7 +11,7 @@ from copick.util.ome import (
     DEFAULT_SPATIAL_CHUNKS,
     fits_in_memory,
     get_level_path,
-    initialize_zarr_v2,
+    initialize_zarr_v3,
     ome_zarr_axes,
     padded_shard_shape,
     segmentation_pyramid,
@@ -1368,8 +1368,8 @@ class CopickRun:
 
             self._segmentations.append(seg)
 
-            # Materialize the new entity as an explicit Zarr v2 group.
-            initialize_zarr_v2(seg.zarr())
+            # Materialize the new entity as an explicit Zarr v3 group.
+            initialize_zarr_v3(seg.zarr())
 
         return seg
 
@@ -1644,8 +1644,8 @@ class CopickVoxelSpacing:
                 self._tomograms = []
             self._tomograms.append(tomo)
 
-            # Materialize the new entity as an explicit Zarr v2 group.
-            initialize_zarr_v2(tomo.zarr())
+            # Materialize the new entity as an explicit Zarr v3 group.
+            initialize_zarr_v3(tomo.zarr())
 
         return tomo
 
@@ -1800,8 +1800,8 @@ class CopickTomogram:
 
             self._features.append(feat)
 
-            # Materialize the new entity as an explicit Zarr v2 group.
-            initialize_zarr_v2(feat.zarr())
+            # Materialize the new entity as an explicit Zarr v3 group.
+            initialize_zarr_v3(feat.zarr())
 
         return feat
 
@@ -2015,6 +2015,7 @@ class CopickFeatures:
         shards: Optional[Tuple[int, ...]] = None,
         dtype: Optional[np.dtype] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        overwrite: bool = True,
     ) -> None:
         """Write a 3D or feature-major 4D feature array.
 
@@ -2024,6 +2025,7 @@ class CopickFeatures:
             shards: Optional dimension-matched shard shape.
             dtype: Optional dtype conversion applied before writing.
             metadata: Optional OME multiscale metadata payload.
+            overwrite: Replace an existing feature array. Defaults to True for backward compatibility.
         """
         array = np.asarray(data, dtype=dtype)
         if array.ndim not in (3, 4):
@@ -2053,6 +2055,7 @@ class CopickFeatures:
             effective_chunks,
             metadata=metadata,
             shard_size=effective_shards,
+            overwrite=overwrite,
         )
 
     def set_region(

--- a/src/copick/ops/add.py
+++ b/src/copick/ops/add.py
@@ -366,18 +366,15 @@ def add_features(
             logging.exception(e)
         raise e
 
-    existing_features = tomogram.get_features(feature_type)
-
     # Create the features
     features = tomogram.new_features(feature_type, exist_ok=exist_ok)
-    if existing_features is not None and not overwrite:
-        return features
 
     features.from_numpy(
         features_vol,
         chunks=chunks,
         shards=shards,
         metadata=meta,
+        overwrite=overwrite,
     )
 
     # Log

--- a/src/copick/util/ome.py
+++ b/src/copick/util/ome.py
@@ -3,6 +3,7 @@ import itertools
 import math
 import tempfile
 import warnings
+from collections.abc import Mapping
 from typing import Any, Dict, Iterator, List, Tuple, Union
 
 import numpy as np
@@ -10,13 +11,13 @@ import psutil
 import zarr
 from zarr.abc.store import Store
 from zarr.codecs import Shuffle, ZstdCodec
+from zarr.storage import LocalStore
 
 from copick.util.log import get_logger
-from copick.util.zarr_copy import zarr_store_is_empty
+from copick.util.zarr_copy import prepare_zarr_store_for_write, zarr_store_is_empty
 
 logger = get_logger(__name__)
 
-_DEFAULT_WRITER_METADATA = object()
 DEFAULT_SPATIAL_CHUNKS = (128, 128, 128)
 _SHARD_WARNING_BYTES = 5 * 1000**3
 _SHARD_LIMIT_BYTES = 5 * 1000**4
@@ -70,9 +71,14 @@ def zarr_root_exists(fs: Any, path: str) -> bool:
     return fs.exists(f"{root}/.zgroup") or fs.exists(f"{root}/zarr.json")
 
 
-def initialize_zarr_v2(store: Union[str, Store]) -> None:
-    """Materialize an empty Zarr v2 group in a new entity store."""
-    zarr.group(store=store, overwrite=False, zarr_format=2)
+def initialize_zarr_v3(store: Union[str, Store]) -> None:
+    """Materialize an empty Zarr v3 group in a new entity store."""
+    zarr.group(store=store, overwrite=False, zarr_format=3)
+
+
+def _writer_store(store: Union[str, Store]) -> Store:
+    """Normalize the writer's local-path convenience input to a Zarr store."""
+    return LocalStore(store) if isinstance(store, str) else store
 
 
 def _ome_zarr_axes() -> List[Dict[str, str]]:
@@ -241,7 +247,7 @@ def write_ome_zarr(
     axes: List[Dict[str, str]],
     chunk_size: Tuple[int, ...],
     overwrite: bool = True,
-    metadata: Any = _DEFAULT_WRITER_METADATA,
+    metadata: Union[Mapping[str, Any], None] = None,
     shard_size: Union[Tuple[int, ...], None] = None,
     coordinate_transformations: Union[List[List[Dict[str, Any]]], None] = None,
 ) -> None:
@@ -259,6 +265,9 @@ def write_ome_zarr(
         raise ValueError(f"axes must contain exactly {ndim} entries, got {len(axes)}")
     if coordinate_transformations is not None and len(coordinate_transformations) != len(pyramid):
         raise ValueError("coordinate_transformations must contain one entry per pyramid level")
+    if metadata is not None and not isinstance(metadata, Mapping):
+        raise TypeError("metadata must be a mapping or None")
+    writer_metadata = {} if metadata is None else copy.deepcopy(dict(metadata))
 
     layouts = []
     for array in pyramid.values():
@@ -268,9 +277,9 @@ def write_ome_zarr(
         _preflight_shard_size(shards, array.dtype)
         layouts.append((shards, canonical_v3_compressors(array.dtype)))
 
-    root_group = zarr.group(store=store, overwrite=overwrite, zarr_format=3)
-    writer_metadata = {} if metadata is _DEFAULT_WRITER_METADATA else metadata
-    ome_zarr_metadata = writer_metadata if isinstance(writer_metadata, dict) else {}
+    target_store = _writer_store(store)
+    prepare_zarr_store_for_write(target_store, overwrite)
+    root_group = zarr.group(store=target_store, overwrite=overwrite, zarr_format=3)
 
     datasets = []
     dimension_names = tuple(axis["name"] for axis in axes)
@@ -303,9 +312,9 @@ def write_ome_zarr(
         datasets,
         fmt=FormatV05(),
         axes=axes,
-        metadata=ome_zarr_metadata,
+        metadata=writer_metadata,
     )
-    if metadata is not _DEFAULT_WRITER_METADATA:
+    if metadata is not None:
         ome = copy.deepcopy(root_group.attrs["ome"])
         ome["multiscales"][0]["metadata"] = copy.deepcopy(writer_metadata)
         root_group.attrs["ome"] = ome
@@ -316,7 +325,7 @@ def write_ome_zarr_3d(
     pyramid: Dict[float, np.ndarray],
     chunk_size: Tuple[int, ...] = DEFAULT_SPATIAL_CHUNKS,
     overwrite: bool = True,
-    metadata: Any = _DEFAULT_WRITER_METADATA,
+    metadata: Union[Mapping[str, Any], None] = None,
     shard_size: Union[Tuple[int, ...], None] = None,
 ) -> None:
     """Write a 3D pyramid as OME-Zarr 0.5 / Zarr v3.
@@ -326,7 +335,7 @@ def write_ome_zarr_3d(
         pyramid: The pyramid to write.
         chunk_size: Inner chunk shape. Default is ``(128, 128, 128)``.
         overwrite: Whether to overwrite an existing group and arrays.
-        metadata: Additional OME multiscale metadata. When omitted, preserve the existing empty metadata mapping.
+        metadata: Additional OME multiscale metadata. ``None`` omits the optional metadata field.
         shard_size: Optional explicit shard shape. By default, one padded logical shard is used per level.
     """
     for array in pyramid.values():
@@ -375,6 +384,8 @@ def write_single_level_ome_zarr(source_group: zarr.Group, target_store: Store, l
 
     source_path = get_level_path(source_group, level)
     source_array = source_group[source_path]
+    if source_array.ndim not in (3, 4):
+        raise ValueError(f"Single-level OME-Zarr export supports 3D or 4D arrays, got {source_array.ndim} dimensions")
     if not zarr_store_is_empty(target_store):
         raise FileExistsError("Single-level Zarr export target is not empty")
 
@@ -398,11 +409,12 @@ def write_single_level_ome_zarr(source_group: zarr.Group, target_store: Store, l
         writer_kwargs = {}
         if "metadata" in source_multiscale:
             writer_kwargs["metadata"] = copy.deepcopy(source_multiscale["metadata"])
+        chunk_size = DEFAULT_SPATIAL_CHUNKS if source_array.ndim == 3 else (1, *DEFAULT_SPATIAL_CHUNKS)
         write_ome_zarr(
             target_store,
             {1.0: staging},
             axes,
-            DEFAULT_SPATIAL_CHUNKS,
+            chunk_size,
             coordinate_transformations=[transformations],
             **writer_kwargs,
         )

--- a/src/copick/util/zarr_copy.py
+++ b/src/copick/util/zarr_copy.py
@@ -159,6 +159,34 @@ def zarr_store_is_empty(store: Store) -> bool:
     return _zarr_sync(store.is_empty(""))
 
 
+async def _prepare_store_for_write(store: Store, overwrite: bool) -> None:
+    keys = await _list_keys(store)
+    if not keys:
+        return
+
+    if await _is_materialized_empty_group(store, keys):
+        # A bare v3 group is already the desired writable container. A bare
+        # v2 group is the legacy entity-materialization contract; remove only
+        # its root metadata so the v3 writer cannot leave a mixed hierarchy.
+        if ".zgroup" in keys:
+            for key in keys:
+                await store.delete(key)
+        return
+
+    if not overwrite:
+        raise FileExistsError("Zarr write target is not empty")
+
+
+def prepare_zarr_store_for_write(store: Store, overwrite: bool) -> None:
+    """Validate a writer target and clean up a bare legacy v2 group.
+
+    Populated targets are rejected before mutation unless ``overwrite`` is
+    enabled. Bare groups materialized by copick are treated as empty, and a
+    bare v2 group is converted without leaving v2 metadata beside v3 output.
+    """
+    _zarr_sync(_prepare_store_for_write(store, overwrite))
+
+
 def _digest(data: bytes) -> _KeyDigest:
     return _KeyDigest(size=len(data), sha256=hashlib.sha256(data).digest())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,19 +10,32 @@ from pathlib import Path, PurePath
 import fsspec
 import pooch
 import pytest
+from corpus_registry import ARCHIVE_NAME, CORPUS_DIGEST, CORPUS_DOI
 
 # Directory containing this conftest.py file - used for resolving relative paths
 TESTS_DIR = Path(__file__).parent
 DOCKER_COMPOSE_FILE = TESTS_DIR / "docker-compose.yml"
 
-OZ = pooch.os_cache("test_data")  # Path("/Users/utz.ermel/Documents/copick/testproject")  # pooch.os_cache("test_data")
+OZ = Path(os.environ.get("COPICK_TEST_DATA_CACHE", pooch.os_cache("test_data")))
 TOTO = pooch.create(
     path=OZ,
-    base_url="doi:10.5281/zenodo.19686100",
+    base_url=f"doi:{CORPUS_DOI}",
     registry={
-        "sample_project.zip": "md5:8b8941350af1f621effd4903e75255c0",
+        "sample_project.zip": CORPUS_DIGEST,
     },
 )
+TEST_ZARR_FORMAT = os.environ.get("COPICK_TEST_ZARR_FORMAT", "v2").lower()
+if TEST_ZARR_FORMAT not in {"v2", "v3"}:
+    raise ValueError("COPICK_TEST_ZARR_FORMAT must be either 'v2' or 'v3'")
+CORPUS_SUFFIX = "_v3" if TEST_ZARR_FORMAT == "v3" else ""
+CORPUS_FIXTURE_NAMES = {
+    "base_config",
+    "base_config_overlay_only",
+    "base_overlay_directory",
+    "base_project_directory",
+    "local_path",
+    "test_payload",
+}
 
 # Determine if all tests should be run
 RUN_ALL = bool(int(os.environ.get("RUN_ALL", 1)))
@@ -30,6 +43,52 @@ RUN_ALL = bool(int(os.environ.get("RUN_ALL", 1)))
 BACKEND = os.environ.get("BACKEND", "all")
 
 CLEANUP = True
+
+
+def ensure_test_data(corpus=TOTO, *, zarr_format: str = TEST_ZARR_FORMAT) -> Path:
+    """Fetch and extract the corpus selected by its registry digest.
+
+    Fetching on every session lets pooch validate the cached archive. The
+    extraction sentinel prevents a valid archive from being paired with a
+    stale, previously extracted directory.
+    """
+    if zarr_format not in {"v2", "v3"}:
+        raise ValueError("zarr_format must be either 'v2' or 'v3'")
+
+    cache_path = Path(corpus.path)
+    archive_path = Path(corpus.fetch(ARCHIVE_NAME))
+    registry_digest = corpus.registry[ARCHIVE_NAME]
+    extract_path = cache_path / "sample_project"
+    suffix = "_v3" if zarr_format == "v3" else ""
+    required = (
+        extract_path / f"sample_project{suffix}",
+        extract_path / f"sample_overlay{suffix}",
+        extract_path / f"filesystem{suffix}.json",
+        extract_path / f"filesystem_overlay_only{suffix}.json",
+    )
+    sentinel = extract_path / ".archive-digest"
+    if (
+        sentinel.is_file()
+        and sentinel.read_text(encoding="utf-8").strip() == registry_digest
+        and all(path.exists() for path in required)
+    ):
+        return extract_path
+
+    staging_path = Path(tempfile.mkdtemp(prefix=".sample_project-stage-", dir=cache_path))
+    try:
+        pooch.Unzip(extract_dir=staging_path.name)(str(archive_path), "update", corpus)
+        staged_required = tuple(staging_path / path.relative_to(extract_path) for path in required)
+        missing = [str(path.relative_to(staging_path)) for path in staged_required if not path.exists()]
+        if missing:
+            raise FileNotFoundError(f"Corpus archive is missing required {zarr_format} paths: {missing}")
+        (staging_path / ".archive-digest").write_text(f"{registry_digest}\n", encoding="utf-8")
+        if extract_path.exists():
+            shutil.rmtree(extract_path)
+        staging_path.replace(extract_path)
+    finally:
+        if staging_path.exists():
+            shutil.rmtree(staging_path)
+    return extract_path
 
 
 def _copytree_world_writable(src: Path, dst: Path):
@@ -51,22 +110,22 @@ def local_path() -> Path:
 
 @pytest.fixture(scope="session")
 def base_project_directory(local_path) -> Path:
-    return local_path / "sample_project"
+    return local_path / f"sample_project{CORPUS_SUFFIX}"
 
 
 @pytest.fixture(scope="session")
 def base_overlay_directory(local_path) -> Path:
-    return local_path / "sample_overlay"
+    return local_path / f"sample_overlay{CORPUS_SUFFIX}"
 
 
 @pytest.fixture(scope="session")
 def base_config_overlay_only(local_path) -> Path:
-    return local_path / "filesystem_overlay_only.json"
+    return local_path / f"filesystem_overlay_only{CORPUS_SUFFIX}.json"
 
 
 @pytest.fixture(scope="session")
 def base_config(local_path) -> Path:
-    return local_path / "filesystem.json"
+    return local_path / f"filesystem{CORPUS_SUFFIX}.json"
 
 
 COMMON_CASES = []
@@ -681,11 +740,17 @@ if BACKEND in ("all", "smb") and importlib_util.find_spec("smbclient") and RUN_A
 def pytest_configure(config):
     # Pre-extract test data in the controller process before xdist workers spawn.
     # This avoids race conditions where multiple workers try to unzip simultaneously.
-    extract_path = OZ / "sample_project"
-    if not (extract_path / "sample_project").exists():
-        # Remove partial extractions if any
-        if extract_path.exists():
-            shutil.rmtree(extract_path)
-        TOTO.fetch("sample_project.zip", processor=pooch.Unzip(extract_dir="sample_project"))
+    ensure_test_data()
 
     pytest.common_cases = COMMON_CASES
+
+
+def pytest_collection_modifyitems(items):
+    """Tag only tests that consume the selected corpus for parity CI."""
+    for item in items:
+        callspec = getattr(item, "callspec", None)
+        uses_backend_case = callspec is not None and any(
+            value in COMMON_CASES for value in callspec.params.values() if isinstance(value, str)
+        )
+        if CORPUS_FIXTURE_NAMES.intersection(item.fixturenames) or uses_backend_case:
+            item.add_marker("corpus_parity")

--- a/tests/corpus_registry.py
+++ b/tests/corpus_registry.py
@@ -1,0 +1,7 @@
+"""Single source of truth for the immutable test-corpus archive."""
+
+import os
+
+ARCHIVE_NAME = "sample_project.zip"
+CORPUS_DOI = os.environ.get("COPICK_TEST_DATA_DOI", "10.5281/zenodo.21939821")
+CORPUS_DIGEST = os.environ.get("COPICK_TEST_DATA_DIGEST", "md5:05b1582e675719d3f1bb23349c20b86c")

--- a/tests/scripts/README.md
+++ b/tests/scripts/README.md
@@ -12,6 +12,37 @@ must be uploaded to Zenodo (as a new version of record 19686100, or a new
 record) and `copick/tests/conftest.py:18-25` must be updated with the new DOI
 and md5 so pooch pulls the new version.
 
+## Building the independent Zarr v3 twin
+
+```bash
+python copick/tests/scripts/build_v3_twin.py \
+  /path/to/current/sample_project.zip \
+  --output /tmp/sample_project.zip
+```
+
+`build_v3_twin.py` deliberately imports zarr, ome-zarr, and
+ome-zarr-models directly and must never import copick. It retains every legacy
+file, adds sibling `sample_project_v3`, `sample_overlay_v3`, and v3 config
+paths, independently converts all 23 stores and 61 arrays, and adds a
+standalone feature-major 4D fixture. It validates each converted image and
+compares its decoded values with the legacy source before emitting the zip.
+The archive writer fixes timestamps and permissions, so repeated builds from
+the same source have identical hashes.
+
+Before publishing, build the archive twice, compare its MD5 and SHA-256, then
+run both selections from a cold cache and again from the populated cache:
+
+```bash
+COPICK_TEST_ZARR_FORMAT=v2 pytest -m corpus_parity tests
+COPICK_TEST_ZARR_FORMAT=v3 pytest -m corpus_parity tests
+```
+
+The default is `v2`; format-insensitive tests therefore continue to run only
+once. CI sets `COPICK_TEST_ZARR_FORMAT=v3` in dedicated local, S3, SSH, and ML
+Croissant parity jobs. Corpus extraction is keyed by the pooch registry digest
+rather than directory existence, so changing the registered archive forces a
+fresh extraction even when the old directory is still cached.
+
 ## Regenerating `sample_project.zip` with Croissant sidecars
 
 ```bash
@@ -20,7 +51,7 @@ python copick/tests/scripts/regenerate_sample_zip.py --output-dir /tmp
 
 The script:
 
-1. Downloads the current `sample_project.zip` from `doi:10.5281/zenodo.19686100` (updated as new versions are published; see `regenerate_sample_zip.py::CURRENT_DOI`)
+1. Downloads the current `sample_project.zip` from `doi:10.5281/zenodo.21939821` (updated as new versions are published; see `regenerate_sample_zip.py::CURRENT_DOI`)
    via pooch (reusing the existing cache when possible).
 2. Extracts it to a temp directory.
 3. Loads the filesystem project and calls `copick.ops.croissant.export_croissant`
@@ -35,15 +66,17 @@ The script:
 
 1. Go to <https://zenodo.org/record/19686100> and create a new version (or a
    new record).
-2. Upload the regenerated `sample_project.zip`.
-3. Publish. Zenodo assigns a new DOI (`10.5281/zenodo.<NEW-RECORD-ID>`).
+2. Upload the exact validated `sample_project.zip` without renaming it.
+3. Publish and record the immutable, version-specific DOI (not only the
+   concept DOI). Zenodo assigns a DOI such as
+   `10.5281/zenodo.<NEW-RECORD-ID>`.
 
 ## Updating `conftest.py`
 
 Edit `copick/tests/conftest.py` lines 18–25:
 
 ```python
-OZ = pooch.os_cache("test_data")
+OZ = Path(os.environ.get("COPICK_TEST_DATA_CACHE", pooch.os_cache("test_data")))
 TOTO = pooch.create(
     path=OZ,
     base_url="doi:10.5281/zenodo.<NEW-RECORD-ID>",
@@ -54,6 +87,14 @@ TOTO = pooch.create(
 ```
 
 The next test run pulls the new archive into the local pooch cache.
+
+`tests/corpus_registry.py` is the single source of truth for these values.
+The `prepare-test-corpus` CI job first restores a digest-keyed Actions cache,
+runs `fetch_test_corpus.py` once to verify or fetch the zip, and uploads the
+verified file as a short-lived workflow artifact. Every test-matrix runner
+downloads that artifact into `COPICK_TEST_DATA_CACHE`. This avoids concurrent
+Zenodo downloads and the resulting rate-limit failures; repeated runs for the
+same corpus normally make no Zenodo request at all.
 
 ## Flags
 

--- a/tests/scripts/build_v3_twin.py
+++ b/tests/scripts/build_v3_twin.py
@@ -185,14 +185,17 @@ def _copy_config(source: Path, target: Path) -> None:
     config = json.loads(source.read_text(encoding="utf-8"))
     for key in ("static_root", "overlay_root"):
         if isinstance(config.get(key), str):
-            config[key] = (
-                config[key]
-                .replace("sample_project", "sample_project_v3")
-                .replace(
-                    "sample_overlay",
-                    "sample_overlay_v3",
-                )
-            )
+            value = config[key]
+            stripped = value.rstrip("/\\")
+            trailing = value[len(stripped) :]
+            for legacy_name, v3_name in (
+                ("sample_project", "sample_project_v3"),
+                ("sample_overlay", "sample_overlay_v3"),
+            ):
+                if stripped == legacy_name or stripped.endswith((f"/{legacy_name}", f"\\{legacy_name}")):
+                    stripped = f"{stripped[: -len(legacy_name)]}{v3_name}"
+                    break
+            config[key] = f"{stripped}{trailing}"
     target.write_text(json.dumps(config, indent=4) + "\n", encoding="utf-8")
 
 

--- a/tests/scripts/build_v3_twin.py
+++ b/tests/scripts/build_v3_twin.py
@@ -1,0 +1,288 @@
+"""Build the independent OME-Zarr 0.5 / Zarr v3 test-corpus twin.
+
+This script intentionally imports zarr, ome-zarr, and ome-zarr-models directly;
+it never imports copick. The legacy corpus is copied byte-for-byte and retained
+beside new ``*_v3`` project, overlay, and configuration paths.
+
+Usage:
+    python tests/scripts/build_v3_twin.py SOURCE --output sample_project.zip
+
+``SOURCE`` may be the extracted archive root or the legacy zip itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import math
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import zarr
+from ome_zarr.format import FormatV05
+from ome_zarr.writer import write_multiscales_metadata
+from ome_zarr_models.v05.image import Image
+from zarr.codecs import Shuffle, ZstdCodec
+from zarr.storage import LocalStore
+
+EXPECTED_STORES = 23
+EXPECTED_ARRAYS = 61
+SPATIAL_CHUNKS = (128, 128, 128)
+ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+
+
+def _digest(path: Path, algorithm: str = "sha256") -> str:
+    hasher = hashlib.new(algorithm)
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            hasher.update(block)
+    return hasher.hexdigest()
+
+
+def _archive_root(extracted: Path) -> Path:
+    candidates = [extracted, *(path for path in extracted.iterdir() if path.is_dir())]
+    for candidate in candidates:
+        if (candidate / "sample_project").is_dir() and (candidate / "filesystem.json").is_file():
+            return candidate
+    raise FileNotFoundError("Could not find sample_project/ and filesystem.json in the source corpus")
+
+
+def _multiscale(group: zarr.Group) -> dict:
+    entries = group.attrs.get("multiscales")
+    if not isinstance(entries, list) or len(entries) != 1:
+        raise ValueError(f"Expected one legacy multiscale entry in {group.store_path}")
+    return entries[0]
+
+
+def _padded_shards(shape: tuple[int, ...], chunks: tuple[int, ...]) -> tuple[int, ...]:
+    return tuple(chunk * math.ceil(size / chunk) for size, chunk in zip(shape, chunks, strict=True))
+
+
+def _compressors(dtype: np.dtype) -> tuple:
+    dtype = np.dtype(dtype)
+    if np.issubdtype(dtype, np.bool_) or np.issubdtype(dtype, np.integer):
+        return (ZstdCodec(level=3),)
+    if np.issubdtype(dtype, np.floating):
+        return (Shuffle(elementsize=dtype.itemsize), ZstdCodec(level=3))
+    raise TypeError(f"Unsupported corpus dtype: {dtype}")
+
+
+def _write_image(
+    target_path: Path,
+    arrays: list[np.ndarray],
+    datasets: list[dict],
+    axes: list[dict],
+    *,
+    array_attributes: list[dict] | None = None,
+    multiscale_metadata: dict | None = None,
+    name: str | None = None,
+    feature_major: bool = False,
+) -> zarr.Group:
+    target = zarr.group(store=LocalStore(target_path), overwrite=True, zarr_format=3)
+    written_datasets = []
+    for level, (values, source_dataset) in enumerate(zip(arrays, datasets, strict=True)):
+        path = str(level)
+        chunks = (1, *SPATIAL_CHUNKS) if feature_major else SPATIAL_CHUNKS
+        shards = (
+            (1, *_padded_shards(values.shape[1:], SPATIAL_CHUNKS))
+            if feature_major
+            else _padded_shards(values.shape, chunks)
+        )
+        attributes = {} if array_attributes is None else copy.deepcopy(array_attributes[level])
+        target.create_array(
+            path,
+            data=values,
+            chunks=chunks,
+            shards=shards,
+            compressors=_compressors(values.dtype),
+            chunk_key_encoding={"name": "v2", "separator": "/"},
+            dimension_names=tuple(axis["name"] for axis in axes),
+            attributes=attributes,
+        )
+        written_datasets.append(
+            {
+                "path": path,
+                "coordinateTransformations": copy.deepcopy(source_dataset["coordinateTransformations"]),
+            },
+        )
+
+    kwargs = {}
+    if multiscale_metadata:
+        kwargs["metadata"] = copy.deepcopy(multiscale_metadata)
+    write_multiscales_metadata(
+        target,
+        written_datasets,
+        fmt=FormatV05(),
+        axes=copy.deepcopy(axes),
+        name=name,
+        **kwargs,
+    )
+    Image.from_zarr(target)
+    return target
+
+
+def _convert_store(source_path: Path, target_path: Path) -> int:
+    source = zarr.open_group(LocalStore(source_path), mode="r")
+    multiscale = _multiscale(source)
+    datasets = multiscale["datasets"]
+    arrays = []
+    attributes = []
+    for dataset in datasets:
+        array = source[dataset["path"]]
+        if array.ndim != 3:
+            raise ValueError(f"Legacy corpus array {source_path / dataset['path']} is not 3D")
+        arrays.append(np.asarray(array))
+        attributes.append(dict(array.attrs))
+
+    if target_path.exists():
+        shutil.rmtree(target_path)
+    target = _write_image(
+        target_path,
+        arrays,
+        datasets,
+        multiscale["axes"],
+        array_attributes=attributes,
+        multiscale_metadata=multiscale.get("metadata"),
+        name=multiscale.get("name"),
+    )
+    for level, expected in enumerate(arrays):
+        np.testing.assert_array_equal(target[str(level)][:], expected)
+    return len(arrays)
+
+
+def _add_feature_major_fixture(project_v3: Path, target_path: Path) -> Path:
+    source_path = sorted(project_v3.rglob("*_features.zarr"))[0]
+    source = zarr.open_group(LocalStore(source_path), mode="r")
+    multiscale = source.attrs["ome"]["multiscales"][0]
+    source_array = source[multiscale["datasets"][0]["path"]]
+    values = np.stack((np.asarray(source_array), np.asarray(source_array)), axis=0)
+    spatial_transform = multiscale["datasets"][0]["coordinateTransformations"][0]
+    dataset = {
+        "path": "0",
+        "coordinateTransformations": [
+            {
+                "type": "scale",
+                "scale": [1.0, *spatial_transform["scale"]],
+            },
+        ],
+    }
+    _write_image(
+        target_path,
+        [values],
+        [dataset],
+        [{"name": "feature"}, *multiscale["axes"]],
+        feature_major=True,
+    )
+    return target_path
+
+
+def _copy_config(source: Path, target: Path) -> None:
+    config = json.loads(source.read_text(encoding="utf-8"))
+    for key in ("static_root", "overlay_root"):
+        if isinstance(config.get(key), str):
+            config[key] = (
+                config[key]
+                .replace("sample_project", "sample_project_v3")
+                .replace(
+                    "sample_overlay",
+                    "sample_overlay_v3",
+                )
+            )
+    target.write_text(json.dumps(config, indent=4) + "\n", encoding="utf-8")
+
+
+def _non_zarr_files(root: Path) -> dict[str, str]:
+    result = {}
+    for path in root.rglob("*"):
+        if path.is_file() and not any(part.endswith(".zarr") for part in path.relative_to(root).parts):
+            result[path.relative_to(root).as_posix()] = _digest(path)
+    return result
+
+
+def _pack(source: Path, output: Path) -> None:
+    """Create a byte-reproducible archive independent of build time and umask."""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(output, "w", zipfile.ZIP_DEFLATED) as archive:
+        for path in sorted(source.rglob("*")):
+            relative = path.relative_to(source).as_posix()
+            info = zipfile.ZipInfo(relative, ZIP_TIMESTAMP)
+            info.create_system = 3
+            info.compress_type = zipfile.ZIP_DEFLATED
+            if path.is_dir():
+                info.filename = f"{relative.rstrip('/')}/"
+                info.external_attr = (0o40755 << 16) | 0x10
+                archive.writestr(info, b"")
+            else:
+                info.external_attr = 0o100644 << 16
+                with path.open("rb") as source_file, archive.open(info, "w") as target_file:
+                    shutil.copyfileobj(source_file, target_file)
+
+
+def build(source: Path, output: Path) -> dict:
+    with tempfile.TemporaryDirectory(prefix="copick-v3-twin-") as directory:
+        workspace = Path(directory)
+        if source.is_file():
+            with zipfile.ZipFile(source) as archive:
+                archive.extractall(workspace / "input")
+            legacy_root = _archive_root(workspace / "input")
+        else:
+            legacy_root = _archive_root(source)
+
+        built_root = workspace / "built"
+        shutil.copytree(legacy_root, built_root)
+        project = built_root / "sample_project"
+        project_v3 = built_root / "sample_project_v3"
+        overlay_v3 = built_root / "sample_overlay_v3"
+        shutil.copytree(project, project_v3)
+        shutil.copytree(built_root / "sample_overlay", overlay_v3)
+
+        source_stores = sorted(path for path in project.rglob("*.zarr") if path.is_dir())
+        if len(source_stores) != EXPECTED_STORES:
+            raise ValueError(f"Expected {EXPECTED_STORES} stores, found {len(source_stores)}")
+        array_count = 0
+        for source_store in source_stores:
+            relative = source_store.relative_to(project)
+            array_count += _convert_store(source_store, project_v3 / relative)
+        if array_count != EXPECTED_ARRAYS:
+            raise ValueError(f"Expected {EXPECTED_ARRAYS} arrays, found {array_count}")
+
+        feature_fixture = _add_feature_major_fixture(
+            project_v3,
+            built_root / "wbp_multifeature_features.zarr",
+        )
+        if _non_zarr_files(project) != _non_zarr_files(project_v3):
+            raise ValueError("Non-Zarr files in the v3 project twin differ from the legacy corpus")
+
+        _copy_config(built_root / "filesystem.json", built_root / "filesystem_v3.json")
+        _copy_config(
+            built_root / "filesystem_overlay_only.json",
+            built_root / "filesystem_overlay_only_v3.json",
+        )
+        _pack(built_root, output)
+
+    return {
+        "stores": EXPECTED_STORES,
+        "arrays": EXPECTED_ARRAYS,
+        "feature_fixture": feature_fixture.name,
+        "archive": str(output),
+        "size": output.stat().st_size,
+        "md5": _digest(output, "md5"),
+        "sha256": _digest(output),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path, help="Legacy extracted corpus root or sample_project.zip")
+    parser.add_argument("--output", type=Path, required=True, help="Output zip containing legacy and v3 twins")
+    args = parser.parse_args()
+    print(json.dumps(build(args.source, args.output), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/fetch_test_corpus.py
+++ b/tests/scripts/fetch_test_corpus.py
@@ -1,0 +1,29 @@
+"""Fetch and checksum the immutable copick test corpus for CI fan-out."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pooch
+
+sys.path.insert(0, str(Path(__file__).parents[1]))
+
+from corpus_registry import ARCHIVE_NAME, CORPUS_DIGEST, CORPUS_DOI  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cache", type=Path, required=True, help="Directory that receives the verified archive")
+    args = parser.parse_args()
+    corpus = pooch.create(
+        path=args.cache,
+        base_url=f"doi:{CORPUS_DOI}",
+        registry={ARCHIVE_NAME: CORPUS_DIGEST},
+    )
+    print(corpus.fetch(ARCHIVE_NAME))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/regenerate_sample_zip.py
+++ b/tests/scripts/regenerate_sample_zip.py
@@ -24,8 +24,8 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-CURRENT_DOI = "doi:10.5281/zenodo.19686100"
-CURRENT_MD5 = "md5:8b8941350af1f621effd4903e75255c0"
+CURRENT_DOI = "doi:10.5281/zenodo.21939821"
+CURRENT_MD5 = "md5:05b1582e675719d3f1bb23349c20b86c"
 ARCHIVE_NAME = "sample_project.zip"
 
 

--- a/tests/test_corpus_parity.py
+++ b/tests/test_corpus_parity.py
@@ -1,5 +1,6 @@
 import ast
 import hashlib
+import runpy
 import zipfile
 from pathlib import Path
 
@@ -85,6 +86,32 @@ def test_v3_twin_builder_does_not_import_copick():
         elif isinstance(node, ast.ImportFrom) and node.module:
             imported.add(node.module.split(".")[0])
     assert "copick" not in imported
+
+
+def test_v3_twin_builder_rewrites_only_exact_root_leaf_components(tmp_path):
+    source_path = TESTS_DIR / "scripts" / "build_v3_twin.py"
+    copy_config = runpy.run_path(str(source_path))["_copy_config"]
+    source = tmp_path / "source.json"
+    target = tmp_path / "target.json"
+    source.write_text(
+        """{
+    "static_root": "local:///parent-sample_project/sample_project/",
+    "overlay_root": "local:///sample_overlay-backup/sample_overlay"
+}
+""",
+        encoding="utf-8",
+    )
+
+    copy_config(source, target)
+
+    assert (
+        target.read_text(encoding="utf-8")
+        == """{
+    "static_root": "local:///parent-sample_project/sample_project_v3/",
+    "overlay_root": "local:///sample_overlay-backup/sample_overlay_v3"
+}
+"""
+    )
 
 
 @pytest.fixture(params=pytest.common_cases)

--- a/tests/test_corpus_parity.py
+++ b/tests/test_corpus_parity.py
@@ -1,0 +1,160 @@
+import ast
+import hashlib
+import zipfile
+from pathlib import Path
+
+import copick
+import numpy as np
+import pytest
+import zarr
+from conftest import BACKEND, TEST_ZARR_FORMAT, TESTS_DIR, ensure_test_data
+from ome_zarr_models.v05.image import Image
+from zarr.storage import LocalStore
+
+
+class _LocalCorpus:
+    def __init__(self, path: Path, archive: Path, digest: str):
+        self.path = path
+        self.archive = archive
+        self.registry = {"sample_project.zip": digest}
+        self.fetch_count = 0
+
+    def fetch(self, name: str) -> str:
+        assert name == "sample_project.zip"
+        self.fetch_count += 1
+        return str(self.archive)
+
+
+def _write_test_archive(path: Path, marker: str) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        for name in (
+            "sample_project_v3/",
+            "sample_overlay_v3/",
+            "filesystem_v3.json",
+            "filesystem_overlay_only_v3.json",
+        ):
+            archive.writestr(name, b"")
+        archive.writestr("sample_project_v3/version.txt", marker)
+
+
+def _digest(path: Path) -> str:
+    return f"sha256:{hashlib.sha256(path.read_bytes()).hexdigest()}"
+
+
+def _multiscale(group: zarr.Group) -> dict:
+    attrs = dict(group.attrs)
+    return attrs.get("ome", attrs)["multiscales"][0]
+
+
+def _non_zarr_files(root: Path) -> dict[str, str]:
+    result = {}
+    for path in root.rglob("*"):
+        relative = path.relative_to(root)
+        if path.is_file() and not any(part.endswith(".zarr") for part in relative.parts):
+            result[relative.as_posix()] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return result
+
+
+def test_corpus_cache_uses_the_registry_digest_for_cold_and_warm_runs(tmp_path):
+    archive = tmp_path / "sample_project.zip"
+    _write_test_archive(archive, "first")
+    corpus = _LocalCorpus(tmp_path, archive, _digest(archive))
+
+    extracted = ensure_test_data(corpus, zarr_format="v3")
+    marker = extracted / "sample_project_v3" / "version.txt"
+    assert marker.read_text() == "first"
+
+    marker.write_text("warm cache must remain untouched")
+    assert ensure_test_data(corpus, zarr_format="v3") == extracted
+    assert marker.read_text() == "warm cache must remain untouched"
+
+    _write_test_archive(archive, "second")
+    corpus.registry["sample_project.zip"] = _digest(archive)
+    assert ensure_test_data(corpus, zarr_format="v3") == extracted
+    assert marker.read_text() == "second"
+    assert corpus.fetch_count == 3
+
+
+def test_v3_twin_builder_does_not_import_copick():
+    source_path = TESTS_DIR / "scripts" / "build_v3_twin.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+    assert "copick" not in imported
+
+
+@pytest.fixture(params=pytest.common_cases)
+def corpus_backend_root(request):
+    payload = request.getfixturevalue(request.param)
+    return copick.from_file(payload["cfg_file"])
+
+
+@pytest.mark.corpus_parity
+@pytest.mark.remote_corpus_parity
+def test_selected_corpus_reads_and_region_writes(corpus_backend_root):
+    run = corpus_backend_root.get_run("TS_001")
+    voxel_spacing = run.get_voxel_spacing(10.0)
+
+    tomogram = voxel_spacing.get_tomogram("denoised")
+    assert tomogram.numpy().shape == (64, 64, 64)
+    assert tomogram.numpy(z=slice(10, 40), y=slice(50, 60), x=slice(0, 30)).shape == (30, 10, 30)
+
+    segmentation = run.get_segmentations(name="membrane")[0]
+    assert segmentation.numpy(z=slice(20, 40), y=slice(20, 40), x=slice(20, 40)).shape == (20, 20, 20)
+
+    source_feature = voxel_spacing.get_tomogram("wbp").get_features("sobel")
+    assert source_feature.numpy(slices=(slice(20, 40),) * 3).shape == (20, 20, 20)
+
+    written_feature = tomogram.new_features("corpus-parity")
+    expected = np.arange(16**3, dtype=np.float32).reshape((16, 16, 16))
+    written_feature.from_numpy(expected)
+    update = np.full((4, 4, 4), -1.0, dtype=np.float32)
+    written_feature.set_region(update, slices=(slice(4, 8),) * 3)
+    expected[4:8, 4:8, 4:8] = update
+    np.testing.assert_array_equal(written_feature.numpy(), expected)
+
+
+@pytest.mark.corpus_parity
+@pytest.mark.skipif(TEST_ZARR_FORMAT != "v3" or BACKEND != "local", reason="local v3 corpus parity gate")
+def test_v3_corpus_matches_every_legacy_store_and_array(local_path):
+    legacy_project = local_path / "sample_project"
+    v3_project = local_path / "sample_project_v3"
+    legacy_stores = sorted(path for path in legacy_project.rglob("*.zarr") if path.is_dir())
+    assert len(legacy_stores) == 23
+
+    array_count = 0
+    for legacy_path in legacy_stores:
+        v3_path = v3_project / legacy_path.relative_to(legacy_project)
+        legacy = zarr.open_group(LocalStore(legacy_path), mode="r")
+        twin = zarr.open_group(LocalStore(v3_path), mode="r")
+        Image.from_zarr(twin)
+        assert twin.metadata.zarr_format == 3
+
+        legacy_multiscale = _multiscale(legacy)
+        twin_multiscale = _multiscale(twin)
+        assert twin_multiscale["axes"] == legacy_multiscale["axes"]
+        assert len(twin_multiscale["datasets"]) == len(legacy_multiscale["datasets"])
+        for legacy_dataset, twin_dataset in zip(
+            legacy_multiscale["datasets"],
+            twin_multiscale["datasets"],
+            strict=True,
+        ):
+            assert twin_dataset["coordinateTransformations"] == legacy_dataset["coordinateTransformations"]
+            np.testing.assert_array_equal(
+                twin[twin_dataset["path"]][:],
+                legacy[legacy_dataset["path"]][:],
+            )
+            array_count += 1
+
+    assert array_count == 61
+    assert _non_zarr_files(v3_project) == _non_zarr_files(legacy_project)
+
+    feature_stores = sorted(local_path.glob("*_multifeature_features.zarr"))
+    assert len(feature_stores) == 1
+    feature_group = zarr.open_group(LocalStore(feature_stores[0]), mode="r")
+    Image.from_zarr(feature_group)
+    assert feature_group["0"].ndim == 4

--- a/tests/test_delete_overwrite.py
+++ b/tests/test_delete_overwrite.py
@@ -5,8 +5,8 @@ import pytest
 import zarr
 
 
-def _assert_v2_group(store):
-    assert zarr.open_group(store, mode="r").metadata.zarr_format == 2
+def _assert_v3_group(store):
+    assert zarr.open_group(store, mode="r").metadata.zarr_format == 3
 
 
 @pytest.fixture(params=pytest.common_cases)
@@ -87,7 +87,7 @@ def test_delete_tomogram(test_payload: Dict[str, Any]):
     # Create a new tomogram to delete
     tomo_type = "delete-test"
     tomogram = vs.new_tomogram(tomo_type=tomo_type)
-    _assert_v2_group(tomogram.zarr())
+    _assert_v3_group(tomogram.zarr())
     assert tomogram in vs.tomograms, "Tomogram not added to tomograms"
 
     # Check that tomogram exists in filesystem
@@ -123,7 +123,7 @@ def test_delete_features(test_payload: Dict[str, Any]):
     # Create a new feature to delete
     feature_type = "delete-test"
     feature = tomogram.new_features(feature_type=feature_type)
-    _assert_v2_group(feature.zarr())
+    _assert_v3_group(feature.zarr())
     assert feature in tomogram.features, "Feature not added to features"
 
     # Check that feature exists in filesystem
@@ -238,7 +238,7 @@ def test_delete_segmentation(test_payload: Dict[str, Any]):
         name=name,
         is_multilabel=is_multilabel,
     )
-    _assert_v2_group(segmentation.zarr())
+    _assert_v3_group(segmentation.zarr())
     assert segmentation in copick_run.segmentations, "Segmentation not added to segmentations"
 
     # Check that segmentation exists in filesystem
@@ -309,7 +309,7 @@ def test_exist_ok_tomogram(test_payload: Dict[str, Any]):
     # Create a new tomogram
     tomo_type = "exist-ok-test"
     tomo1 = vs.new_tomogram(tomo_type=tomo_type)
-    _assert_v2_group(tomo1.zarr())
+    _assert_v3_group(tomo1.zarr())
 
     # Attempt to create the same tomogram without exist_ok
     with pytest.raises(ValueError):
@@ -332,7 +332,7 @@ def test_exist_ok_features(test_payload: Dict[str, Any]):
     # Create a new feature
     feature_type = "exist-ok-test"
     feature1 = tomogram.new_features(feature_type=feature_type)
-    _assert_v2_group(feature1.zarr())
+    _assert_v3_group(feature1.zarr())
 
     # Attempt to create the same feature without exist_ok
     with pytest.raises(ValueError):
@@ -408,7 +408,7 @@ def test_exist_ok_segmentation(test_payload: Dict[str, Any]):
         name=name,
         is_multilabel=is_multilabel,
     )
-    _assert_v2_group(seg1.zarr())
+    _assert_v3_group(seg1.zarr())
 
     # Attempt to create the same segmentation without exist_ok
     with pytest.raises(ValueError):
@@ -464,7 +464,7 @@ def test_delete_collections(test_payload: Dict[str, Any]):
         name="ribosome",
         is_multilabel=False,
     )
-    _assert_v2_group(seg1.zarr())
+    _assert_v3_group(seg1.zarr())
 
     seg2 = copick_run.new_segmentation(
         voxel_size=10.000,
@@ -473,7 +473,7 @@ def test_delete_collections(test_payload: Dict[str, Any]):
         name="segment2",
         is_multilabel=True,
     )
-    _assert_v2_group(seg2.zarr())
+    _assert_v3_group(seg2.zarr())
 
     # Refresh to ensure all entities are tracked
     copick_run.refresh()

--- a/tests/test_feature_writer.py
+++ b/tests/test_feature_writer.py
@@ -115,6 +115,8 @@ def test_feature_from_numpy_dtype_override_and_region_write():
     features = _MemoryFeatures()
     values = np.arange(2 * 3 * 4 * 5).reshape(2, 3, 4, 5)
     features.from_numpy(values, chunks=(2, 2, 2), dtype=np.float32)
+    _, array = _written_array(features)
+    layout_before = array.metadata.to_dict()
 
     replacement = np.full((1, 2, 2, 2), 99, dtype=np.float32)
     selection = (slice(1, 2), slice(1, 3), slice(1, 3), slice(1, 3))
@@ -123,8 +125,30 @@ def test_feature_from_numpy_dtype_override_and_region_write():
     result = features.numpy()
     assert result.dtype == np.float32
     np.testing.assert_array_equal(result[selection], replacement)
+    _, array = _written_array(features)
+    assert array.metadata.to_dict() == layout_before
+
+
+def test_feature_from_numpy_refuses_or_replaces_existing_data_explicitly():
+    features = _MemoryFeatures()
+    original = np.ones((3, 4, 5), dtype=np.float32)
+    replacement = np.full((3, 4, 5), 2.0, dtype=np.float32)
+    features.from_numpy(original)
+
+    with pytest.raises(FileExistsError, match="not empty"):
+        features.from_numpy(replacement, overwrite=False)
+
+    np.testing.assert_array_equal(features.numpy(), original)
+    features.from_numpy(replacement, overwrite=True)
+    np.testing.assert_array_equal(features.numpy(), replacement)
 
 
 def test_add_features_appends_shards_after_existing_parameters():
     parameters = list(inspect.signature(add_features).parameters)
     assert parameters[-1] == "shards"
+
+
+def test_feature_from_numpy_overwrite_is_keyword_only_and_defaults_to_replace():
+    parameter = inspect.signature(CopickFeatures.from_numpy).parameters["overwrite"]
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameter.default is True

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -12,8 +12,8 @@ from trimesh.parent import Geometry
 NUMERICAL_PRECISION = 1e-8
 
 
-def _assert_v2_group(store):
-    assert zarr.open_group(store, mode="r").metadata.zarr_format == 2
+def _assert_v3_group(store):
+    assert zarr.open_group(store, mode="r").metadata.zarr_format == 3
 
 
 @pytest.fixture(params=pytest.common_cases)
@@ -1063,7 +1063,7 @@ def test_run_new_segmentations(test_payload: Dict[str, Any]):
             is_multilabel=False,
         )
 
-    # Adding the first segmentation initializes and materializes its Zarr v2 group.
+    # Adding the first segmentation initializes and materializes its Zarr v3 group.
     seg4 = copick_run.new_segmentation(
         voxel_size=10.000,
         user_id="test.user",
@@ -1071,7 +1071,7 @@ def test_run_new_segmentations(test_payload: Dict[str, Any]):
         name="ribosome",
         is_multilabel=False,
     )
-    _assert_v2_group(seg4.zarr())
+    _assert_v3_group(seg4.zarr())
     assert copick_run._segmentations is not None, "Segmentations should be populated"
     assert seg4 in copick_run.segmentations, "Segmentation not added to segmentations"
 
@@ -1083,7 +1083,7 @@ def test_run_new_segmentations(test_payload: Dict[str, Any]):
         name="location",
         is_multilabel=True,
     )
-    _assert_v2_group(seg5.zarr())
+    _assert_v3_group(seg5.zarr())
     assert seg5 in copick_run.segmentations, "Segmentation not added to segmentations"
     assert (
         seg5
@@ -1143,7 +1143,7 @@ def test_new_zarr_entities_reopen_and_delete_without_array_write(test_payload: D
     features = tomogram.new_features("materialization-test")
 
     for entity in (segmentation, tomogram, features):
-        _assert_v2_group(entity.zarr())
+        _assert_v3_group(entity.zarr())
 
     reopened = copick.from_file(test_payload["cfg_file"])
     reopened_run = reopened.get_run("TS_001")
@@ -1264,16 +1264,16 @@ def test_vs_new_tomogram(test_payload: Dict[str, Any]):
     with pytest.raises(ValueError):
         vs.new_tomogram(tomo_type="denoised")
 
-    # Adding the first tomogram initializes and materializes its Zarr v2 group.
+    # Adding the first tomogram initializes and materializes its Zarr v3 group.
     tomogram = vs.new_tomogram(tomo_type="isonet")
-    _assert_v2_group(tomogram.zarr())
+    _assert_v3_group(tomogram.zarr())
 
     assert vs._tomograms is not None, "Tomograms should be populated"
     assert tomogram in vs.tomograms, "Tomogram not added to tomograms"
 
     # Adding another tomogram appends to the list.
     tomogram = vs.new_tomogram(tomo_type="SIRT")
-    _assert_v2_group(tomogram.zarr())
+    _assert_v3_group(tomogram.zarr())
 
     assert tomogram in vs.tomograms, "Tomogram not added to tomograms"
     assert tomogram == vs.get_tomogram(tomo_type="SIRT"), "Tomogram not found"
@@ -1394,16 +1394,16 @@ def test_tomogram_new_features(test_payload: Dict[str, Any]):
     with pytest.raises(ValueError):
         tomogram.new_features(feature_type="sobel")
 
-    # Adding the first feature initializes and materializes its Zarr v2 group.
+    # Adding the first feature initializes and materializes its Zarr v3 group.
     feature = tomogram.new_features(feature_type="sift")
-    _assert_v2_group(feature.zarr())
+    _assert_v3_group(feature.zarr())
 
     assert tomogram._features is not None, "Features should be populated"
     assert feature in tomogram.features, "Feature not added to features"
 
     # Adding another feature appends to the list.
     feature = tomogram.new_features(feature_type="tomotwin")
-    _assert_v2_group(feature.zarr())
+    _assert_v3_group(feature.zarr())
 
     assert feature in tomogram.features, "Feature not added to features"
     assert feature == tomogram.get_features(feature_type="tomotwin"), "Feature not found"

--- a/tests/test_ome_writer.py
+++ b/tests/test_ome_writer.py
@@ -4,6 +4,7 @@ import ast
 import inspect
 import json
 import math
+import warnings
 from pathlib import Path
 
 import copick.util.ome as ome
@@ -85,13 +86,37 @@ def test_writer_emits_v3_ome_zarr_05_contract(tmp_path, writer_pyramid, target_k
     assert (path / "0" / "0" / "0" / "0").is_file()
 
 
-@pytest.mark.parametrize("metadata", [None, {"source": "golden-test"}])
-def test_writer_preserves_explicit_metadata_value(tmp_path, writer_pyramid, metadata):
+def _file_contents(path):
+    return {item.relative_to(path): item.read_bytes() for item in path.rglob("*") if item.is_file()}
+
+
+def test_writer_treats_none_metadata_as_omitted(tmp_path, writer_pyramid):
     path = str(tmp_path / "metadata.zarr")
+    write_ome_zarr_3d(path, writer_pyramid, metadata=None)
+
+    group = zarr.open_group(path, mode="r")
+    assert "metadata" not in group.attrs["ome"]["multiscales"][0]
+
+
+def test_writer_preserves_explicit_metadata_mapping(tmp_path, writer_pyramid):
+    path = str(tmp_path / "metadata.zarr")
+    metadata = {"source": "golden-test"}
+
     write_ome_zarr_3d(path, writer_pyramid, metadata=metadata)
 
     group = zarr.open_group(path, mode="r")
+    Image.from_zarr(group)
     assert group.attrs["ome"]["multiscales"][0]["metadata"] == metadata
+
+
+@pytest.mark.parametrize("metadata", ["invalid", ["invalid"], 3])
+def test_writer_rejects_non_mapping_metadata_before_materializing_store(tmp_path, writer_pyramid, metadata):
+    path = tmp_path / "invalid-metadata.zarr"
+
+    with pytest.raises(TypeError, match="mapping or None"):
+        write_ome_zarr_3d(str(path), writer_pyramid, metadata=metadata)
+
+    assert not path.exists()
 
 
 def test_writer_preserves_default_chunk_shape(tmp_path, writer_pyramid):
@@ -203,6 +228,89 @@ def test_complete_level_writes_its_remote_shard_once():
     write_ome_zarr_3d(store, {10.0: values}, chunk_size=(2, 3, 4))
 
     assert store.written_keys.count("0/0/0/0") == 1
+
+
+@pytest.mark.parametrize("target_kind", ["path", "store"])
+def test_writer_converts_bare_v2_group_without_mixed_metadata(tmp_path, writer_pyramid, target_kind):
+    path = tmp_path / "legacy-empty.zarr"
+    zarr.group(store=LocalStore(path), zarr_format=2)
+    target = str(path) if target_kind == "path" else LocalStore(path)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        write_ome_zarr_3d(target, {10.0: writer_pyramid[10.0]}, chunk_size=(2, 2, 2), overwrite=False)
+        group = zarr.open_group(LocalStore(path), mode="r")
+
+    assert group.metadata.zarr_format == 3
+    assert not any("Both zarr.json" in str(warning.message) for warning in caught)
+    assert not list(path.rglob(".zgroup"))
+    assert not list(path.rglob(".zattrs"))
+
+
+def test_writer_accepts_bare_v3_group_without_overwrite(tmp_path, writer_pyramid):
+    path = tmp_path / "empty-v3.zarr"
+    zarr.group(store=LocalStore(path), zarr_format=3)
+
+    write_ome_zarr_3d(
+        LocalStore(path),
+        {10.0: writer_pyramid[10.0]},
+        chunk_size=(2, 2, 2),
+        overwrite=False,
+    )
+
+    group = zarr.open_group(LocalStore(path), mode="r")
+    np.testing.assert_array_equal(group[get_level_path(group, 0)][:], writer_pyramid[10.0])
+
+
+def test_writer_converts_bare_remote_v2_group_without_mixed_metadata(writer_pyramid):
+    store = MemoryStore()
+    zarr.group(store=store, zarr_format=2)
+
+    write_ome_zarr_3d(
+        store,
+        {10.0: writer_pyramid[10.0]},
+        chunk_size=(2, 2, 2),
+        overwrite=False,
+    )
+
+    assert "zarr.json" in store._store_dict
+    assert ".zgroup" not in store._store_dict
+    assert ".zattrs" not in store._store_dict
+
+
+@pytest.mark.parametrize("zarr_format", [2, 3])
+def test_writer_refuses_populated_target_without_mutation(tmp_path, writer_pyramid, zarr_format):
+    path = tmp_path / f"populated-v{zarr_format}.zarr"
+    group = zarr.group(store=LocalStore(path), zarr_format=zarr_format)
+    group.create_array("0", data=np.ones((2, 2, 2), dtype=np.uint8), chunks=(2, 2, 2))
+    before = _file_contents(path)
+
+    with pytest.raises(FileExistsError, match="not empty"):
+        write_ome_zarr_3d(
+            LocalStore(path),
+            {10.0: writer_pyramid[10.0]},
+            chunk_size=(2, 2, 2),
+            overwrite=False,
+        )
+
+    assert _file_contents(path) == before
+
+
+def test_writer_refuses_mixed_root_metadata_without_mutation(tmp_path, writer_pyramid):
+    path = tmp_path / "mixed.zarr"
+    zarr.group(store=LocalStore(path), zarr_format=2)
+    (path / "zarr.json").write_text('{"zarr_format": 3, "node_type": "group", "attributes": {}}')
+    before = _file_contents(path)
+
+    with pytest.raises(FileExistsError, match="not empty"):
+        write_ome_zarr_3d(
+            LocalStore(path),
+            {10.0: writer_pyramid[10.0]},
+            chunk_size=(2, 2, 2),
+            overwrite=False,
+        )
+
+    assert _file_contents(path) == before
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ops_add.py
+++ b/tests/test_ops_add.py
@@ -3,6 +3,7 @@
 import contextlib
 import os
 import tempfile
+import warnings
 from typing import Any, Dict
 
 import copick
@@ -157,8 +158,12 @@ class TestAddTomogram:
         assert tomo.tomo_type == "test-tomo-np"
 
         # Verify data is stored
-        zarr_group = zarr.open(tomo.zarr(), mode="r")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            zarr_group = zarr.open(tomo.zarr(), mode="r")
         assert zarr_group[get_level_path(zarr_group, 0)].shape == (8, 8, 8)
+        assert zarr_group.metadata.zarr_format == 3
+        assert not any("Both zarr.json" in str(warning.message) for warning in caught)
 
     def test_add_tomogram_dict_pyramid(self, test_payload):
         """Adding a tomogram from a dict pyramid writes multiple levels."""
@@ -233,14 +238,13 @@ class TestAddFeatures:
         """Adding features to an existing tomogram succeeds."""
         root = test_payload["root"]
 
-        # add_features hardcodes voxel_spacing=1.0 for get_or_create_voxelspacing
-        # We need a tomogram at voxel_spacing 1.0, so add one first
         volume = np.random.randn(8, 8, 8).astype(np.float32)
-        add_tomogram(root, "TS_001", "feat-test-tomo", volume, voxel_spacing=1.0, exist_ok=True)
+        add_tomogram(root, "TS_001", "feat-test-tomo", volume, voxel_spacing=10.0, exist_ok=True)
 
         features_vol = np.random.randn(8, 8, 8).astype(np.float32)
-        feat = add_features(root, "TS_001", 1.0, "feat-test-tomo", "sobel-test", features_vol, exist_ok=True)
+        feat = add_features(root, "TS_001", 10.0, "feat-test-tomo", "sobel-test", features_vol, exist_ok=True)
         assert feat.feature_type == "sobel-test"
+        assert feat.tomogram.voxel_spacing.voxel_size == 10.0
         np.testing.assert_array_equal(feat.numpy(), features_vol)
 
     def test_add_features_delegates_feature_major_write(self, test_payload, monkeypatch):
@@ -278,10 +282,57 @@ class TestAddFeatures:
         assert calls == [
             (
                 values.shape,
-                {"chunks": (2, 3, 4), "shards": (1, 4, 6, 8), "metadata": None},
+                {"chunks": (2, 3, 4), "shards": (1, 4, 6, 8), "metadata": None, "overwrite": False},
             ),
         ]
         np.testing.assert_array_equal(features.numpy(), values)
+
+    def test_add_features_refuses_silent_replacement_and_honors_overwrite(self, test_payload):
+        root = test_payload["root"]
+        add_tomogram(
+            root,
+            "TS_001",
+            "feat-overwrite-tomo",
+            np.zeros((4, 5, 6), dtype=np.float32),
+            voxel_spacing=10.0,
+            exist_ok=True,
+        )
+        original = np.ones((4, 5, 6), dtype=np.float32)
+        replacement = np.full((4, 5, 6), 2.0, dtype=np.float32)
+        features = add_features(
+            root,
+            "TS_001",
+            10.0,
+            "feat-overwrite-tomo",
+            "replace-test",
+            original,
+            exist_ok=True,
+        )
+
+        with pytest.raises(FileExistsError, match="not empty"):
+            add_features(
+                root,
+                "TS_001",
+                10.0,
+                "feat-overwrite-tomo",
+                "replace-test",
+                replacement,
+                exist_ok=True,
+                overwrite=False,
+            )
+
+        np.testing.assert_array_equal(features.numpy(), original)
+        replaced = add_features(
+            root,
+            "TS_001",
+            10.0,
+            "feat-overwrite-tomo",
+            "replace-test",
+            replacement,
+            exist_ok=True,
+            overwrite=True,
+        )
+        np.testing.assert_array_equal(replaced.numpy(), replacement)
 
     def test_add_features_missing_tomogram_raises(self, test_payload):
         """Missing tomogram raises ValueError."""

--- a/tests/test_single_level_export.py
+++ b/tests/test_single_level_export.py
@@ -131,7 +131,7 @@ def test_chunkwise_copy_bounds_every_read_to_one_inner_chunk():
 def test_single_level_export_bounds_peak_python_memory_with_memmap_staging(tmp_path):
     source_path = tmp_path / "large-source.zarr"
     source = zarr.group(store=LocalStore(source_path), zarr_format=2)
-    shape = (256, 256, 256)
+    shape = (384, 384, 384)
     chunks = (64, 64, 64)
     source.create_array("s0", shape=shape, chunks=chunks, dtype="u1", fill_value=0)
     source.attrs["multiscales"] = [
@@ -160,7 +160,7 @@ def test_single_level_export_bounds_peak_python_memory_with_memmap_staging(tmp_p
 
     logical_volume_bytes = math.prod(shape)
     assert peak_bytes < 64 * 1024 * 1024
-    assert peak_bytes < logical_volume_bytes * 4
+    assert peak_bytes < logical_volume_bytes * 3 // 4
 
     target = zarr.open_group(LocalStore(tmp_path / "large-target.zarr"), mode="r")
     target_array = target[get_level_path(target, 0)]
@@ -168,6 +168,70 @@ def test_single_level_export_bounds_peak_python_memory_with_memmap_staging(tmp_p
     assert target_array.chunks == (128, 128, 128)
     assert target_array.shards == shape
     assert target_array[0, 0, 0] == 0
+
+
+def test_single_level_export_supports_feature_major_4d_sources(tmp_path):
+    source = zarr.group(store=MemoryStore(), zarr_format=3)
+    values = np.arange(2 * 3 * 4 * 5, dtype=np.float32).reshape(2, 3, 4, 5)
+    source.create_array("features", data=values, chunks=(1, 2, 3, 4))
+    source.attrs["ome"] = {
+        "version": "0.5",
+        "multiscales": [
+            {
+                "version": "0.5",
+                "axes": [
+                    {"name": "feature"},
+                    {"name": "z", "type": "space"},
+                    {"name": "y", "type": "space"},
+                    {"name": "x", "type": "space"},
+                ],
+                "datasets": [
+                    {
+                        "path": "features",
+                        "coordinateTransformations": [
+                            {"type": "scale", "scale": [1.0, 10.0, 10.0, 10.0]},
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+    target_store = LocalStore(tmp_path / "feature-target.zarr")
+
+    write_single_level_ome_zarr(source, target_store)
+
+    target = zarr.open_group(target_store, mode="r")
+    target_array = target[get_level_path(target, 0)]
+    assert target_array.chunks == (1, *([128] * 3))
+    assert target_array.metadata.dimension_names == ("feature", "z", "y", "x")
+    assert get_multiscales(target)[0]["axes"] == source.attrs["ome"]["multiscales"][0]["axes"]
+    np.testing.assert_array_equal(target_array[:], values)
+
+
+def test_single_level_export_rejects_unsupported_dimensions_before_writing(tmp_path):
+    source = zarr.group(store=MemoryStore(), zarr_format=3)
+    source.create_array("image", data=np.ones((3, 4), dtype=np.uint8), chunks=(2, 2))
+    source.attrs["ome"] = {
+        "version": "0.5",
+        "multiscales": [
+            {
+                "version": "0.5",
+                "axes": [{"name": "y", "type": "space"}, {"name": "x", "type": "space"}],
+                "datasets": [
+                    {
+                        "path": "image",
+                        "coordinateTransformations": [{"type": "scale", "scale": [1.0, 1.0]}],
+                    },
+                ],
+            },
+        ],
+    }
+    target = MemoryStore()
+
+    with pytest.raises(ValueError, match="supports 3D or 4D"):
+        write_single_level_ome_zarr(source, target)
+
+    assert not target._store_dict
 
 
 class _RecordingMemoryStore(MemoryStore):

--- a/tests/test_zarr_structural_guards.py
+++ b/tests/test_zarr_structural_guards.py
@@ -37,6 +37,12 @@ STORE_ARGUMENT_NAMES = {"loc", "source", "source_store", "store", "target", "tar
 # Every entry must correspond to a violation observed by the repository scan,
 # which prevents stale or overly broad exemptions.
 ALLOWED_VIOLATIONS = {
+    ("tests/scripts/build_v3_twin.py", "_convert_store", "metadata_level_path"),
+    (
+        "tests/test_corpus_parity.py",
+        "test_v3_corpus_matches_every_legacy_store_and_array",
+        "metadata_level_path",
+    ),
     ("tests/test_ome_writer.py", "test_writer_emits_v3_ome_zarr_05_contract", "metadata_level_path"),
     ("tests/test_ome_writer.py", "test_writer_preserves_default_chunk_shape", "metadata_level_path"),
     ("tests/test_ome_writer.py", "test_zarr_handler_uses_canonical_writer_contract", "metadata_level_path"),


### PR DESCRIPTION
## Summary

- add an independently generated v3 twin of the legacy test corpus and validate semantic parity
- pin the published corpus at DOI 10.5281/zenodo.21939821 with digest verification
- fetch the archive once per workflow and distribute it to every matrix job through a verified GitHub Actions artifact
- complete the writer cutover by materializing new image entities as Zarr v3 and refusing populated targets before mutation
- make `add_features` honor `overwrite` explicitly and preserve the caller's data on refusal
- cover the Zarr and ome-zarr floors, ome-zarr 0.18.0, and real v3 corpus reads on Linux, macOS, and Windows

## Review fixes

- bare legacy v2 groups are converted cleanly; populated and mixed targets raise before any key changes
- custom writer metadata is mapping-only and validated before materialization
- single-level export supports feature-major 4D input and retains a meaningful sub-volume memory bound
- canonical region writes preserve the shard grid and codec pipeline
- future stacked PRs run the tests workflow regardless of their base branch
- S3/SSH parent-creation requirements and the output-format break are documented

## Validation

- full local suite: 1041 passed, 3 skipped
- Python 3.11 + Zarr 3.1.6 + ome-zarr 0.12.2: 193 focused tests passed; real v3 corpus parity passed
- Python 3.13 + ome-zarr 0.18.0: 79 compatibility tests passed
- targeted S3 and SSH writer/entity regressions: 6 passed per backend
- published corpus rebuilt byte-for-byte with MD5 `05b1582e675719d3f1bb23349c20b86c`; no new Zenodo upload is required
- all pre-commit hooks pass

## Stack

1. #414 — #371 centralized writer
2. #415 — #372 canonical layout policy
3. #416 — #52 feature layouts
4. #417 — #373 semantic export
5. #418 — #375 layout-agnostic readers
6. **#419 — #374 independent corpus parity and final review fixes (this PR)**

Part of #370. Depends on #418.
Closes #374

BREAKING CHANGE: Newly created tomogram, segmentation, and feature stores are materialized as Zarr v3 groups, and `add_features` now raises instead of silently retaining existing data when `overwrite=False`.
