### PR TITLE
fix: preserve SSH byte-range reads

### DIFF
--- a/src/copick/util/reconnecting_fs.py
+++ b/src/copick/util/reconnecting_fs.py
@@ -31,6 +31,12 @@ _CONNECTION_ERROR_NAMES = frozenset(
     },
 )
 
+# sshfs exposes an async ``_cat_file`` method which accepts arbitrary keyword
+# arguments but ignores fsspec's ``start``/``end`` byte-range contract. fsspec
+# mirrors that method over its correct synchronous implementation, so Zarr's
+# suffix reads receive the complete shard and fail the shard-index checksum.
+_RANGE_IGNORING_CAT_FILE_NAMES = frozenset({"SSHFileSystem"})
+
 
 def _is_connection_error(exc: BaseException) -> bool:
     """Check if an exception indicates a broken or stale connection."""
@@ -147,6 +153,48 @@ class ReconnectingFileSystem(AbstractFileSystem):
             return getattr(filesystem, method_name)(*args, **kwargs)
         return result
 
+    @staticmethod
+    def _requires_cat_file_range_fallback(filesystem: AbstractFileSystem) -> bool:
+        return any(cls.__name__ in _RANGE_IGNORING_CAT_FILE_NAMES for cls in type(filesystem).__mro__)
+
+    @staticmethod
+    def _cat_file_by_seek(filesystem: AbstractFileSystem, path, start=None, end=None, **kwargs):
+        """Honor fsspec byte ranges using a seekable file object."""
+        if (start is not None and start < 0) or (end is not None and end < 0):
+            size = filesystem.info(path)["size"]
+            if start is not None and start < 0:
+                start = max(0, size + start)
+            if end is not None and end < 0:
+                end = max(0, size + end)
+
+        with filesystem.open(path, "rb", **kwargs) as stream:
+            if start is not None:
+                stream.seek(start)
+            if end is None:
+                return stream.read()
+            return stream.read(max(0, end - stream.tell()))
+
+    def cat_file(self, path, start=None, end=None, **kwargs):
+        """Read a complete file or byte range, reconnecting once on failure."""
+
+        def read(filesystem):
+            if (start is not None or end is not None) and self._requires_cat_file_range_fallback(filesystem):
+                return self._cat_file_by_seek(filesystem, path, start=start, end=end, **kwargs)
+            return filesystem.cat_file(path, start=start, end=end, **kwargs)
+
+        filesystem, generation = self._snapshot()
+        try:
+            return read(filesystem)
+        except Exception as original_exc:
+            if not _is_connection_error(original_exc):
+                raise
+            logger.warning("Connection error during cat_file, reconnecting: %s", original_exc)
+            try:
+                filesystem = self._reconnect(expected_generation=generation)
+            except Exception:
+                raise original_exc from None
+            return read(filesystem)
+
     # -- Explicitly overridden methods (used by copick, Zarr's fsspec adapter, and fsspec FSMap) --
     # Each delegates to self._fs with automatic retry on connection error.
 
@@ -162,7 +210,6 @@ class ReconnectingFileSystem(AbstractFileSystem):
 
     # File read/write methods
     cat = _make_retry_method("cat")
-    cat_file = _make_retry_method("cat_file")
     pipe = _make_retry_method("pipe")
     pipe_file = _make_retry_method("pipe_file")
     open = _make_retry_method("open")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+import subprocess
 import tempfile
 import time
 import uuid
@@ -497,9 +498,36 @@ if BACKEND in ("all", "ssh") and importlib_util.find_spec("sshfs") and RUN_ALL:
         os.environ["HOST_UID"] = str(os.getuid())
         os.environ["HOST_GID"] = str(os.getgid())
 
-        os.system(f"docker compose -f {DOCKER_COMPOSE_FILE} --profile sshfs up -d")
-        # On startup we need to wait for the service to fully initialize (user creation, SSH setup).
-        time.sleep(3)
+        subprocess.run(
+            ["docker", "compose", "-f", str(DOCKER_COMPOSE_FILE), "--profile", "sshfs", "up", "-d"],
+            check=True,
+        )
+
+        # An open TCP port is not sufficient: linuxserver starts accepting
+        # connections before its configured user is always ready. Probe the
+        # same authenticated filesystem the tests use instead of sleeping for
+        # a fixed interval.
+        deadline = time.monotonic() + 60
+        last_error = None
+        while time.monotonic() < deadline:
+            try:
+                probe = fsspec.filesystem(
+                    "ssh",
+                    host="localhost",
+                    port=2222,
+                    username="test.user",
+                    password="password",
+                    known_hosts=None,
+                    skip_instance_cache=True,
+                )
+                probe.ls("/config")
+                probe.client.abort()
+                break
+            except Exception as exc:
+                last_error = exc
+                time.sleep(1)
+        else:
+            raise RuntimeError("SSH test service did not become ready within 60 seconds") from last_error
 
         yield "ssh:///config/test_data/"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -500,7 +500,11 @@ if BACKEND in ("all", "ssh") and importlib_util.find_spec("sshfs") and RUN_ALL:
 
         subprocess.run(
             ["docker", "compose", "-f", str(DOCKER_COMPOSE_FILE), "--profile", "sshfs", "up", "-d"],
-            check=True,
+            # xdist workers can race while starting the shared container. One
+            # compose process may report a name conflict even though the other
+            # successfully started the service; the authenticated probe below
+            # is the authoritative readiness check.
+            check=False,
         )
 
         # An open TCP port is not sufficient: linuxserver starts accepting

--- a/tests/test_reconnecting_fs.py
+++ b/tests/test_reconnecting_fs.py
@@ -27,6 +27,13 @@ class SFTPError(OSError):
     pass
 
 
+class SSHFileSystem(MemoryFileSystem):
+    """Model sshfs's async cat_file implementation, which ignores ranges."""
+
+    def cat_file(self, path, start=None, end=None, **kwargs):
+        return super().cat_file(path, **kwargs)
+
+
 # -- Tests for _is_connection_error --
 
 
@@ -147,6 +154,19 @@ def test_read_recovers_once_on_replacement_filesystem():
     assert fs.cat_file("/test/value") == b"recovered"
     fs._create_filesystem.assert_called_once()
     assert fs._generation == 1
+
+
+def test_ssh_cat_file_fallback_preserves_positive_and_suffix_ranges():
+    fs = ReconnectingFileSystem("memory://test")
+    ssh = SSHFileSystem(skip_instance_cache=True)
+    payload = b"0123456789"
+    ssh.pipe_file("/test/value", payload)
+    fs._fs = ssh
+
+    assert fs.cat_file("/test/value") == payload
+    assert fs.cat_file("/test/value", start=2, end=6) == b"2345"
+    assert fs.cat_file("/test/value", start=-4) == b"6789"
+    assert fs.cat_file("/test/value", end=-2) == b"01234567"
 
 
 def test_write_recovers_once_on_replacement_filesystem():


### PR DESCRIPTION
## Summary

- preserve fsspec start/end byte-range semantics for sshfs by using explicit seek/read ranges
- retain one-shot reconnect behavior for ranged reads
- replace the fixed SSH container sleep with an authenticated readiness probe
- cover positive, suffix, and negative-end ranges and the live Zarr v3 SSH path

## Why

The canonical Zarr v3 sharding codec reads its index from a suffix byte range. sshfs accepts the range keywords but returns the complete file, causing deterministic shard-index checksum failures. This is the prerequisite fix for the SSH job in #431 and the stacked final migration epic.

## Validation

- pre-commit run --all-files
- pytest -q -p no:warnings tests/test_reconnecting_fs.py: 19 passed, 1 skipped
- live SSH Zarr v3 reconnect/copy test: 1 passed