### PR TITLE
docs: rebuild CLI reference against 2.0 alphas

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -1,14 +1,25 @@
 name: docs
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/build-and-deploy-docs.yml"
+      - "docs/**"
+      - "README.md"
+      - "pyproject.toml"
+      - "src/**"
+      - "uv.lock"
+      - "zensical.toml"
   push:
     branches:
       - main
+      - v2.0
 
-# This job installs dependencies, builds the book, and pushes it to
-# the `gh-pages` branch of the same repository.
+permissions:
+  contents: read
+
 jobs:
-  deploy-book:
+  build-book:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -44,15 +55,20 @@ jobs:
       - name: Install plugin packages for CLI introspection
         env:
           UV_TORCH_BACKEND: cpu
-        # Pin minimum versions to the releases that ship the normalized command docstrings, so the
-        # rendered CLI reference can't regress to an older (pre-normalization) plugin.
-        run: uv pip install "copick>=1.24.1" "copick-utils>=1.7.1" "copick-torch>=1.1.1" "copick-mcp>=0.6.0"
+        # Use the exact migrated plugin releases so generated docs exercise the same
+        # OME-Zarr 0.5 / Zarr v3 package set as copick 2.0 alpha users.
+        run: uv pip install "copick-utils==2.0.0a1" "copick-torch==2.0.0a1" "copick-mcp>=0.6.0"
 
       # copick-easymode is git-only (not on PyPI) and its CLI module defers all heavy imports
       # (easymode/TensorFlow), so a --no-deps install is enough for make_cli_docs to introspect
       # `copick inference easymode` without pulling TensorFlow or the git-easymode/old-numpy chain.
       - name: Install copick-easymode for CLI introspection
         run: uv pip install --no-deps "copick-easymode @ git+https://github.com/copick/copick-easymode.git"
+
+      # Plugin dependency resolution may replace the checkout with a released copick
+      # wheel. Restore the branch under test while retaining the installed plugins.
+      - name: Restore the locked checkout runtime
+        run: uv sync --locked --extra docs --inexact
 
       # Regenerate the per-command CLI reference pages and the CLI-Reference nav node
       # from the live --help/docstrings before building.
@@ -64,7 +80,27 @@ jobs:
         run: |
           zensical build
 
-      # Push the site to github-pages
+      - name: Upload rendered site
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-site-${{ github.sha }}
+          path: site/
+          if-no-files-found: error
+          retention-days: 1
+
+  deploy-book:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build-book
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download rendered site
+        uses: actions/download-artifact@v7
+        with:
+          name: docs-site-${{ github.sha }}
+          path: site/
+
       - name: GitHub Pages action
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/docs/cli/add/object.md
+++ b/docs/cli/add/object.md
@@ -32,7 +32,7 @@ attached to the object.
 | `--color` | text | — | RGBA color for the object as comma-separated values (e.g. '255,0,0,255' for red). |
 | `--emdb-id` | text | — | EMDB ID for the object. |
 | `--pdb-id` | text | — | PDB ID for the object. |
-| `--identifier` | text | — | Identifier for the object (e.g. Gene Ontology ID or UniProtKB accession). |
+| `--identifier` | text | — | Ontology/database identifier for the object (namespaces: GO, UniProtKB, CHEBI, PDB [dash separator, e.g. PDB-1BXN], UBERON, CL, CDPO). |
 | `--map-threshold` | float | — | Threshold to apply to the map when rendering the isosurface. |
 | `--radius` | float | `50` | Radius of the particle, when displaying as a sphere. |
 | `--metadata` | text | — | Additional metadata values to associate with the object, in JSON format. |

--- a/docs/cli/convert/index.md
+++ b/docs/cli/convert/index.md
@@ -24,7 +24,7 @@ contributed by installed plugins.
 | [`mesh2caps`](mesh2caps.md) | Extract the top/bottom surfaces (caps) of a slab box mesh. |
 | [`mesh2picks`](mesh2picks.md) | Convert meshes to picks using different sampling strategies. |
 | [`mesh2seg`](mesh2seg.md) | Convert meshes to segmentation volumes. |
-| [`nnunet`](nnunet.md) | Convert a CoPick project to nnUNet raw... |
+| [`nnunet`](nnunet.md) | Convert a copick project to nnUNet raw dataset format. |
 | [`picks2ellipsoid`](picks2ellipsoid.md) | Convert picks to ellipsoid meshes. |
 | [`picks2mesh`](picks2mesh.md) | Convert picks to meshes using convex hull or alpha shapes. |
 | [`picks2plane`](picks2plane.md) | Convert picks to plane meshes. |

--- a/docs/cli/convert/mesh2caps.md
+++ b/docs/cli/convert/mesh2caps.md
@@ -108,13 +108,13 @@ Meshes: object_name:user_id/session_id
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input mesh URI (format: object_name:user_id/session_id). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/convert/mesh2picks.md
+++ b/docs/cli/convert/mesh2picks.md
@@ -131,13 +131,13 @@ Tomograms: tomo_type@voxel_spacing
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input mesh URI (format: object_name:user_id/session_id). Supports glob patterns. |
 | `--tomogram, -t` | COPICK_URI | **required** | Tomogram URI (format: tomo_type@voxel_spacing). Example: 'wbp@10.0' |
 

--- a/docs/cli/convert/mesh2seg.md
+++ b/docs/cli/convert/mesh2seg.md
@@ -109,13 +109,13 @@ Segmentations: name:user_id/session_id@voxel_spacing?multilabel=true
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input mesh URI (format: object_name:user_id/session_id). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/convert/nnunet.md
+++ b/docs/cli/convert/nnunet.md
@@ -5,7 +5,7 @@
 
 <span class="source-badge source-badge--torch" title="Provided by the copick-torch plugin">torch</span>
 
-*Convert a CoPick project to nnUNet raw...*
+*Convert a copick project to nnUNet raw dataset format.*
 
 ??? info "Plugin command — copick-torch"
     This command is provided by the **[copick-torch](https://pypi.org/project/copick-torch/)** plugin, not copick core. Install it to make this command available:
@@ -24,7 +24,15 @@ copick convert nnunet [OPTIONS]
 
 ## Description
 
-Convert a CoPick project to nnUNet raw dataset format (imagesTr / labelsTr / imagesTs).
+Reads tomograms and segmentation masks from a copick project and writes them
+as .nii.gz files in the nnUNet raw dataset layout (a `Dataset{id}_{name}`
+folder containing `imagesTr`, `labelsTr`, and optionally `imagesTs`). A
+`dataset.json` describing the channel and label map is generated from the
+targets config stored in the copick overlay.
+
+Training runs default to every run not listed in the test set. The tomogram
+voxel spacing is read from the tomogram URI and converted from Angstroms to
+nanometres so that nnUNet's patch-size planner sees reasonable numbers.
 
 ## Options
 
@@ -39,3 +47,26 @@ Convert a CoPick project to nnUNet raw dataset format (imagesTr / labelsTr / ima
 | `-n, --dataset-name` | text | **required** | nnUNet dataset name |
 | `-o, --output` | path | **required** | Path to nnunet_raw output directory |
 | `-j, --num-workers` | integer | `4` | Number of parallel worker threads for converting tomograms. |
+
+## Examples
+
+```bash
+# Convert all runs in a project to an nnUNet dataset
+copick convert nnunet -c config.json --dataset-name Membrane \
+    --output /data/nnunet_raw
+
+# Convert with an explicit tomogram URI, segmentation info, and dataset id
+copick convert nnunet -c config.json --tomo-uri wbp@10.0 \
+    --seg-info targets,nnunet,1 --dataset-id 5 --dataset-name Membrane \
+    --output /data/nnunet_raw
+
+# Convert with an explicit train/test split and more worker threads
+copick convert nnunet -c config.json --dataset-name Membrane \
+    --train-run-ids run1,run2,run3 --test-run-ids run4,run5 \
+    --output /data/nnunet_raw -j 8
+```
+
+## See also
+
+- [`copick training nnunet`](../training/nnunet.md) — train an nnUNet model on the converted dataset
+- [`copick inference nnunet`](../inference/nnunet.md) — run inference with a trained nnUNet model

--- a/docs/cli/convert/picks2ellipsoid.md
+++ b/docs/cli/convert/picks2ellipsoid.md
@@ -63,13 +63,13 @@ Meshes: object_name:user_id/session_id
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input picks URI (format: object_name:user_id/session_id). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/convert/picks2mesh.md
+++ b/docs/cli/convert/picks2mesh.md
@@ -66,20 +66,20 @@ Meshes: object_name:user_id/session_id
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input picks URI (format: object_name:user_id/session_id). Supports glob patterns. |
 
 ### Tool Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--mesh-type, -t` | choice (convex_hull \| alpha_shape) | `convex_hull` | Type of mesh to create. |
+| `--mesh-type, -mt` | choice (convex_hull \| alpha_shape) | `convex_hull` | Type of mesh to create. |
 | `--alpha, -a` | float | — | Alpha parameter for alpha shapes (required if mesh-type=alpha_shape). |
 | `--use-clustering, -cl / --no-use-clustering` | boolean flag | `False` | Cluster points before mesh creation. |
 | `--clustering-method` | choice (dbscan \| kmeans) | `dbscan` | Clustering method. |

--- a/docs/cli/convert/picks2plane.md
+++ b/docs/cli/convert/picks2plane.md
@@ -62,13 +62,13 @@ Meshes: object_name:user_id/session_id
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input picks URI (format: object_name:user_id/session_id). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/convert/picks2seg.md
+++ b/docs/cli/convert/picks2seg.md
@@ -61,13 +61,13 @@ Segmentations: name:user_id/session_id@voxel_spacing
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input picks URI (format: object_name:user_id/session_id). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/convert/picks2slab.md
+++ b/docs/cli/convert/picks2slab.md
@@ -121,13 +121,13 @@ Tomograms: tomo_type@voxel_spacing
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input1, -i1` | COPICK_URI | **required** | First input picks URI (format: object_name:user_id/session_id). Supports glob patterns. |
 | `--input2, -i2` | COPICK_URI | **required** | Second input picks URI (format: object_name:user_id/session_id). Supports glob patterns. |
 
@@ -178,3 +178,8 @@ copick convert picks2slab -c config.json \
     --grid-resolution 7 7 --fit-resolution 100 100 \
     -o "sample:picks2slab/fitted"
 ```
+
+## See also
+
+- [`copick convert seg2slab`](seg2slab.md) — fit a slab mesh to a boundary segmentation instead of picks
+- [`copick convert mesh2caps`](mesh2caps.md) — extract the top/bottom cap surfaces of the resulting slab mesh

--- a/docs/cli/convert/picks2sphere.md
+++ b/docs/cli/convert/picks2sphere.md
@@ -65,13 +65,13 @@ Meshes: object_name:user_id/session_id
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input picks URI (format: object_name:user_id/session_id). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/convert/picks2surface.md
+++ b/docs/cli/convert/picks2surface.md
@@ -64,13 +64,13 @@ Meshes: object_name:user_id/session_id
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input picks URI (format: object_name:user_id/session_id). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/convert/seg2mesh.md
+++ b/docs/cli/convert/seg2mesh.md
@@ -64,13 +64,13 @@ Meshes: object_name:user_id/session_id
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input segmentation URI (format: name:user_id/session_id@voxel_spacing). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/convert/seg2picks.md
+++ b/docs/cli/convert/seg2picks.md
@@ -63,13 +63,13 @@ Picks: object_name:user_id/session_id
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input segmentation URI (format: name:user_id/session_id@voxel_spacing). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/convert/seg2slab.md
+++ b/docs/cli/convert/seg2slab.md
@@ -129,13 +129,13 @@ Meshes: object_name:user_id/session_id
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input segmentation URI (format: name:user_id/session_id@voxel_spacing). Supports glob patterns. |
 
 ### Tool Options
@@ -174,3 +174,7 @@ copick convert seg2slab -c config.json \
     --label 1 --method iou --fit-resolution 100 100 \
     -o "sample:seg2slab/fitted"
 ```
+
+## See also
+
+- [`copick convert picks2slab`](picks2slab.md) — fit the same slab surfaces to picked points instead of a segmentation

--- a/docs/cli/export/picks.md
+++ b/docs/cli/export/picks.md
@@ -32,10 +32,10 @@ and Euler-angle conventions, see the docstrings in `copick.util.formats`.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--picks-uri` | text | **required** | URI to filter picks for export (e.g., 'ribosome:user1/*' or '*:*/*'). |
 | `--output-dir` | directory | — | Output directory for per-run export (one file per run). Mutually exclusive with --output-file. |
 | `--output-file` | file | — | Output file for combined export (all runs in one file). Mutually exclusive with --output-dir. |
-| `--run-names` | text | — | Comma-separated list of run names to process. |
 | `--output-format` | choice (em \| star \| dynamo \| csv) | **required** | Output format for picks. |
 | `--voxel-size` | float | — | Voxel size in Angstrom (required for EM, STAR, and Dynamo formats). |
 | `--index-map` | path | — | CSV/TSV file mapping tomogram index to run name. Required for combined EM/Dynamo export, optional for per-run. |

--- a/docs/cli/export/segmentation.md
+++ b/docs/cli/export/segmentation.md
@@ -27,8 +27,8 @@ pyramid. Restrict the export to specific runs with `--run-names`.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--segmentation-uri` | text | **required** | URI to filter segmentations for export (e.g., 'membrane:user1/*@10.0'). |
-| `--run-names` | text | `""` | Comma-separated list of run names to export. If not specified, exports from all runs. |
 | `--output-dir` | directory | **required** | Output directory for exported files. |
 | `--output-format` | choice (mrc \| tiff \| zarr \| em) | **required** | Output format for segmentations. |
 | `--copy-all-levels / --level-only` | boolean flag | `True` | Copy all pyramid levels for Zarr output. |

--- a/docs/cli/export/tomogram.md
+++ b/docs/cli/export/tomogram.md
@@ -27,8 +27,8 @@ writes the full multiscale pyramid. Restrict the export to specific runs with
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--tomogram-uri` | text | **required** | URI to filter tomograms for export (e.g., 'wbp@10.0' or '*@*'). |
-| `--run-names` | text | `""` | Comma-separated list of run names to export. If not specified, exports from all runs. |
 | `--output-dir` | directory | **required** | Output directory for exported files. |
 | `--output-format` | choice (mrc \| tiff \| zarr) | **required** | Output format for tomograms. |
 | `--copy-all-levels / --level-only` | boolean flag | `True` | Copy all pyramid levels for Zarr output. |

--- a/docs/cli/inference/index.md
+++ b/docs/cli/inference/index.md
@@ -22,5 +22,5 @@ contributed by installed plugins.
 | Command | Description |
 |---------|-------------|
 | [`easymode`](easymode.md) | Segment tomograms using easymode pretrained models. |
-| [`membrain-seg`](membrain-seg.md) | Runs the membrane segmentation command. |
-| [`nnunet`](nnunet.md) | Run nnUNet inference on CoPick tomograms... |
+| [`membrain-seg`](membrain-seg.md) | Segment membranes in tomograms with MemBrain-seg. |
+| [`nnunet`](nnunet.md) | Run nnUNet inference on CoPick tomograms. |

--- a/docs/cli/inference/membrain-seg.md
+++ b/docs/cli/inference/membrain-seg.md
@@ -5,7 +5,7 @@
 
 <span class="source-badge source-badge--torch" title="Provided by the copick-torch plugin">torch</span>
 
-*Runs the membrane segmentation command.*
+*Segment membranes in tomograms with MemBrain-seg.*
 
 ??? info "Plugin command — copick-torch"
     This command is provided by the **[copick-torch](https://pypi.org/project/copick-torch/)** plugin, not copick core. Install it to make this command available:
@@ -22,15 +22,67 @@
 copick inference membrain-seg [OPTIONS]
 ```
 
+## Description
+
+For every run in the project (or only the runs given by --run-names/-r), queries
+the tomogram of the given algorithm at the
+requested voxel spacing, runs the MemBrain-seg model with sliding-window inference
+(using test-time augmentation and input normalization), and writes the resulting
+membrane segmentation back into the project. Runs are processed in parallel on a
+GPU pool.
+
+A `threshold` of 0 stores the raw membrane probability map, while a positive
+threshold binarizes the prediction. The model weights are downloaded automatically
+on first use if they are not already cached. The output is saved as a segmentation
+named `membranes`.
+
+## URI Format
+
+```text
+Segmentations: name:user_id/session_id@voxel_spacing
+```
+
 ## Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--config` | text | **required** | Path to Copick Config for Processing Data |
-| `--tomo-alg` | text | **required** | Tomogram Algorithm to use |
-| `--voxel-size` | float | `10` | Voxel Size to Query the Data |
-| `--session-id` | text | `1` | Session ID for the Saved Membrane Segmentation |
-| `--user-id` | text | `membrain-seg` | User ID for the Saved Membrane Segmentation |
-| `--threshold` | float | `0` | Segmentation Threshold for Membrane Segmentation |
+| `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
+| `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
+
+### Input Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--tomo-alg, -ta` | text | **required** | Tomogram algorithm/type to query and segment (e.g. 'wbp'). |
+| `--voxel-size, -vs` | float | `10.0` | Voxel spacing to query, in angstroms. |
+
+### Tool Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--threshold, -t` | float | `0.0` | Segmentation threshold for the membrane probability map (0 keeps the raw map). |
+
+### Output Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--user-id, -u` | text | `membrain-seg` | User ID for the saved membrane segmentation. |
+| `--session-id, -s` | text | `1` | Session ID for the saved membrane segmentation. |
+
+## Examples
+
+```bash
+# Segment membranes in wbp tomograms at 10 A
+copick inference membrain-seg -c config.json --tomo-alg wbp --voxel-size 10.0
+
+# Binarize the prediction and tag the output user/session
+copick inference membrain-seg -c config.json --tomo-alg wbp --voxel-size 10.0 \
+    --threshold 0.5 --user-id membrain-seg --session-id 1
+```
+
+## See also
+
+- [`copick process downsample`](../process/downsample.md) — downsample tomograms before segmentation
 
 --8<-- "docs/cli_editorial/inference/membrain-seg.md"

--- a/docs/cli/inference/nnunet.md
+++ b/docs/cli/inference/nnunet.md
@@ -5,7 +5,7 @@
 
 <span class="source-badge source-badge--torch" title="Provided by the copick-torch plugin">torch</span>
 
-*Run nnUNet inference on CoPick tomograms...*
+*Run nnUNet inference on CoPick tomograms.*
 
 ??? info "Plugin command — copick-torch"
     This command is provided by the **[copick-torch](https://pypi.org/project/copick-torch/)** plugin, not copick core. Install it to make this command available:
@@ -24,7 +24,14 @@ copick inference nnunet [OPTIONS]
 
 ## Description
 
-Run nnUNet inference on CoPick tomograms and write predictions back.
+For every run in the project (or only the runs given by --run-names/-r), queries the requested tomogram, runs sliding-window
+nnUNet prediction, and writes the resulting segmentation back into the CoPick
+project. All available GPUs are used automatically, with run IDs sharded across
+devices for batch inference.
+
+Repeat `-w/--weights` to ensemble multiple folds (logits are averaged before
+argmax). Both standard nnUNet and MedNeXt trainers are supported; the trainer
+class is resolved from the checkpoint metadata.
 
 ## Options
 
@@ -36,5 +43,27 @@ Run nnUNet inference on CoPick tomograms and write predictions back.
 | `-w, --weights` | path · multiple | **required** | Path to checkpoint .pth (repeat for fold ensembling, e.g. -w fold_0/checkpoint_best.pth -w fold_1/checkpoint_best.pth) |
 | `-turi, --tomo-uri` | text | `wbp@10.0` | Tomogram URI to predict |
 | `--tta` | boolean | `True` | Enable mirroring TTA. |
-| `--run-ids, -runs` | text | — | CoPick run IDs to predict (comma-separated). |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `-suri, --seg-uri` | text | `predict:nnunet/1` | Segmentation URI to write (name:user_id/session_id) |
+
+## Examples
+
+```bash
+# Segment all runs with a single-fold model, writing to predict:nnunet/1
+copick inference nnunet -c config.json -p plans.json -d dataset.json \
+    -w fold_0/checkpoint_best.pth -turi wbp@10.0
+
+# Ensemble multiple folds and write to a custom segmentation URI
+copick inference nnunet -c config.json -p plans.json -d dataset.json \
+    -w fold_0/checkpoint_best.pth -w fold_1/checkpoint_best.pth \
+    -suri membrane:nnunet/1
+
+# Predict only specific runs with mirroring TTA disabled
+copick inference nnunet -c config.json -p plans.json -d dataset.json \
+    -w fold_0/checkpoint_best.pth -r TS_01 -r TS_02 --tta False
+```
+
+## See also
+
+- [`copick convert nnunet`](../convert/nnunet.md) — build the nnUNet training dataset from a CoPick project
+- [`copick training nnunet`](../training/nnunet.md) — train the nnUNet model used for inference

--- a/docs/cli/logical/clipmesh.md
+++ b/docs/cli/logical/clipmesh.md
@@ -85,13 +85,13 @@ Tomograms: tomo_type@voxel_spacing
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input mesh URI (format: object_name:user_id/session_id). Supports glob patterns. |
 
 ### Reference Options

--- a/docs/cli/logical/clippicks.md
+++ b/docs/cli/logical/clippicks.md
@@ -88,13 +88,13 @@ Tomograms: tomo_type@voxel_spacing
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input picks URI (format: object_name:user_id/session_id). Supports glob patterns. |
 
 ### Reference Options

--- a/docs/cli/logical/clipseg.md
+++ b/docs/cli/logical/clipseg.md
@@ -86,13 +86,13 @@ Tomograms: tomo_type@voxel_spacing
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input segmentation URI (format: name:user_id/session_id@voxel_spacing). Supports glob patterns. |
 
 ### Reference Options

--- a/docs/cli/logical/enclosed.md
+++ b/docs/cli/logical/enclosed.md
@@ -70,13 +70,13 @@ Segmentations: name:user_id/session_id (voxel spacing specified via --voxel-spac
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input1, -i1` | COPICK_URI | **required** | First input segmentation URI (format: name:user_id/session_id@voxel_spacing). Supports glob patterns. |
 | `--input2, -i2` | COPICK_URI | **required** | Second input segmentation URI (format: name:user_id/session_id@voxel_spacing). Supports glob patterns. |
 

--- a/docs/cli/logical/meshop.md
+++ b/docs/cli/logical/meshop.md
@@ -132,13 +132,13 @@ Meshes: object_name:user_id/session_id
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI · multiple | **required** | Input mesh URI (format: object_name:user_id/session_id). Can be specified multiple times for N-way operations. Supports glob patterns (default) or regex patterns (re: prefix). |
 
 ### Tool Options

--- a/docs/cli/logical/picksin.md
+++ b/docs/cli/logical/picksin.md
@@ -60,13 +60,13 @@ Segmentations: name:user_id/session_id@voxel_spacing
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input picks URI (format: object_name:user_id/session_id). Supports glob patterns. |
 
 ### Reference Options

--- a/docs/cli/logical/picksout.md
+++ b/docs/cli/logical/picksout.md
@@ -60,13 +60,13 @@ Segmentations: name:user_id/session_id@voxel_spacing
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input picks URI (format: object_name:user_id/session_id). Supports glob patterns. |
 
 ### Reference Options

--- a/docs/cli/logical/segop.md
+++ b/docs/cli/logical/segop.md
@@ -135,13 +135,13 @@ Segmentations: name:user_id/session_id (voxel spacing supplied via --voxel-spaci
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI · multiple | **required** | Input segmentation URI (format: name:user_id/session_id@voxel_spacing). Can be specified multiple times for N-way operations. Supports glob patterns (default) or regex patterns (re: prefix). |
 
 ### Tool Options

--- a/docs/cli/process/bandpass.md
+++ b/docs/cli/process/bandpass.md
@@ -5,7 +5,7 @@
 
 <span class="source-badge source-badge--torch" title="Provided by the copick-torch plugin">torch</span>
 
-*3D bandpass filter tomograms.*
+*Band-pass filter tomograms in 3D.*
 
 ??? info "Plugin command — copick-torch"
     This command is provided by the **[copick-torch](https://pypi.org/project/copick-torch/)** plugin, not copick core. Install it to make this command available:
@@ -22,16 +22,72 @@
 copick process bandpass [OPTIONS]
 ```
 
+## Description
+
+For every run in the project (or only the runs given by --run-names/-r), queries the
+input tomogram, applies a Gaussian band-pass filter on the GPU, and writes the
+filtered tomogram back into the project. The output is named by -o/--output, or (when
+omitted) the source name with -lp<freq>A and/or -hp<freq>A suffixes. Band-pass does
+not resample, so the output voxel spacing matches the input. Runs are processed in
+parallel on a GPU pool.
+
+Low-pass and high-pass cutoffs are given as resolutions in angstroms; a value of 0
+disables that side of the filter, but both cannot be 0. Cutoffs finer than Nyquist
+(2 * voxel_size) are rejected, and for a true band-pass the high-pass resolution must
+be coarser than the low-pass resolution. Optionally writes a PNG preview of the filter
+profile (filter3d.png).
+
+## URI Format
+
+```text
+Tomograms: tomo_type@voxel_spacing
+```
+
 ## Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--config` | text | **required** | Path to Copick Config for Processing Data |
-| `--run-ids` | text | — | Run ID to process (No Input would process the entire dataset.) |
-| `--tomo-alg` | text | **required** | Tomogram Algorithm to use |
-| `--voxel-size` | float | `10` | Voxel Size to Query the Data |
+| `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
+| `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
+
+### Input Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--input, -i` | COPICK_URI | — | Input tomogram URI (format: tomo_type@voxel_spacing). Supports glob patterns. |
+
+### Output Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--output, -o` | COPICK_URI | — | Output tomogram URI (format: tomo_type@voxel_spacing). Example: 'wbp@20.0'. |
+
+### Tool Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
 | `--lp-freq` | float | `0` | Low-pass cutoff frequency (in Angstroms) |
 | `--lp-decay` | float | `50` | Low-pass decay width (in pixels) |
 | `--hp-freq` | float | `0` | High-pass cutoff frequency (in Angstroms) |
 | `--hp-decay` | float | `50` | High-pass decay width (in pixels) |
 | `--show-filter` | boolean | `True` | Save the filter as a PNG (filter3d.png) |
+
+## Examples
+
+```bash
+# Low-pass filter wbp tomograms at 10 A voxel spacing to 30 A resolution
+copick process bandpass -c config.json -i wbp@10.0 --lp-freq 30.0
+
+# Band-pass a single run between 100 A (high-pass) and 30 A (low-pass)
+copick process bandpass -c config.json -i wbp@10.0 -r TS_001 \
+    --lp-freq 30.0 --hp-freq 100.0
+
+# High-pass the whole dataset into a named output, skipping the preview PNG
+copick process bandpass -c config.json -i wbp@10.0 -o wbp-hp150A@10.0 \
+    --hp-freq 150.0 --show-filter false
+```
+
+## See also
+
+- [`copick process downsample`](downsample.md) — downsample tomograms via Fourier rescaling

--- a/docs/cli/process/combine.md
+++ b/docs/cli/process/combine.md
@@ -62,13 +62,13 @@ Use glob/regex patterns to match multiple segmentations per run.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input segmentation URI (format: name:user_id/session_id@voxel_spacing). Supports glob patterns. |
 | `--workers, -w` | integer | `8` | Number of worker processes. |
 

--- a/docs/cli/process/downsample.md
+++ b/docs/cli/process/downsample.md
@@ -5,7 +5,7 @@
 
 <span class="source-badge source-badge--torch" title="Provided by the copick-torch plugin">torch</span>
 
-*Downsample tomograms with Fourier Re-Scaling.*
+*Downsample tomograms via Fourier rescaling.*
 
 ??? info "Plugin command — copick-torch"
     This command is provided by the **[copick-torch](https://pypi.org/project/copick-torch/)** plugin, not copick core. Install it to make this command available:
@@ -22,12 +22,57 @@
 copick process downsample [OPTIONS]
 ```
 
+## Description
+
+Downsample tomograms on the GPU with Fourier rescaling.
+
+For every run in the project (or only the runs given by --run-names/-r), queries
+the input tomogram, Fourier-rescales it to the output voxel spacing on the GPU, and
+writes the downsampled tomogram back into the project. The output voxel spacing (and
+optional rename) is taken from -o/--output. Runs are processed in parallel on a GPU pool.
+
+## URI Format
+
+```text
+Tomograms: tomo_type@voxel_spacing
+```
+
 ## Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--config` | text | **required** | Path to Copick Config for Processing Data |
-| `--tomo-alg` | text | **required** | Tomogram Algorithm to use |
-| `--voxel-size` | float | `10` | Voxel Size to Query the Data |
-| `--target-resolution` | float | `10` | Target Resolution to Downsample to |
-| `--delete-source` | boolean | `False` | Delete the source tomograms after downsampling |
+| `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
+| `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
+
+### Input Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--input, -i` | COPICK_URI | — | Input tomogram URI (format: tomo_type@voxel_spacing). Supports glob patterns. |
+
+### Output Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--output, -o` | COPICK_URI | — | Output tomogram URI (format: tomo_type@voxel_spacing). Example: 'wbp@20.0'. |
+
+### Tool Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--delete-source / --keep-source` | boolean flag | `False` | Delete the source tomograms after downsampling. |
+
+## Examples
+
+```bash
+# Downsample wbp tomograms from 10 A to 20 A
+copick process downsample -c config.json -i wbp@10.0 -o wbp@20.0
+
+# Downsample and rename the output, then delete the source tomograms
+copick process downsample -c config.json -i wbp@10.0 -o wbp-bin2@20.0 --delete-source
+```
+
+## See also
+
+- [`copick process bandpass`](bandpass.md) — band-pass filter tomograms without resampling

--- a/docs/cli/process/expand-labels.md
+++ b/docs/cli/process/expand-labels.md
@@ -63,13 +63,13 @@ Segmentations: name:user_id/session_id@voxel_spacing
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input segmentation URI (format: name:user_id/session_id@voxel_spacing). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/process/filter-components.md
+++ b/docs/cli/process/filter-components.md
@@ -62,13 +62,13 @@ Segmentations: name:user_id/session_id@voxel_spacing
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input segmentation URI (format: name:user_id/session_id@voxel_spacing). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/process/fit-spline.md
+++ b/docs/cli/process/fit-spline.md
@@ -62,15 +62,14 @@ Picks: object_name:user_id/session_id
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input segmentation URI (format: name:user_id/session_id@voxel_spacing). Supports glob patterns. |
-| `--voxel-spacing, -vs` | float | **required** | Voxel spacing for coordinate scaling. |
 
 ### Tool Options
 
@@ -94,13 +93,13 @@ Picks: object_name:user_id/session_id
 ## Examples
 
 ```bash
-# Fit splines to skeletonized components
+# Fit splines to skeletonized components (voxel spacing from the @10.0 in -i)
 copick process fit_spline -i "skeleton:skel/inst-.*@10.0" \
-    -o "skeleton:spline/spline-{input_session_id}" --spacing-distance 4.4 --voxel-spacing 10.0
+    -o "skeleton:spline/spline-{input_session_id}" --spacing-distance 4.4
 
 # Process a single skeleton component
 copick process fit_spline -i "skeleton:skel/skel-0@10.0" \
-    -o "skeleton:spline/spline-0" --spacing-distance 2.0 --voxel-spacing 10.0
+    -o "skeleton:spline/spline-0" --spacing-distance 2.0
 ```
 
 ## See also

--- a/docs/cli/process/hull.md
+++ b/docs/cli/process/hull.md
@@ -59,13 +59,13 @@ Meshes: object_name:user_id/session_id
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input mesh URI (format: object_name:user_id/session_id). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/process/index.md
+++ b/docs/cli/process/index.md
@@ -21,9 +21,9 @@ Subcommands are contributed by installed plugins.
 
 | Command | Description |
 |---------|-------------|
-| [`bandpass`](bandpass.md) | 3D bandpass filter tomograms. |
+| [`bandpass`](bandpass.md) | Band-pass filter tomograms in 3D. |
 | [`combine`](combine.md) | Combine single-label segmentations into a multilabel segmentation. |
-| [`downsample`](downsample.md) | Downsample tomograms with Fourier Re-Scaling. |
+| [`downsample`](downsample.md) | Downsample tomograms via Fourier rescaling. |
 | [`expand-labels`](expand-labels.md) | Expand labels in segmentations to fill holes and gaps. |
 | [`filter-components`](filter-components.md) | Filter connected components in segmentations by size. |
 | [`fit-spline`](fit-spline.md) | Fit 3D splines to skeletons and generate oriented picks. |

--- a/docs/cli/process/rescale.md
+++ b/docs/cli/process/rescale.md
@@ -58,13 +58,13 @@ Segmentations: name:user_id/session_id@voxel_spacing
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input segmentation URI (format: name:user_id/session_id@voxel_spacing). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/process/seg-stats.md
+++ b/docs/cli/process/seg-stats.md
@@ -41,13 +41,13 @@ Voxel spacing is optional — omit to match all voxel spacings.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input segmentation URI (format: name:user_id/session_id@voxel_spacing). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/process/separate-components.md
+++ b/docs/cli/process/separate-components.md
@@ -60,13 +60,13 @@ Segmentations: name:user_id/session_id@voxel_spacing
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input segmentation URI (format: name:user_id/session_id@voxel_spacing). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/process/skeletonize.md
+++ b/docs/cli/process/skeletonize.md
@@ -63,13 +63,13 @@ Segmentations: name:user_id/session_id@voxel_spacing
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input segmentation URI (format: name:user_id/session_id@voxel_spacing). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/process/split.md
+++ b/docs/cli/process/split.md
@@ -71,13 +71,13 @@ Label-to-Object Mapping:
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input segmentation URI (format: name:user_id/session_id@voxel_spacing). Supports glob patterns. |
 
 ### Tool Options

--- a/docs/cli/process/thickness-filter.md
+++ b/docs/cli/process/thickness-filter.md
@@ -63,20 +63,20 @@ Segmentations: name:user_id/session_id@voxel_spacing
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--input, -i` | COPICK_URI | **required** | Input segmentation URI (format: name:user_id/session_id@voxel_spacing). Supports glob patterns. |
 
 ### Tool Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--min-thickness, -t` | float | **required** | Minimum thickness (diameter) of structures to keep. Unit set by --thickness-unit. |
+| `--min-thickness, -mt` | float | — | Minimum thickness (diameter) of structures to keep. Unit set by --thickness-unit. |
 | `--thickness-unit` | choice (angstrom \| voxel) | `angstrom` | Unit for --min-thickness: 'angstrom' for Å, 'voxel' for voxel diameters. |
 | `--workers, -w` | integer | `8` | Number of worker processes. |
 

--- a/docs/cli/process/validbox.md
+++ b/docs/cli/process/validbox.md
@@ -63,13 +63,13 @@ Tomograms: tomo_type@voxel_spacing
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--debug / --no-debug` | boolean flag | `False` | Enable debug logging. |
 
 ### Input Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). |
 | `--tomogram, -t` | COPICK_URI | **required** | Tomogram URI (format: tomo_type@voxel_spacing). Example: 'wbp@10.0' |
 
 ### Tool Options

--- a/docs/cli/stats/meshes.md
+++ b/docs/cli/stats/meshes.md
@@ -26,7 +26,7 @@ JSON.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
-| `--runs` | text · multiple | — | Specific run names to analyze. Can be specified multiple times. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--user-id` | text · multiple | — | Filter by user ID. Can be specified multiple times. |
 | `--session-id` | text · multiple | — | Filter by session ID. Can be specified multiple times. |
 | `--object-name` | text · multiple | — | Filter by pickable object name. Can be specified multiple times. |

--- a/docs/cli/stats/picks.md
+++ b/docs/cli/stats/picks.md
@@ -25,7 +25,7 @@ sessions, or objects, and printed as a human-readable table or as JSON.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
-| `--runs` | text · multiple | — | Specific run names to analyze. Can be specified multiple times. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--user-id` | text · multiple | — | Filter by user ID. Can be specified multiple times. |
 | `--session-id` | text · multiple | — | Filter by session ID. Can be specified multiple times. |
 | `--object-name` | text · multiple | — | Filter by pickable object name. Can be specified multiple times. |
@@ -41,7 +41,7 @@ sessions, or objects, and printed as a human-readable table or as JSON.
 copick stats picks --config config.json
 
 # Restrict the summary to specific runs
-copick stats picks --config config.json --runs TS_001 --runs TS_002
+copick stats picks --config config.json -r TS_001 -r TS_002
 
 # Filter by object and user, then emit JSON using parallel workers
 copick stats picks --config config.json --object-name ribosome --user-id alice \

--- a/docs/cli/stats/segmentations.md
+++ b/docs/cli/stats/segmentations.md
@@ -27,7 +27,7 @@ JSON.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `-c, --config` | path | — | Path to the configuration file. |
-| `--runs` | text · multiple | — | Specific run names to analyze. Can be specified multiple times. |
+| `--run-names, -r` | text · multiple | — | Specific run names to process (default: all runs). Repeatable; pass -r once per run. |
 | `--user-id` | text · multiple | — | Filter by user ID. Can be specified multiple times. |
 | `--session-id` | text · multiple | — | Filter by session ID. Can be specified multiple times. |
 | `--name` | text · multiple | — | Filter by segmentation name. Can be specified multiple times. |

--- a/docs/cli/training/index.md
+++ b/docs/cli/training/index.md
@@ -20,4 +20,4 @@ data. Subcommands are contributed by installed plugins.
 
 | Command | Description |
 |---------|-------------|
-| [`nnunet`](nnunet.md) | Plan, preprocess, and train nnUNet on a... |
+| [`nnunet`](nnunet.md) | Plan, preprocess, and train nnUNet on a CoPick dataset. |

--- a/docs/cli/training/nnunet.md
+++ b/docs/cli/training/nnunet.md
@@ -5,7 +5,7 @@
 
 <span class="source-badge source-badge--torch" title="Provided by the copick-torch plugin">torch</span>
 
-*Plan, preprocess, and train nnUNet on a...*
+*Plan, preprocess, and train nnUNet on a CoPick dataset.*
 
 ??? info "Plugin command — copick-torch"
     This command is provided by the **[copick-torch](https://pypi.org/project/copick-torch/)** plugin, not copick core. Install it to make this command available:
@@ -24,7 +24,17 @@ copick training nnunet [OPTIONS]
 
 ## Description
 
-Plan, preprocess, and train nnUNet on a CoPick dataset.
+Runs nnUNet planning and preprocessing followed by training on a dataset that
+already exists in `nnunet_raw` (produced by `copick convert nnunet`). The command
+first invokes `nnUNetv2_plan_and_preprocess` to fingerprint the dataset and plan
+patch sizes, then runs `nnUNetv2_train` once per requested fold. Pass
+`--skip-preprocess` to reuse an existing plan.
+
+The `--model` flag selects the architecture and the matching trainer class:
+`nnunet` (standard nnUNet), `resnecl` (Residual Encoder Large), and the MedNeXt
+variants (`mednext_s`, `mednext_b`, `mednext_m`, `mednext_l`). MedNeXt trainers
+require the MedNeXt package to be installed. If a fold checkpoint already exists in
+the results directory, training resumes from it automatically.
 
 ## Options
 
@@ -39,3 +49,26 @@ Plan, preprocess, and train nnUNet on a CoPick dataset.
 | `-f, --folds` | text | `0` | Folds to train, e.g. 0 or 0,1,2,3,4 |
 | `-m, --model` | choice (nnunet \| resnecl \| mednext_s \| mednext_b \| mednext_m \| mednext_l) | `nnunet` | Model architecture to train. |
 | `-skip, --skip-preprocess` | boolean flag | `False` | Skip nnUNetv2_plan_and_preprocess (useful if already done). |
+
+## Examples
+
+```bash
+# Plan, preprocess, and train the default nnUNet on fold 0
+copick training nnunet -n my_dataset -id 1 \
+    -r ./nnUNet_raw -pre ./nnUNet_preprocessed -o ./nnUNet_results
+
+# Train a MedNeXt Medium model across all five folds
+copick training nnunet -n my_dataset -id 1 \
+    -r ./nnUNet_raw -pre ./nnUNet_preprocessed -o ./nnUNet_results \
+    --model mednext_m --folds 0,1,2,3,4
+
+# Reuse an existing plan and resume training, skipping preprocessing
+copick training nnunet -n my_dataset -id 1 \
+    -r ./nnUNet_raw -pre ./nnUNet_preprocessed -o ./nnUNet_results \
+    --skip-preprocess
+```
+
+## See also
+
+- [`copick convert nnunet`](../convert/nnunet.md) — convert a CoPick project into an nnUNet raw dataset
+- [`copick inference nnunet`](../inference/nnunet.md) — run inference with a trained nnUNet model

--- a/docs/processing_tools.md
+++ b/docs/processing_tools.md
@@ -39,7 +39,7 @@ Convert one copick type to another.
 
     **[nnunet](cli/convert/nnunet.md)**
 
-    Convert a CoPick project to nnUNet raw...
+    Convert a copick project to nnUNet raw dataset format.
 
     [:octicons-arrow-right-24: Details](cli/convert/nnunet.md)
 
@@ -135,7 +135,7 @@ Apply processing methods to copick data.
 
     **[bandpass](cli/process/bandpass.md)**
 
-    3D bandpass filter tomograms.
+    Band-pass filter tomograms in 3D.
 
     [:octicons-arrow-right-24: Details](cli/process/bandpass.md)
 
@@ -151,7 +151,7 @@ Apply processing methods to copick data.
 
     **[downsample](cli/process/downsample.md)**
 
-    Downsample tomograms with Fourier Re-Scaling.
+    Downsample tomograms via Fourier rescaling.
 
     [:octicons-arrow-right-24: Details](cli/process/downsample.md)
 

--- a/docs/snippets/processing_carousel.snippet
+++ b/docs/snippets/processing_carousel.snippet
@@ -39,7 +39,7 @@
 
     **[downsample](cli/process/downsample.md)**
 
-    Downsample tomograms with Fourier Re-Scaling.
+    Downsample tomograms via Fourier rescaling.
 
 -   [![clippicks](assets/tools/logical/clippicks.png){ .tool-thumb }](cli/logical/clippicks.md)
 
@@ -91,7 +91,7 @@
 
     **[downsample](cli/process/downsample.md)**
 
-    Downsample tomograms with Fourier Re-Scaling.
+    Downsample tomograms via Fourier rescaling.
 
 -   [![clippicks](assets/tools/logical/clippicks.png){ .tool-thumb }](cli/logical/clippicks.md)
 


### PR DESCRIPTION
## Summary

- restore pull-request and v2.0 documentation builds now that the downstream migration releases exist
- pin CLI introspection to copick-utils 2.0.0a1 and copick-torch 2.0.0a1 while building copick from the checked-out 2.0 alpha branch
- regenerate all 97 CLI pages, including 52 updates from the released plugin command surfaces
- keep GitHub Pages deployment restricted to pushes on main while uploading rendered sites for validation

## Validation

- resolved copick, copick-utils, and copick-torch together at 2.0.0a1 in an isolated Python 3.13 environment
- uv lock --check
- make_cli_docs --check
- zensical build
- pre-commit run --all-files

This closes the documentation-build deferral recorded in the final migration work after the copick-utils and copick-torch alpha.1 releases.