### PR TITLE
feat: add Embrella backend (config_type "embrella")

### DIFF
--- a/docs/api_reference/implementations/Embrella.md
+++ b/docs/api_reference/implementations/Embrella.md
@@ -1,0 +1,71 @@
+The Embrella implementation is a concrete implementation of the abstract copick API that reads tomograms in place from
+an [Embrella](https://github.com/czimaginginstitute/embrella) server's processing tree (no data duplication) and
+reads/writes annotations to the per-session copick overlay projects managed by Embrella. Tomogram versions (AreTomo3 or
+DenoisET processing runs and reconstruction types) are selected per session in the configuration. The Embrella
+implementation is defined in the `copick.impl.embrella` module.
+
+## Metadata Models
+
+[](){#CopickConfigEmbrella}
+::: copick.impl.embrella.CopickConfigEmbrella
+
+****
+
+[](){#EmbrellaSessionSpec}
+::: copick.impl.embrella.EmbrellaSessionSpec
+
+****
+
+[](){#EmbrellaTomoSelection}
+::: copick.impl.embrella.EmbrellaTomoSelection
+
+****
+
+[](){#EmbrellaClusterSpec}
+::: copick.impl.embrella.EmbrellaClusterSpec
+
+
+## Data Entities
+
+[](){#CopickRootEmbrella}
+::: copick.impl.embrella.CopickRootEmbrella
+
+****
+
+[](){#CopickObjectEmbrella}
+::: copick.impl.embrella.CopickObjectEmbrella
+
+****
+
+[](){#CopickRunEmbrella}
+::: copick.impl.embrella.CopickRunEmbrella
+
+****
+
+[](){#CopickPicksEmbrella}
+::: copick.impl.embrella.CopickPicksEmbrella
+
+****
+
+[](){#CopickMeshEmbrella}
+::: copick.impl.embrella.CopickMeshEmbrella
+
+****
+
+[](){#CopickSegmentationEmbrella}
+::: copick.impl.embrella.CopickSegmentationEmbrella
+
+****
+
+[](){#CopickVoxelSpacingEmbrella}
+::: copick.impl.embrella.CopickVoxelSpacingEmbrella
+
+****
+
+[](){#CopickTomogramEmbrella}
+::: copick.impl.embrella.CopickTomogramEmbrella
+
+****
+
+[](){#CopickFeaturesEmbrella}
+::: copick.impl.embrella.CopickFeaturesEmbrella

--- a/docs/templates/configs/embrella.json
+++ b/docs/templates/configs/embrella.json
@@ -1,0 +1,55 @@
+{
+    "config_type": "embrella",
+    "name": "Example Embrella Project",
+    "description": "This copick project combines tomograms from multiple Embrella sessions.",
+    "version": "2.0.0",
+    "pickable_objects": [
+        {
+            "name": "proteasome",
+            "is_particle": true,
+            "identifier": "GO:0000502",
+            "label": 1,
+            "color": [255, 0, 0, 255],
+            "radius": 60,
+            "map_threshold": 0.0418
+        },
+        {
+            "name": "membrane",
+            "is_particle": false,
+            "identifier": "GO:0016020",
+            "label": 2,
+            "color": [0, 255, 0, 255],
+            "radius": 10
+        }
+    ],
+    "embrella_base_url": "https://umbrella.czbiohub.org",
+    "sessions": [
+        {
+            "name": "25aug25a",
+            "tomograms": [
+                {"proc_run": "run003", "recon_type": "dctf"},
+                {"proc_run": "run003", "recon_type": "sart"},
+                {"proc_run": "run001", "recon_type": "denoise"}
+            ],
+            "overlay_run": "run002"
+        },
+        {
+            "name": "25aug22b",
+            "tomograms": [
+                {"proc_run": "run001", "recon_type": "dctf", "cluster": "bruno", "voxel_size": 5.002}
+            ]
+        }
+    ],
+    "default_data_cluster": "czii",
+    "scope": "krios1",
+    "overlay_mode": "ssh",
+    "overlay_fs_args": {
+        "host": "login-01.hpc.example.com",
+        "username": "user.name"
+    },
+    "static_mode": "http",
+    "overlay_root": "local:///PATH/TO/PROJECT_OVERLAY_DIR",
+    "overlay_root_fs_args": {
+        "auto_mkdir": true
+    }
+}

--- a/src/copick/__init__.py
+++ b/src/copick/__init__.py
@@ -1,13 +1,14 @@
 __version__ = "2.0.0-alpha.1"
 
 from copick.models import COPICK_TYPES
-from copick.ops.open import from_croissant, from_czcdp_datasets, from_file, from_string, new_config
+from copick.ops.open import from_croissant, from_czcdp_datasets, from_embrella, from_file, from_string, new_config
 
 __all__ = [
     "from_file",
     "from_string",
     "from_croissant",
     "from_czcdp_datasets",
+    "from_embrella",
     "new_config",
     "__version__",
     "COPICK_TYPES",

--- a/src/copick/impl/embrella.py
+++ b/src/copick/impl/embrella.py
@@ -1,0 +1,1523 @@
+"""Copick backend serving tomograms from an Embrella server without duplicating data.
+
+Embrella (https://github.com/czimaginginstitute/embrella) is a cryo-ET data management
+service. It exposes a public HTTP API listing per-session copick overlay projects and
+serves the processing tree (AreTomo3/DenoisET output, including OME-Zarr tomograms)
+through per-cluster static file servers.
+
+This backend combines tomograms from multiple Embrella sessions into a single copick
+project. The static (read-only) side are the tomogram zarrs in the processing tree,
+addressed by ``(session, proc_run, recon_type, position)``. The writable overlay side
+are the per-session copick projects that Embrella creates on the cluster, so
+annotations made through this backend land in the same place as annotations made
+through Embrella itself (run names follow the shared ``{session}_{position}``
+convention).
+"""
+
+import json
+import random
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Type
+
+import fsspec
+from fsspec import AbstractFileSystem
+from fsspec.implementations.local import LocalFileSystem
+from pydantic import BaseModel, Field, ValidationError, field_validator
+from zarr.abc.store import Store
+
+from copick.impl.overlay import (
+    CopickFeaturesOverlay,
+    CopickMeshOverlay,
+    CopickObjectOverlay,
+    CopickPicksOverlay,
+    CopickRunOverlay,
+    CopickSegmentationOverlay,
+    CopickTomogramOverlay,
+    CopickVoxelSpacingOverlay,
+)
+from copick.models import (
+    CopickConfig,
+    CopickFeaturesMeta,
+    CopickMeshMeta,
+    CopickPicksFile,
+    CopickRoot,
+    CopickRunMeta,
+    CopickSegmentationMeta,
+    CopickTomogramMeta,
+    CopickVoxelSpacingMeta,
+    PickableObject,
+)
+from copick.util.log import get_logger
+from copick.util.ome import UNITFACTOR, zarr_root_exists
+from copick.util.store import copick_store
+
+# Don't import Geometry at runtime to keep CLI snappy
+if TYPE_CHECKING:
+    from trimesh.parent import Geometry
+
+logger = get_logger(__name__)
+
+# Reconstruction type -> (workflow directory, volume subdirectory) in the processing
+# tree. This mirrors Embrella's hardcoded AreTomo3 output convention. WBP volumes
+# (vol002) exist as MRC only and are therefore not supported.
+RECON_DIRS: Dict[str, Tuple[str, Optional[str]]] = {
+    "dctf": ("aretomo3", "vol001"),
+    "sart": ("aretomo3", "vol003"),
+    "denoise": ("denoise", None),
+}
+
+# Known CZII cluster file servers. Overridable via the config's "clusters" field.
+DEFAULT_CLUSTERS: Dict[str, Dict[str, str]] = {
+    "czii": {"http_base": "https://czii-onsite.czbiohub.org/"},
+    "bruno": {"http_base": "https://onsite.czbiohub.org/group.czii/"},
+}
+
+_VOL_SUFFIX = "_Vol.zarr"
+
+_SSL_CONTEXT_CACHE: List[Any] = []
+
+
+def _ssl_context():
+    """Return an SSL context using certifi's CA bundle when available.
+
+    Python environments (notably conda) frequently point OpenSSL at a missing default
+    CA path; certifi (a transitive copick dependency) is the reliable fallback.
+    """
+    if not _SSL_CONTEXT_CACHE:
+        import ssl
+
+        try:
+            import certifi
+
+            _SSL_CONTEXT_CACHE.append(ssl.create_default_context(cafile=certifi.where()))
+        except ImportError:
+            _SSL_CONTEXT_CACHE.append(ssl.create_default_context())
+    return _SSL_CONTEXT_CACHE[0]
+
+
+async def _get_http_client(**kwargs):
+    """aiohttp client factory for fsspec's HTTP filesystem using certifi's CA bundle."""
+    import aiohttp
+
+    connector = aiohttp.TCPConnector(ssl=_ssl_context())
+    return aiohttp.ClientSession(connector=connector, **kwargs)
+
+
+def _join_path(base: str, *parts: Optional[str]) -> str:
+    """Join URL or POSIX path segments, skipping empty segments (no duplicate slashes)."""
+    segments = [base.rstrip("/")]
+    segments.extend(p.strip("/") for p in parts if p)
+    return "/".join(segments)
+
+
+def _http_get(url: str, accept: Optional[str] = None, timeout: int = 60, retries: int = 3) -> bytes:
+    """GET a URL with retry/backoff on transient errors. 404s are raised immediately."""
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            headers = {"Accept": accept} if accept else {}
+            req = urllib.request.Request(url, headers=headers)
+            context = _ssl_context() if url.startswith("https") else None
+            with urllib.request.urlopen(req, timeout=timeout, context=context) as resp:  # noqa: S310
+                return resp.read()
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                raise
+            last_exc = e
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            last_exc = e
+
+        if attempt < retries - 1:
+            time.sleep(2**attempt + random.uniform(0, 0.5))
+
+    raise ConnectionError(f"Failed to fetch {url} after {retries} attempts: {last_exc}")
+
+
+def _entries_from_fs(fs: AbstractFileSystem, path: str) -> List[Dict[str, Any]]:
+    """List a directory through fsspec, normalized to ``{"name", "is_dir"}`` entries.
+
+    Junk entries produced by HTML link scraping (query links, parent references) are
+    dropped.
+    """
+    entries = fs.ls(path.rstrip("/") + "/", detail=True)
+    out = []
+    for e in entries:
+        name = e["name"].rstrip("/").rsplit("/", 1)[-1]
+        if not name or name in (".", "..") or name.startswith("?"):
+            continue
+        out.append({"name": name, "is_dir": e.get("type") == "directory"})
+    return out
+
+
+def _list_dir_http(url: str) -> List[Dict[str, Any]]:
+    """List a directory served by an Embrella file server.
+
+    Prefers Caddy's JSON browse listing (``Accept: application/json``), falling back to
+    fsspec's HTML link scraping.
+
+    Returns:
+        List of ``{"name": str, "is_dir": bool}`` entries.
+    """
+    listing_url = url.rstrip("/") + "/"
+    try:
+        data = json.loads(_http_get(listing_url, accept="application/json"))
+        if isinstance(data, list):
+            return [{"name": e["name"].rstrip("/"), "is_dir": bool(e.get("is_dir"))} for e in data]
+    except (json.JSONDecodeError, KeyError, TypeError):
+        pass
+
+    # Fallback: HTML link scraping via fsspec's HTTP filesystem.
+    proto = urllib.parse.urlparse(listing_url).scheme
+    fs_kwargs = {"get_client": _get_http_client} if proto == "https" else {}
+    fs = fsspec.filesystem(proto, **fs_kwargs)
+    return _entries_from_fs(fs, listing_url)
+
+
+def _positions_from_listing(entries: List[Dict[str, Any]]) -> List[str]:
+    """Extract tomogram position stems (``{stem}_Vol.zarr``) from a directory listing.
+
+    Enumeration is by suffix because position stems are not uniform (``Position_1_4``,
+    but also e.g. ``L2_Series3A_Pos1.mrc``). Even/odd half-reconstructions are excluded.
+    """
+    stems = set()
+    for e in entries:
+        name = e["name"]
+        if not name.endswith(_VOL_SUFFIX) or name.startswith("."):
+            continue
+        stem = name[: -len(_VOL_SUFFIX)]
+        if stem.endswith(("_EVN", "_ODD")):
+            continue
+        stems.add(stem)
+    return sorted(stems)
+
+
+def _voxel_size_from_zattrs(zattrs: Dict[str, Any]) -> float:
+    """Extract the level-0 voxel size (Angstrom) from OME-NGFF multiscales attributes.
+
+    Handles both NGFF 0.4 (root-level ``multiscales``) and 0.5 (nested under ``ome``).
+    """
+    multiscales = zattrs.get("multiscales") or zattrs.get("ome", {}).get("multiscales")
+    if not multiscales:
+        raise ValueError("No multiscales metadata found in .zattrs")
+
+    unit = "angstrom"
+    for axis in multiscales[0].get("axes", []):
+        if axis.get("type") == "space" and "unit" in axis:
+            unit = axis["unit"]
+            break
+
+    for transform in multiscales[0]["datasets"][0].get("coordinateTransformations", []):
+        if transform.get("type") == "scale":
+            return float(transform["scale"][0]) * UNITFACTOR.get(unit, 1.0)
+
+    raise ValueError("No scale transformation found in multiscales metadata")
+
+
+class EmbrellaClusterSpec(BaseModel):
+    """Location of one cluster's processing tree.
+
+    Attributes:
+        http_base: Base URL of the cluster's static file server.
+        posix_base: POSIX base path of the processing tree (for local/ssh access).
+    """
+
+    http_base: str
+    posix_base: str = "/hpc/projects/group.czii/"
+
+
+class EmbrellaTomoSelection(BaseModel):
+    """One selected tomogram version: a processing run and reconstruction type.
+
+    Attributes:
+        proc_run: Embrella processing run name, e.g. "run003" (an AreTomo3 run for
+            dctf/sart, a DenoisET run for denoise).
+        recon_type: Reconstruction type, one of "dctf", "sart", "denoise".
+        cluster: Cluster (key into the config's clusters map) holding the tomogram
+            zarrs. Defaults to the config's default_data_cluster.
+        voxel_size: Voxel size override (Angstrom). If unset, the voxel size is read
+            from the first tomogram's OME-Zarr metadata.
+        positions: Pinned position stems. If unset, positions are enumerated by
+            listing the volume directory.
+    """
+
+    proc_run: str
+    recon_type: str
+    cluster: Optional[str] = None
+    voxel_size: Optional[float] = None
+    positions: Optional[List[str]] = None
+
+    @field_validator("recon_type")
+    @classmethod
+    def _validate_recon_type(cls, v: str) -> str:
+        v = v.lower()
+        if v == "wbp":
+            raise ValueError(
+                "WBP reconstructions are stored as MRC only (no zarr is produced) and cannot be "
+                "served by the embrella backend. Choose one of 'dctf', 'sart' or 'denoise'.",
+            )
+        if v not in RECON_DIRS:
+            raise ValueError(f"Unknown recon_type '{v}'. Supported types are {sorted(RECON_DIRS)}.")
+        return v
+
+    @field_validator("proc_run")
+    @classmethod
+    def _validate_proc_run(cls, v: str) -> str:
+        if "_" in v:
+            raise ValueError(
+                "proc_run must not contain underscores (the derived tomo_type is used in "
+                "'{tomo_type}_{feature_type}_features.zarr' file names).",
+            )
+        return v
+
+    @property
+    def tomo_type(self) -> str:
+        """The copick tomo_type for this selection, e.g. "run003-dctf"."""
+        return f"{self.proc_run}-{self.recon_type}"
+
+
+class EmbrellaSessionSpec(BaseModel):
+    """One Embrella session contributing tomograms to the project.
+
+    Attributes:
+        name: The Embrella session name (MsiSession.name), e.g. "25aug25a".
+        tomograms: Tomogram versions to expose from this session.
+        overlay_run: Name of the Embrella copick project (processing run under the
+            copick plan) used as the annotation overlay for this session. If unset,
+            the newest completed project reported by the Embrella API is used.
+    """
+
+    name: str
+    tomograms: List[EmbrellaTomoSelection]
+    overlay_run: Optional[str] = None
+
+
+class CopickConfigEmbrella(CopickConfig):
+    """Copick configuration for Embrella-backed projects.
+
+    Attributes:
+        embrella_base_url: Base URL of the Embrella server, e.g.
+            "https://umbrella.czbiohub.org".
+        sessions: Embrella sessions (and per-session tomogram versions) to combine.
+        clusters: Cluster name -> file server locations. Defaults to the known CZII
+            clusters.
+        default_data_cluster: Cluster holding the tomogram zarrs unless overridden
+            per selection.
+        scope: The "{scope}.processing" path segment (falls back to this value when a
+            session has no Embrella copick project reporting its scope).
+        overlay_mode: How the per-session overlay projects are accessed: "local"
+            (POSIX paths, on-cluster), "ssh" (fsspec sshfs, off-cluster) or "http"
+            (read-only, via the file server).
+        overlay_fs_args: Filesystem arguments for the overlay access (e.g. sshfs
+            host/username for "ssh" mode).
+        static_mode: How tomogram zarrs are read: "http" (default) or "local".
+        static_fs_args: Filesystem arguments for static access.
+        overlay_root: Optional project-level overlay URL used to store pickable
+            object templates (Objects/). Without it, objects are config-only.
+        overlay_root_fs_args: Filesystem arguments for the project-level overlay.
+        exclude_overlay_tomo_types: Tomo types hidden from overlay projects (e.g.
+            legacy duplicated "dctf" imports).
+    """
+
+    config_type: str = "embrella"
+    embrella_base_url: str
+    sessions: List[EmbrellaSessionSpec]
+
+    clusters: Dict[str, EmbrellaClusterSpec] = Field(
+        default_factory=lambda: {k: EmbrellaClusterSpec(**v) for k, v in DEFAULT_CLUSTERS.items()},
+    )
+    default_data_cluster: str = "czii"
+    scope: str = "krios1"
+
+    overlay_mode: Literal["local", "ssh", "http"] = "local"
+    overlay_fs_args: Optional[Dict[str, Any]] = {}
+    static_mode: Literal["http", "local"] = "http"
+    static_fs_args: Optional[Dict[str, Any]] = {}
+
+    overlay_root: Optional[str] = None
+    overlay_root_fs_args: Optional[Dict[str, Any]] = {}
+
+    exclude_overlay_tomo_types: List[str] = []
+
+
+@dataclass
+class EmbrellaSessionEntry:
+    """Resolved per-session state: the overlay project location and scope."""
+
+    session: str
+    scope: str
+    overlay_run: Optional[str] = None
+    cluster_id: Optional[str] = None
+    overlay_url: Optional[str] = None
+    overlay_posix: Optional[str] = None
+    read_only: bool = True
+    pickable_objects: List[Dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class EmbrellaTomoRecord:
+    """One static tomogram: a position of a (session, proc_run, recon_type) selection."""
+
+    session: str
+    proc_run: str
+    recon_type: str
+    position: str
+    tomo_type: str
+    voxel_size: float
+    static_url: str
+    static_posix: str
+
+
+@dataclass
+class EmbrellaIndex:
+    """In-memory index of all static entities served by this project."""
+
+    sessions: Dict[str, EmbrellaSessionEntry] = field(default_factory=dict)
+    runs: Dict[str, Tuple[str, str]] = field(default_factory=dict)
+    tomos_by_run: Dict[str, List[EmbrellaTomoRecord]] = field(default_factory=dict)
+
+
+def _build_index(data: Dict[str, Any]) -> EmbrellaIndex:
+    """Build the in-memory index from the (JSON-serializable) fetch payload."""
+    index = EmbrellaIndex()
+
+    for sess in data["sessions"]:
+        entry = EmbrellaSessionEntry(
+            session=sess["session"],
+            scope=sess["scope"],
+            overlay_run=sess.get("overlay_run"),
+            cluster_id=sess.get("cluster_id"),
+            overlay_url=sess.get("overlay_url"),
+            overlay_posix=sess.get("overlay_posix"),
+            read_only=sess.get("read_only", True),
+            pickable_objects=sess.get("pickable_objects", []),
+        )
+        index.sessions[entry.session] = entry
+
+        for sel in sess["selections"]:
+            tomo_type = f"{sel['proc_run']}-{sel['recon_type']}"
+            for position in sel["positions"]:
+                run_name = f"{entry.session}_{position}"
+                record = EmbrellaTomoRecord(
+                    session=entry.session,
+                    proc_run=sel["proc_run"],
+                    recon_type=sel["recon_type"],
+                    position=position,
+                    tomo_type=tomo_type,
+                    voxel_size=sel["voxel_size"],
+                    static_url=_join_path(sel["data_url"], f"{position}{_VOL_SUFFIX}"),
+                    static_posix=_join_path(sel["data_posix"], f"{position}{_VOL_SUFFIX}"),
+                )
+                index.runs[run_name] = (entry.session, position)
+                index.tomos_by_run.setdefault(run_name, []).append(record)
+
+    return index
+
+
+class CopickPicksEmbrella(CopickPicksOverlay):
+    """CopickPicks stored in the owning session's Embrella copick overlay project."""
+
+    run: "CopickRunEmbrella"
+
+    @property
+    def path(self) -> str:
+        return f"{self.run.overlay_path}/Picks/{self.user_id}_{self.session_id}_{self.pickable_object_name}.json"
+
+    @property
+    def directory(self) -> str:
+        return f"{self.run.overlay_path}/Picks/"
+
+    @property
+    def fs(self) -> Optional[AbstractFileSystem]:
+        return self.run.fs_overlay
+
+    def _load(self) -> CopickPicksFile:
+        if self.fs is None or not self.fs.exists(self.path):
+            logger.critical(f"File not found: {self.path}")
+            raise FileNotFoundError(f"File not found: {self.path}")
+
+        with self.fs.open(self.path, "r") as f:
+            data = json.load(f)
+
+        return CopickPicksFile(**data)
+
+    def _store(self) -> None:
+        if self.fs is None:
+            raise PermissionError(f"Run {self.run.name} has no writable Embrella overlay project.")
+
+        if not self.fs.exists(self.directory):
+            self.fs.makedirs(self.directory, exist_ok=True)
+
+        with self.fs.open(self.path, "w") as f:
+            json.dump(self.meta.model_dump(), f, indent=4)
+
+    def _delete_data(self) -> None:
+        if self.fs is not None and self.fs.exists(self.path):
+            self.fs.rm(self.path)
+        else:
+            raise FileNotFoundError(f"File not found: {self.path}")
+
+
+class CopickMeshEmbrella(CopickMeshOverlay):
+    """CopickMesh stored in the owning session's Embrella copick overlay project."""
+
+    run: "CopickRunEmbrella"
+
+    @property
+    def path(self) -> str:
+        return f"{self.run.overlay_path}/Meshes/{self.user_id}_{self.session_id}_{self.pickable_object_name}.glb"
+
+    @property
+    def directory(self) -> str:
+        return f"{self.run.overlay_path}/Meshes/"
+
+    @property
+    def fs(self) -> Optional[AbstractFileSystem]:
+        return self.run.fs_overlay
+
+    def _load(self) -> "Geometry":
+        if self.fs is None or not self.fs.exists(self.path):
+            logger.critical(f"File not found: {self.path}")
+            raise FileNotFoundError(f"File not found: {self.path}")
+
+        with self.fs.open(self.path, "rb") as f:
+            # Defer trimesh import to keep CLI snappy (trimesh imports scipy)
+            import trimesh
+
+            scene = trimesh.load(f, file_type="glb")
+
+        return scene
+
+    def _store(self) -> None:
+        if self.fs is None:
+            raise PermissionError(f"Run {self.run.name} has no writable Embrella overlay project.")
+
+        if not self.fs.exists(self.directory):
+            self.fs.makedirs(self.directory, exist_ok=True)
+
+        with self.fs.open(self.path, "wb") as f:
+            _ = self._mesh.export(f, file_type="glb")
+
+    def _delete_data(self) -> None:
+        if self.fs is not None and self.fs.exists(self.path):
+            self.fs.rm(self.path)
+        else:
+            raise FileNotFoundError(f"File not found: {self.path}")
+
+
+class CopickSegmentationEmbrella(CopickSegmentationOverlay):
+    """CopickSegmentation stored in the owning session's Embrella copick overlay project."""
+
+    run: "CopickRunEmbrella"
+
+    @property
+    def filename(self) -> str:
+        if self.is_multilabel:
+            return f"{self.voxel_size:.3f}_{self.user_id}_{self.session_id}_{self.name}-multilabel.zarr"
+        else:
+            return f"{self.voxel_size:.3f}_{self.user_id}_{self.session_id}_{self.name}.zarr"
+
+    @property
+    def path(self) -> str:
+        return f"{self.run.overlay_path}/Segmentations/{self.filename}"
+
+    @property
+    def fs(self) -> Optional[AbstractFileSystem]:
+        return self.run.fs_overlay
+
+    def zarr(self) -> Store:
+        """Get the zarr store for the segmentation object.
+
+        Returns:
+            Store: The zarr store for the segmentation object.
+        """
+        if self.fs is None:
+            raise PermissionError(f"Run {self.run.name} has no writable Embrella overlay project.")
+
+        if self.read_only:
+            mode = "r"
+            create = False
+        else:
+            mode = "w"
+            create = not self.fs.exists(self.path)
+
+        return copick_store(self.fs, self.path, read_only=mode == "r", create=create)
+
+    def _delete_data(self) -> None:
+        if self.fs is not None and self.fs.exists(self.path):
+            self.fs.rm(self.path, recursive=True)
+        else:
+            raise FileNotFoundError(f"File not found: {self.path}")
+
+
+class CopickFeaturesEmbrella(CopickFeaturesOverlay):
+    """CopickFeatures stored in the owning session's Embrella copick overlay project."""
+
+    tomogram: "CopickTomogramEmbrella"
+
+    @property
+    def path(self) -> str:
+        return f"{self.tomogram.overlay_stem}_{self.feature_type}_features.zarr"
+
+    @property
+    def fs(self) -> Optional[AbstractFileSystem]:
+        return self.tomogram.fs_overlay
+
+    def zarr(self) -> Store:
+        """Get the zarr store for the features object.
+
+        Returns:
+            Store: The zarr store for the features object.
+        """
+        if self.fs is None:
+            raise PermissionError(
+                f"Run {self.tomogram.voxel_spacing.run.name} has no writable Embrella overlay project.",
+            )
+
+        if self.read_only:
+            mode = "r"
+            create = False
+        else:
+            mode = "w"
+            create = not self.fs.exists(self.path)
+
+        return copick_store(self.fs, self.path, read_only=mode == "r", create=create)
+
+    def _delete_data(self) -> None:
+        if self.fs is not None and self.fs.exists(self.path):
+            self.fs.rm(self.path, recursive=True)
+        else:
+            raise FileNotFoundError(f"File not found: {self.path}")
+
+
+class CopickTomogramMetaEmbrella(CopickTomogramMeta):
+    """Tomogram metadata with Embrella provenance."""
+
+    embrella_session: Optional[str] = None
+    embrella_proc_run: Optional[str] = None
+    embrella_recon_type: Optional[str] = None
+    embrella_position: Optional[str] = None
+    embrella_static_url: Optional[str] = None
+    embrella_static_path: Optional[str] = None
+
+    @classmethod
+    def from_record(cls, record: EmbrellaTomoRecord) -> "CopickTomogramMetaEmbrella":
+        return cls(
+            tomo_type=record.tomo_type,
+            embrella_session=record.session,
+            embrella_proc_run=record.proc_run,
+            embrella_recon_type=record.recon_type,
+            embrella_position=record.position,
+            embrella_static_url=record.static_url,
+            embrella_static_path=record.static_posix,
+        )
+
+
+class CopickTomogramEmbrella(CopickTomogramOverlay):
+    """CopickTomogram served in place from the Embrella processing tree (static) or the
+    session's overlay project (writable)."""
+
+    voxel_spacing: "CopickVoxelSpacingEmbrella"
+    meta: CopickTomogramMetaEmbrella
+
+    def _feature_factory(self) -> Tuple[Type[CopickFeaturesEmbrella], Type[CopickFeaturesMeta]]:
+        return CopickFeaturesEmbrella, CopickFeaturesMeta
+
+    @property
+    def embrella_tomo(self) -> bool:
+        """Whether this tomogram is served from the Embrella processing tree."""
+        return self.meta.embrella_static_url is not None
+
+    @property
+    def static_path(self) -> Optional[str]:
+        if not self.embrella_tomo:
+            return None
+        root = self.voxel_spacing.run.root
+        if root.config.static_mode == "local":
+            return self.meta.embrella_static_path
+        return self.meta.embrella_static_url
+
+    @property
+    def fs_static(self) -> Optional[AbstractFileSystem]:
+        if not self.embrella_tomo:
+            return None
+        return self.voxel_spacing.run.root._static_fs_for(self.static_path)
+
+    @property
+    def overlay_path(self) -> Optional[str]:
+        base = self.voxel_spacing.overlay_path
+        return None if base is None else f"{base}/{self.tomo_type}.zarr"
+
+    @property
+    def overlay_stem(self) -> Optional[str]:
+        base = self.voxel_spacing.overlay_path
+        return None if base is None else f"{base}/{self.tomo_type}"
+
+    @property
+    def fs_overlay(self) -> Optional[AbstractFileSystem]:
+        return self.voxel_spacing.fs_overlay
+
+    def _query_static_features(self) -> List[CopickFeaturesEmbrella]:
+        # Embrella does not serve features.
+        return []
+
+    def _query_overlay_features(self) -> List[CopickFeaturesEmbrella]:
+        if self.fs_overlay is None or self.overlay_stem is None:
+            return []
+
+        root = self.voxel_spacing.run.root
+        entries = root.overlay_listdir(self.fs_overlay, self.voxel_spacing.overlay_path)
+        prefix = f"{self.tomo_type}_"
+        suffix = "_features.zarr"
+        feature_types = [
+            e["name"].removeprefix(prefix).removesuffix(suffix)
+            for e in entries
+            if e["is_dir"] and e["name"].startswith(prefix) and e["name"].endswith(suffix)
+        ]
+        feature_types = [ft for ft in feature_types if ft and not ft.startswith(".")]
+
+        feature_types = list(set(feature_types))
+        clz, meta_clz = self._feature_factory()
+
+        return [
+            clz(
+                tomogram=self,
+                meta=meta_clz(
+                    tomo_type=self.tomo_type,
+                    feature_type=ft,
+                ),
+                read_only=self.voxel_spacing.run.overlay_read_only,
+            )
+            for ft in feature_types
+        ]
+
+    def zarr(self) -> Store:
+        """Get the zarr store for the tomogram object.
+
+        Returns:
+            Store: The zarr store for the tomogram object.
+        """
+        if self.read_only:
+            fs = self.fs_static
+            path = self.static_path
+            mode = "r"
+            create = False
+        else:
+            fs = self.fs_overlay
+            path = self.overlay_path
+            if fs is None or path is None:
+                raise PermissionError(
+                    f"Run {self.voxel_spacing.run.name} has no writable Embrella overlay project.",
+                )
+            mode = "w"
+            create = not fs.exists(path)
+
+        return copick_store(fs, path, read_only=mode == "r", create=create)
+
+    def _delete_data(self) -> None:
+        if self.fs_overlay is not None and self.fs_overlay.exists(self.overlay_path):
+            self.fs_overlay.rm(self.overlay_path, recursive=True)
+        else:
+            raise FileNotFoundError(f"File not found: {self.overlay_path}")
+
+
+class CopickVoxelSpacingEmbrella(CopickVoxelSpacingOverlay):
+    """CopickVoxelSpacing combining static Embrella tomograms and overlay tomograms."""
+
+    run: "CopickRunEmbrella"
+
+    def _tomogram_factory(self) -> Tuple[Type[CopickTomogramEmbrella], Type[CopickTomogramMetaEmbrella]]:
+        return CopickTomogramEmbrella, CopickTomogramMetaEmbrella
+
+    @property
+    def overlay_path(self) -> Optional[str]:
+        base = self.run.overlay_path
+        return None if base is None else f"{base}/VoxelSpacing{self.voxel_size:.3f}"
+
+    @property
+    def fs_overlay(self) -> Optional[AbstractFileSystem]:
+        return self.run.fs_overlay
+
+    def _static_records(self) -> List[EmbrellaTomoRecord]:
+        records = self.run.root.index.tomos_by_run.get(self.run.name, [])
+        size = round(self.voxel_size, 3)
+        return [r for r in records if r.voxel_size == size]
+
+    def _query_static_tomograms(self) -> List[CopickTomogramEmbrella]:
+        clz, meta_clz = self._tomogram_factory()
+        return [
+            clz(
+                voxel_spacing=self,
+                meta=meta_clz.from_record(r),
+                read_only=True,
+            )
+            for r in self._static_records()
+        ]
+
+    def _query_overlay_tomograms(self) -> List[CopickTomogramEmbrella]:
+        if self.fs_overlay is None or self.overlay_path is None:
+            return []
+
+        entries = self.run.root.overlay_listdir(self.fs_overlay, self.overlay_path)
+        tomo_types = [
+            e["name"].removesuffix(".zarr") for e in entries if e["is_dir"] and e["name"].endswith(".zarr")
+        ]
+        tomo_types = [t for t in tomo_types if "features" not in t]
+        tomo_types = [tt for tt in tomo_types if tt and not tt.startswith(".")]
+        tomo_types = [tt for tt in tomo_types if tt not in self.run.root.config.exclude_overlay_tomo_types]
+
+        tomo_types = list(set(tomo_types))
+        clz, meta_clz = self._tomogram_factory()
+
+        return [
+            clz(
+                voxel_spacing=self,
+                meta=meta_clz(tomo_type=tt),
+                read_only=self.run.overlay_read_only,
+            )
+            for tt in tomo_types
+        ]
+
+    def ensure(self, create: bool = False) -> bool:
+        """Checks if the voxel spacing record exists in the static index or overlay directory,
+        optionally creating it in the overlay filesystem if it does not.
+
+        Args:
+            create: Whether to create the voxel spacing record if it does not exist.
+
+        Returns:
+            bool: True if the voxel spacing record exists, False otherwise.
+        """
+        exists = bool(self._static_records())
+
+        if not exists and self.fs_overlay is not None and self.overlay_path is not None:
+            exists = self.fs_overlay.exists(self.overlay_path)
+
+        if not exists and create:
+            if self.fs_overlay is None or self.overlay_path is None or self.run.overlay_read_only:
+                raise PermissionError(
+                    f"Run {self.run.name} has no writable Embrella overlay project.",
+                )
+            self.fs_overlay.makedirs(self.overlay_path, exist_ok=True)
+            with self.fs_overlay.open(self.overlay_path + "/.meta", "w") as f:
+                f.write("meta")  # Touch the file
+            return True
+        else:
+            return exists
+
+    def _delete_data(self) -> None:
+        if self.fs_overlay is not None and self.fs_overlay.exists(self.overlay_path):
+            self.fs_overlay.rm(self.overlay_path, recursive=True)
+        else:
+            raise FileNotFoundError(f"File not found: {self.overlay_path}")
+
+
+class CopickRunMetaEmbrella(CopickRunMeta):
+    """Run metadata with Embrella provenance."""
+
+    embrella_session: Optional[str] = None
+    embrella_position: Optional[str] = None
+
+
+class CopickRunEmbrella(CopickRunOverlay):
+    """CopickRun combining static Embrella tomograms and one session's overlay project.
+
+    Run names follow Embrella's copick convention ``{session}_{position}``, so overlay
+    annotations line up with the per-session copick projects created by Embrella.
+    """
+
+    root: "CopickRootEmbrella"
+    meta: CopickRunMetaEmbrella
+
+    def _voxel_spacing_factory(self) -> Tuple[Type[CopickVoxelSpacingEmbrella], Type[CopickVoxelSpacingMeta]]:
+        return CopickVoxelSpacingEmbrella, CopickVoxelSpacingMeta
+
+    def _picks_factory(self) -> Type[CopickPicksEmbrella]:
+        return CopickPicksEmbrella
+
+    def _mesh_factory(self) -> Tuple[Type[CopickMeshEmbrella], Type[CopickMeshMeta]]:
+        return CopickMeshEmbrella, CopickMeshMeta
+
+    def _segmentation_factory(self) -> Tuple[Type[CopickSegmentationEmbrella], Type[CopickSegmentationMeta]]:
+        return CopickSegmentationEmbrella, CopickSegmentationMeta
+
+    @property
+    def embrella_session(self) -> Optional[str]:
+        """The Embrella session this run belongs to."""
+        return self.meta.embrella_session or self.root.session_for_run(self.name)
+
+    @property
+    def embrella_position(self) -> Optional[str]:
+        """The position stem of this run within its Embrella session."""
+        if self.meta.embrella_position is not None:
+            return self.meta.embrella_position
+        hit = self.root.index.runs.get(self.name)
+        return hit[1] if hit else None
+
+    @property
+    def fs_overlay(self) -> Optional[AbstractFileSystem]:
+        return self.root.overlay_for_run(self.name)[0]
+
+    @property
+    def overlay_path(self) -> Optional[str]:
+        return self.root.overlay_for_run(self.name)[1]
+
+    @property
+    def overlay_read_only(self) -> bool:
+        return self.root.overlay_for_run(self.name)[2]
+
+    def _query_static_voxel_spacings(self) -> List[CopickVoxelSpacingEmbrella]:
+        records = self.root.index.tomos_by_run.get(self.name, [])
+        sizes = sorted({r.voxel_size for r in records})
+        clz, meta_clz = self._voxel_spacing_factory()
+
+        return [clz(meta=meta_clz(voxel_size=s), run=self) for s in sizes]
+
+    def _query_overlay_voxel_spacings(self) -> List[CopickVoxelSpacingEmbrella]:
+        if self.fs_overlay is None or self.overlay_path is None:
+            return []
+
+        entries = self.root.overlay_listdir(self.fs_overlay, self.overlay_path)
+        spacings = [
+            float(e["name"].removeprefix("VoxelSpacing"))
+            for e in entries
+            if e["is_dir"] and e["name"].startswith("VoxelSpacing")
+        ]
+
+        clz, meta_clz = self._voxel_spacing_factory()
+
+        return [
+            clz(
+                meta=meta_clz(voxel_size=s),
+                run=self,
+            )
+            for s in spacings
+        ]
+
+    def _query_static_picks(self) -> List[CopickPicksEmbrella]:
+        # Embrella does not serve annotations; they live in the overlay projects.
+        return []
+
+    def _query_overlay_picks(self) -> List[CopickPicksEmbrella]:
+        if self.fs_overlay is None or self.overlay_path is None:
+            return []
+
+        entries = self.root.overlay_listdir(self.fs_overlay, f"{self.overlay_path}/Picks")
+        names = [
+            e["name"].removesuffix(".json")
+            for e in entries
+            if not e["is_dir"] and e["name"].endswith(".json") and not e["name"].startswith(".")
+        ]
+
+        users = [n.split("_")[0] for n in names]
+        sessions = [n.split("_")[1] for n in names]
+        objects = [n.split("_")[2] for n in names]
+
+        assert len(users) == len(sessions) == len(objects)
+
+        return [
+            CopickPicksEmbrella(
+                run=self,
+                file=CopickPicksFile(
+                    pickable_object_name=o,
+                    user_id=u,
+                    session_id=s,
+                ),
+                read_only=self.overlay_read_only,
+            )
+            for u, s, o in zip(users, sessions, objects, strict=True)
+        ]
+
+    def _query_static_meshes(self) -> List[CopickMeshEmbrella]:
+        # Embrella does not serve annotations; they live in the overlay projects.
+        return []
+
+    def _query_overlay_meshes(self) -> List[CopickMeshEmbrella]:
+        if self.fs_overlay is None or self.overlay_path is None:
+            return []
+
+        entries = self.root.overlay_listdir(self.fs_overlay, f"{self.overlay_path}/Meshes")
+        names = [
+            e["name"].removesuffix(".glb")
+            for e in entries
+            if not e["is_dir"] and e["name"].endswith(".glb") and not e["name"].startswith(".")
+        ]
+
+        users = [n.split("_")[0] for n in names]
+        sessions = [n.split("_")[1] for n in names]
+        objects = [n.split("_")[2] for n in names]
+
+        clz, meta_clz = self._mesh_factory()
+
+        return [
+            clz(
+                run=self,
+                meta=meta_clz(
+                    pickable_object_name=o,
+                    user_id=u,
+                    session_id=s,
+                ),
+                read_only=self.overlay_read_only,
+            )
+            for u, s, o in zip(users, sessions, objects, strict=True)
+        ]
+
+    def _query_static_segmentations(self) -> List[CopickSegmentationEmbrella]:
+        # Embrella does not serve annotations; they live in the overlay projects.
+        return []
+
+    def _query_overlay_segmentations(self) -> List[CopickSegmentationEmbrella]:
+        if self.fs_overlay is None or self.overlay_path is None:
+            return []
+
+        entries = self.root.overlay_listdir(self.fs_overlay, f"{self.overlay_path}/Segmentations")
+        names = [
+            e["name"].removesuffix(".zarr")
+            for e in entries
+            if e["is_dir"] and e["name"].endswith(".zarr") and not e["name"].startswith(".")
+        ]
+
+        # Deduplicate
+        names = list(set(names))
+
+        # multilabel vs single label
+        metas = []
+        clz, meta_clz = self._segmentation_factory()
+        for n in names:
+            parts = n.split("_")
+            if "multilabel" in n:
+                metas.append(
+                    meta_clz(
+                        is_multilabel=True,
+                        voxel_size=float(parts[0]),
+                        user_id=parts[1],
+                        session_id=parts[2],
+                        name=parts[3].replace("-multilabel", ""),
+                    ),
+                )
+            else:
+                metas.append(
+                    meta_clz(
+                        is_multilabel=False,
+                        voxel_size=float(parts[0]),
+                        user_id=parts[1],
+                        session_id=parts[2],
+                        name=parts[3],
+                    ),
+                )
+
+        return [
+            clz(
+                run=self,
+                meta=m,
+                read_only=self.overlay_read_only,
+            )
+            for m in metas
+        ]
+
+    def ensure(self, create: bool = False) -> bool:
+        """Checks if the run exists in the static index or overlay project, optionally creating
+        it in the overlay filesystem if it does not.
+
+        Args:
+            create: Whether to create the run record if it does not exist.
+
+        Returns:
+            bool: True if the run record exists, False otherwise.
+        """
+        exists = self.name in self.root.index.runs
+
+        if not exists:
+            fs, path, _ = self.root.overlay_for_run(self.name)
+            if fs is not None and path is not None:
+                exists = fs.exists(path)
+
+        if not exists and create:
+            fs, path, read_only = self.root.overlay_for_run(self.name)
+            if fs is None or path is None:
+                raise ValueError(
+                    f"Cannot create run '{self.name}': it does not belong to any configured "
+                    f"Embrella session with a writable overlay project. Configured sessions: "
+                    f"{sorted(self.root.index.sessions)}.",
+                )
+            if read_only:
+                raise PermissionError(
+                    f"Cannot create run '{self.name}': the overlay project of session "
+                    f"'{self.root.session_for_run(self.name)}' is read-only.",
+                )
+            fs.makedirs(path, exist_ok=True)
+            with fs.open(path + "/.meta", "w") as f:
+                f.write("meta")  # Touch the file
+            return True
+        else:
+            return exists
+
+    def _delete_data(self) -> None:
+        fs, path, _ = self.root.overlay_for_run(self.name)
+        if fs is not None and path is not None and fs.exists(path):
+            fs.rm(path, recursive=True)
+        else:
+            raise FileNotFoundError(f"File not found: {path}")
+
+
+class CopickObjectEmbrella(CopickObjectOverlay):
+    """CopickObject with templates stored in the optional project-level overlay.
+
+    The per-session overlay projects are shared Embrella artifacts, so project-global
+    object templates are not written into them. Without a project-level
+    ``overlay_root`` in the config, objects are config-only (no density maps).
+    """
+
+    root: "CopickRootEmbrella"
+
+    @property
+    def path(self) -> Optional[str]:
+        if self.root.root_objects is None:
+            return None
+        return f"{self.root.root_objects}/Objects/{self.name}.zarr"
+
+    @property
+    def fs(self) -> Optional[AbstractFileSystem]:
+        return self.root.fs_objects
+
+    def zarr(self) -> Optional[Store]:
+        if not self.is_particle:
+            return None
+
+        if self.fs is None:
+            self.root._warn_no_object_root()
+            return None
+
+        # Read-only objects have no destination when their map is absent.
+        if self.read_only and not self.has_density_map():
+            return None
+
+        if self.read_only:
+            mode = "r"
+            create = False
+        else:
+            mode = "w"
+            create = not self.fs.exists(self.path)
+
+        return copick_store(self.fs, self.path, read_only=mode == "r", create=create)
+
+    def has_density_map(self) -> bool:
+        """Return whether the project-level overlay contains Zarr root metadata for this object."""
+        if not self.is_particle or self.fs is None:
+            return False
+        return zarr_root_exists(self.fs, self.path)
+
+    def _delete_data(self) -> None:
+        if self.fs is not None and self.fs.exists(self.path):
+            self.fs.rm(self.path, recursive=True)
+
+
+class CopickRootEmbrella(CopickRoot):
+    """CopickRoot combining tomograms from multiple Embrella sessions.
+
+    At construction the root builds an in-memory index by querying the Embrella
+    projects API (one call per session), fetching each session's overlay project
+    ``config.json``, enumerating tomogram zarrs via the cluster file servers and
+    reading one ``.zattrs`` per selection for the voxel size. All static queries are
+    served from this index; no further network round trips per run.
+    """
+
+    config: CopickConfigEmbrella
+
+    def __init__(self, config: CopickConfigEmbrella):
+        import weakref
+
+        from copick.util.reconnecting_fs import ReconnectingFileSystem
+
+        super().__init__(config)
+
+        self._index: Optional[EmbrellaIndex] = None
+        self._index_data: Optional[Dict[str, Any]] = None
+        self._fs_cache: Dict[str, AbstractFileSystem] = {}
+        self._warned_no_object_root = False
+
+        # Optional project-level overlay for pickable object templates.
+        self.fs_objects: Optional[AbstractFileSystem] = None
+        self.root_objects: Optional[str] = None
+        if config.overlay_root:
+            self.fs_objects = ReconnectingFileSystem(config.overlay_root, config.overlay_root_fs_args)
+            self.root_objects = self.fs_objects._strip_protocol(config.overlay_root).rstrip("/")
+            self.fs_objects._root_ref = weakref.ref(self)
+
+        # Eagerly build the index and per-session overlay filesystems.
+        self._ensure_index()
+        self._session_fs: Dict[str, Tuple[Optional[AbstractFileSystem], Optional[str], bool]] = (
+            self._build_session_filesystems()
+        )
+
+    @classmethod
+    def from_file(cls, path: str) -> "CopickRootEmbrella":
+        with open(path, "r") as f:
+            data = json.load(f)
+
+        return cls(CopickConfigEmbrella(**data))
+
+    @property
+    def index(self) -> EmbrellaIndex:
+        return self._ensure_index()
+
+    def _ensure_index(self) -> EmbrellaIndex:
+        if self._index is None:
+            self._index_data = self._fetch_index_data()
+            self._index = _build_index(self._index_data)
+        return self._index
+
+    def _fetch_index_data(self) -> Dict[str, Any]:
+        """Fetch all remote state into a JSON-serializable payload (see _build_index)."""
+        config = self.config
+        base = config.embrella_base_url.rstrip("/")
+        payload_sessions = []
+
+        for spec in config.sessions:
+            url = f"{base}/copick/v1/projects/?session_id={urllib.parse.quote(spec.name)}&status=all"
+            try:
+                data = json.loads(_http_get(url, accept="application/json"))
+                projects = data.get("projects", [])
+            except (ConnectionError, urllib.error.HTTPError) as e:
+                raise ConnectionError(f"Could not reach the Embrella projects API at {url}: {e}") from e
+
+            sess = self._resolve_session(spec, projects)
+            sess["selections"] = [self._resolve_selection(spec, sel, sess["scope"]) for sel in spec.tomograms]
+            payload_sessions.append(sess)
+
+        return {"sessions": payload_sessions}
+
+    def _resolve_session(self, spec: EmbrellaSessionSpec, projects: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Pick this session's overlay project and resolve its locations."""
+        project = None
+        if spec.overlay_run is not None:
+            matches = [p for p in projects if p.get("run_name") == spec.overlay_run]
+            if not matches:
+                logger.warning(
+                    f"Embrella session '{spec.name}': pinned overlay project '{spec.overlay_run}' was not "
+                    f"found; the session will be read-only.",
+                )
+            else:
+                project = matches[0]
+        elif projects:
+            candidates = sorted(projects, key=lambda p: p.get("created_at") or "", reverse=True)
+            completed = [p for p in candidates if p.get("status") == "completed"]
+            project = completed[0] if completed else candidates[0]
+        else:
+            logger.warning(
+                f"Embrella session '{spec.name}' has no copick overlay project; annotations will be "
+                f"unavailable (static tomograms are still served).",
+            )
+
+        sess: Dict[str, Any] = {
+            "session": spec.name,
+            "scope": self.config.scope,
+            "overlay_run": None,
+            "cluster_id": None,
+            "overlay_url": None,
+            "overlay_posix": None,
+            "read_only": True,
+            "pickable_objects": [],
+        }
+
+        if project is None:
+            return sess
+
+        sess["overlay_run"] = project.get("run_name")
+        sess["cluster_id"] = project.get("cluster_id")
+        sess["scope"] = project.get("scope") or self.config.scope
+        sess["overlay_url"] = (project.get("root_url") or "").rstrip("/") or None
+
+        config_url = project.get("config_url")
+        try:
+            overlay_config = json.loads(_http_get(config_url))
+            overlay_root = overlay_config.get("overlay_root") or ""
+            overlay_posix = overlay_root.removeprefix("local://").rstrip("/")
+            sess["overlay_posix"] = overlay_posix or None
+            sess["read_only"] = not overlay_posix
+            sess["pickable_objects"] = overlay_config.get("pickable_objects", [])
+        except (ConnectionError, urllib.error.HTTPError, json.JSONDecodeError) as e:
+            logger.warning(
+                f"Embrella session '{spec.name}': could not read the overlay project config at "
+                f"{config_url} ({e}); the session will be read-only.",
+            )
+
+        return sess
+
+    def _resolve_selection(
+        self,
+        spec: EmbrellaSessionSpec,
+        sel: EmbrellaTomoSelection,
+        scope: str,
+    ) -> Dict[str, Any]:
+        """Resolve one tomogram selection: data locations, positions and voxel size."""
+        cluster_key = sel.cluster or self.config.default_data_cluster
+        if cluster_key not in self.config.clusters:
+            raise ValueError(
+                f"Unknown cluster '{cluster_key}' for session '{spec.name}' selection "
+                f"'{sel.proc_run}:{sel.recon_type}'. Configured clusters: {sorted(self.config.clusters)}.",
+            )
+        cluster = self.config.clusters[cluster_key]
+
+        workflow, vol = RECON_DIRS[sel.recon_type]
+        data_url = _join_path(cluster.http_base, f"{scope}.processing", workflow, spec.name, sel.proc_run, vol)
+        data_posix = _join_path(cluster.posix_base, f"{scope}.processing", workflow, spec.name, sel.proc_run, vol)
+
+        context = f"session '{spec.name}', selection '{sel.proc_run}:{sel.recon_type}'"
+
+        positions = sel.positions
+        if positions is None:
+            positions = self._list_positions(data_url, data_posix, context)
+
+        if not positions:
+            logger.warning(
+                f"No tomogram zarrs found for {context} at "
+                f"{data_url if self.config.static_mode == 'http' else data_posix}. Check the cluster "
+                f"('{cluster_key}') and proc_run, or pin 'positions' in the config.",
+            )
+
+        voxel_size = sel.voxel_size
+        if voxel_size is None and positions:
+            voxel_size = self._sniff_voxel_size(data_url, data_posix, positions[0], context)
+
+        return {
+            "proc_run": sel.proc_run,
+            "recon_type": sel.recon_type,
+            "positions": positions,
+            "voxel_size": round(voxel_size, 3) if voxel_size is not None else None,
+            "data_url": data_url,
+            "data_posix": data_posix,
+        }
+
+    def _list_positions(self, data_url: str, data_posix: str, context: str) -> List[str]:
+        """Enumerate position stems by listing the volume directory."""
+        if self.config.static_mode == "local":
+            fs = self._static_fs_for(data_posix)
+            if not fs.exists(data_posix):
+                return []
+            return _positions_from_listing(_entries_from_fs(fs, data_posix))
+
+        try:
+            return _positions_from_listing(_list_dir_http(data_url))
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return []
+            raise
+        except ConnectionError as e:
+            raise ConnectionError(
+                f"Could not list tomograms for {context} at {data_url}: {e}. If the file server does "
+                f"not allow directory listings, pin 'positions' in the config.",
+            ) from e
+
+    def _sniff_voxel_size(self, data_url: str, data_posix: str, position: str, context: str) -> float:
+        """Read the voxel size from the first tomogram's OME-Zarr attributes."""
+        try:
+            if self.config.static_mode == "local":
+                zattrs_path = _join_path(data_posix, f"{position}{_VOL_SUFFIX}", ".zattrs")
+                fs = self._static_fs_for(zattrs_path)
+                with fs.open(zattrs_path, "r") as f:
+                    zattrs = json.load(f)
+            else:
+                zattrs_url = _join_path(data_url, f"{position}{_VOL_SUFFIX}", ".zattrs")
+                zattrs = json.loads(_http_get(zattrs_url))
+
+            return _voxel_size_from_zattrs(zattrs)
+        except (ConnectionError, urllib.error.HTTPError, OSError, json.JSONDecodeError, ValueError, KeyError) as e:
+            raise ValueError(
+                f"Could not determine the voxel size for {context} from the tomogram's OME-Zarr "
+                f"metadata ({e}). Set 'voxel_size' for this selection in the config.",
+            ) from e
+
+    def _build_session_filesystems(
+        self,
+    ) -> Dict[str, Tuple[Optional[AbstractFileSystem], Optional[str], bool]]:
+        """Build one (filesystem, root, read_only) triple per session for overlay access."""
+        import weakref
+
+        from copick.util.reconnecting_fs import ReconnectingFileSystem
+
+        mode = self.config.overlay_mode
+        out: Dict[str, Tuple[Optional[AbstractFileSystem], Optional[str], bool]] = {}
+        local_fs: Optional[AbstractFileSystem] = None
+        ssh_fs: Optional[AbstractFileSystem] = None
+
+        for name, entry in self.index.sessions.items():
+            fs: Optional[AbstractFileSystem] = None
+            root: Optional[str] = None
+            read_only = True
+
+            if mode == "http":
+                if entry.overlay_url is not None:
+                    fs = self._static_fs_for(entry.overlay_url)
+                    root = entry.overlay_url
+            elif entry.overlay_posix is not None and not entry.read_only:
+                if mode == "local":
+                    if local_fs is None:
+                        local_fs = LocalFileSystem(auto_mkdir=True)
+                    fs, root = local_fs, entry.overlay_posix
+                else:  # ssh
+                    if ssh_fs is None:
+                        ssh_fs = ReconnectingFileSystem(
+                            f"ssh://{entry.overlay_posix}",
+                            self.config.overlay_fs_args,
+                        )
+                        ssh_fs._root_ref = weakref.ref(self)
+                    fs, root = ssh_fs, entry.overlay_posix
+                read_only = False
+
+            out[name] = (fs, root, read_only if fs is not None else True)
+
+        return out
+
+    def _static_fs_for(self, path: str) -> AbstractFileSystem:
+        """Return a (cached) filesystem for a static URL or POSIX path."""
+        proto = urllib.parse.urlparse(path).scheme if "://" in path else "file"
+        if proto not in self._fs_cache:
+            fs_args = dict(self.config.static_fs_args or {})
+            if proto == "https" and "get_client" not in fs_args:
+                fs_args["get_client"] = _get_http_client
+            self._fs_cache[proto] = fsspec.filesystem(proto, **fs_args)
+        return self._fs_cache[proto]
+
+    def overlay_listdir(self, fs: AbstractFileSystem, path: str) -> List[Dict[str, Any]]:
+        """List an overlay directory, normalized to ``{"name", "is_dir"}`` entries.
+
+        Over HTTP, the file server's JSON listing is used (fsspec's HTML scraping and
+        glob are unreliable against directory index pages). A missing directory yields
+        an empty list.
+        """
+        proto = fs.protocol if isinstance(fs.protocol, str) else fs.protocol[0]
+        try:
+            if proto in ("http", "https"):
+                return _list_dir_http(path)
+            return _entries_from_fs(fs, path)
+        except FileNotFoundError:
+            return []
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return []
+            raise
+
+    def _warn_no_object_root(self) -> None:
+        if not self._warned_no_object_root:
+            logger.warning(
+                "This project has no project-level 'overlay_root'; pickable object templates cannot "
+                "be stored. Set 'overlay_root' in the config to enable object density maps.",
+            )
+            self._warned_no_object_root = True
+
+    def session_for_run(self, name: str) -> Optional[str]:
+        """Resolve the Embrella session owning a copick run name."""
+        hit = self.index.runs.get(name)
+        if hit is not None:
+            return hit[0]
+
+        candidates = [s for s in self.index.sessions if name.startswith(f"{s}_")]
+        return max(candidates, key=len) if candidates else None
+
+    def overlay_for_run(self, name: str) -> Tuple[Optional[AbstractFileSystem], Optional[str], bool]:
+        """Resolve the overlay (filesystem, run path, read_only) for a copick run name."""
+        session = self.session_for_run(name)
+        if session is None:
+            return None, None, True
+
+        fs, root, read_only = self._session_fs[session]
+        if fs is None or root is None:
+            return None, None, True
+
+        return fs, f"{root}/ExperimentRuns/{name}", read_only
+
+    def _run_factory(self) -> Tuple[Type[CopickRunEmbrella], Type[CopickRunMetaEmbrella]]:
+        return CopickRunEmbrella, CopickRunMetaEmbrella
+
+    def _object_factory(self) -> Tuple[Type[CopickObjectEmbrella], Type[PickableObject]]:
+        return CopickObjectEmbrella, PickableObject
+
+    def query(self) -> List[CopickRunEmbrella]:
+        names: Dict[str, Tuple[str, Optional[str]]] = {
+            run_name: (session, position) for run_name, (session, position) in self.index.runs.items()
+        }
+
+        # Union with runs that only exist in the overlay projects.
+        for session, (fs, root, _) in self._session_fs.items():
+            if fs is None or root is None:
+                continue
+            run_dir = f"{root}/ExperimentRuns"
+            try:
+                entries = self.overlay_listdir(fs, run_dir)
+            except (OSError, ConnectionError) as e:
+                logger.warning(f"Could not list overlay runs for session '{session}' at {run_dir}: {e}")
+                continue
+            for e in entries:
+                if not e["is_dir"] or e["name"].startswith("."):
+                    continue
+                names.setdefault(e["name"], (session, None))
+
+        clz, meta_clz = self._run_factory()
+        runs = []
+        for n in sorted(names):
+            session, position = names[n]
+            rm = meta_clz(name=n, embrella_session=session, embrella_position=position)
+            runs.append(clz(root=self, meta=rm))
+
+        return runs
+
+    def _query_objects(self) -> None:
+        """Objects are writable only when a project-level overlay_root is configured."""
+        clz, meta_clz = self._object_factory()
+        writable = self.fs_objects is not None
+        self._objects = [clz(self, obj_meta, read_only=not writable) for obj_meta in self.config.pickable_objects]
+
+    def overlay_pickable_objects(self) -> List[PickableObject]:
+        """Collect the pickable objects declared by the sessions' overlay projects.
+
+        Objects are deduplicated by name (first session wins); conflicting duplicate
+        definitions are reported.
+
+        Returns:
+            List[PickableObject]: The deduplicated objects.
+        """
+        out: Dict[str, PickableObject] = {}
+        for entry in self.index.sessions.values():
+            for obj_dict in entry.pickable_objects:
+                try:
+                    po = PickableObject(**obj_dict)
+                except ValidationError as e:
+                    logger.warning(
+                        f"Skipping invalid pickable object {obj_dict.get('name')!r} from session "
+                        f"'{entry.session}': {e}",
+                    )
+                    continue
+                if po.name in out:
+                    prev = out[po.name]
+                    if prev.label != po.label or prev.identifier != po.identifier:
+                        logger.warning(
+                            f"Conflicting definitions for pickable object '{po.name}' across overlay "
+                            f"projects; keeping the first one (label={prev.label}, "
+                            f"identifier={prev.identifier}).",
+                        )
+                    continue
+                out[po.name] = po
+
+        return list(out.values())
+
+    def refresh_index(self) -> None:
+        """Re-fetch the Embrella index and invalidate all cached entities."""
+        self._index = None
+        self._index_data = None
+        self._ensure_index()
+        self._session_fs = self._build_session_filesystems()
+        self._invalidate_all_caches()
+
+    def reconnect(self) -> None:
+        """Force reconnection of all reconnecting filesystems."""
+        seen = set()
+        for fs, _, _ in self._session_fs.values():
+            if fs is not None and hasattr(fs, "_reconnect") and id(fs) not in seen:
+                fs._reconnect()
+                seen.add(id(fs))
+        if self.fs_objects is not None and id(self.fs_objects) not in seen:
+            self.fs_objects._reconnect()

--- a/src/copick/impl/embrella.py
+++ b/src/copick/impl/embrella.py
@@ -762,9 +762,7 @@ class CopickVoxelSpacingEmbrella(CopickVoxelSpacingOverlay):
             return []
 
         entries = self.run.root.overlay_listdir(self.fs_overlay, self.overlay_path)
-        tomo_types = [
-            e["name"].removesuffix(".zarr") for e in entries if e["is_dir"] and e["name"].endswith(".zarr")
-        ]
+        tomo_types = [e["name"].removesuffix(".zarr") for e in entries if e["is_dir"] and e["name"].endswith(".zarr")]
         tomo_types = [t for t in tomo_types if "features" not in t]
         tomo_types = [tt for tt in tomo_types if tt and not tt.startswith(".")]
         tomo_types = [tt for tt in tomo_types if tt not in self.run.root.config.exclude_overlay_tomo_types]
@@ -1149,9 +1147,10 @@ class CopickRootEmbrella(CopickRoot):
 
         # Eagerly build the index and per-session overlay filesystems.
         self._ensure_index()
-        self._session_fs: Dict[str, Tuple[Optional[AbstractFileSystem], Optional[str], bool]] = (
-            self._build_session_filesystems()
-        )
+        self._session_fs: Dict[
+            str,
+            Tuple[Optional[AbstractFileSystem], Optional[str], bool],
+        ] = self._build_session_filesystems()
 
     @classmethod
     def from_file(cls, path: str) -> "CopickRootEmbrella":
@@ -1437,9 +1436,7 @@ class CopickRootEmbrella(CopickRoot):
         return CopickObjectEmbrella, PickableObject
 
     def query(self) -> List[CopickRunEmbrella]:
-        names: Dict[str, Tuple[str, Optional[str]]] = {
-            run_name: (session, position) for run_name, (session, position) in self.index.runs.items()
-        }
+        names: Dict[str, Tuple[str, Optional[str]]] = dict(self.index.runs.items())
 
         # Union with runs that only exist in the overlay projects.
         for session, (fs, root, _) in self._session_fs.items():

--- a/src/copick/ops/_markdown.py
+++ b/src/copick/ops/_markdown.py
@@ -5,6 +5,7 @@ from copick.impl.cryoet_data_portal import (
     CopickSegmentationCDP,
     CopickTomogramCDP,
 )
+from copick.impl.embrella import CopickRootEmbrella, CopickRunEmbrella, CopickTomogramEmbrella
 from copick.impl.filesystem import CopickRootFSSpec, CopickRunFSSpec
 from copick.impl.mlcroissant import CopickRootMLC, CopickRunMLC
 from copick.models import (
@@ -77,6 +78,8 @@ def root_to_md(root: CopickRoot) -> str:
         md += "* Project Type: CryoET Data Portal\n"
     elif root.config.config_type == "mlcroissant":
         md += "* Project Type: mlcroissant\n"
+    elif root.config.config_type == "embrella":
+        md += "* Project Type: Embrella\n"
 
     if isinstance(root, CopickRootFSSpec):
         if root.static_is_overlay:
@@ -95,6 +98,12 @@ def root_to_md(root: CopickRoot) -> str:
         md += f"* Mode: {'self-contained (A)' if root.mode == 'A' else 'overlay (B)'}\n"
         if root.config.overlay_root:
             md += f"* Overlay Location: {root.config.overlay_root}\n"
+    elif isinstance(root, CopickRootEmbrella):
+        md += f"* Embrella: {root.config.embrella_base_url}\n"
+        md += f"* Sessions: {', '.join(s.name for s in root.config.sessions)}\n"
+        md += f"* Overlay Mode: {root.config.overlay_mode}\n"
+        if root.config.overlay_root:
+            md += f"* Objects Location: {root.config.overlay_root}\n"
 
     return md
 
@@ -115,6 +124,13 @@ def run_to_md(run: CopickRun) -> str:
         md += f"* Overlay Location: {run.overlay_path}\n"
     elif isinstance(run, CopickRunMLC):
         md += f"* Location: {run.overlay_path}\n"
+    elif isinstance(run, CopickRunEmbrella):
+        if run.embrella_session:
+            md += f"* Embrella Session: {run.embrella_session}\n"
+        if run.embrella_position:
+            md += f"* Position: {run.embrella_position}\n"
+        if run.overlay_path:
+            md += f"* Overlay Location: {run.overlay_path}\n"
 
     return md
 
@@ -134,6 +150,12 @@ def tomogram_to_md(tomogram: CopickTomogram) -> str:
 
     if isinstance(tomogram.voxel_spacing.run, CopickRunCDP) and isinstance(tomogram, CopickTomogramCDP):
         md += f"* cryoET Data portal: [Tomogram {tomogram.meta.portal_tomo_id}](https://cryoetdataportal.czscience.com/runs/{tomogram.voxel_spacing.run.portal_run_id}?table-tab=Tomograms)\n"
+
+    if isinstance(tomogram, CopickTomogramEmbrella) and tomogram.embrella_tomo:
+        md += f"* Embrella Session: {tomogram.meta.embrella_session}\n"
+        md += f"* Processing Run: {tomogram.meta.embrella_proc_run} ({tomogram.meta.embrella_recon_type})\n"
+        md += f"* Position: {tomogram.meta.embrella_position}\n"
+        md += f"* Source: {tomogram.meta.embrella_static_url}\n"
 
     return md
 

--- a/src/copick/ops/open.py
+++ b/src/copick/ops/open.py
@@ -10,19 +10,20 @@ logger = get_logger(__name__)
 
 if TYPE_CHECKING:
     from copick.impl.cryoet_data_portal import CopickRootCDP
+    from copick.impl.embrella import CopickRootEmbrella, EmbrellaSessionSpec
     from copick.impl.filesystem import CopickRootFSSpec
     from copick.impl.mlcroissant import CopickRootMLC
     from copick.models import PickableObject
 
 
-def from_string(data: str) -> Union["CopickRootFSSpec", "CopickRootCDP", "CopickRootMLC"]:
+def from_string(data: str) -> Union["CopickRootFSSpec", "CopickRootCDP", "CopickRootMLC", "CopickRootEmbrella"]:
     """Create a Copick project from a JSON string.
 
     Args:
         data (str): JSON string containing the project configuration.
 
     Returns:
-        CopickRootFSSpec, CopickRootCDP, or CopickRootMLC: The initialized Copick project.
+        CopickRootFSSpec, CopickRootCDP, CopickRootMLC, or CopickRootEmbrella: The initialized Copick project.
     """
 
     from copick.impl.cryoet_data_portal import CopickConfigCDP, CopickRootCDP
@@ -46,20 +47,24 @@ def from_string(data: str) -> Union["CopickRootFSSpec", "CopickRootCDP", "Copick
         from copick.impl.mlcroissant import CopickConfigMLCroissant, CopickRootMLC
 
         return CopickRootMLC(CopickConfigMLCroissant(**data))
+    elif data["config_type"] == "embrella":
+        from copick.impl.embrella import CopickConfigEmbrella, CopickRootEmbrella
+
+        return CopickRootEmbrella(CopickConfigEmbrella(**data))
     else:
         raise ValueError(
             f"Unknown config_type: {data['config_type']}. Supported types are 'filesystem', "
-            f"'cryoet_data_portal', and 'mlcroissant'.",
+            f"'cryoet_data_portal', 'mlcroissant', and 'embrella'.",
         )
 
 
-def from_file(path: str) -> Union["CopickRootFSSpec", "CopickRootCDP", "CopickRootMLC"]:
+def from_file(path: str) -> Union["CopickRootFSSpec", "CopickRootCDP", "CopickRootMLC", "CopickRootEmbrella"]:
     """Create a Copick project from a JSON file.
     Args:
         path (str): Path to the JSON file containing the project configuration.
 
     Returns:
-        CopickRootFSSpec, CopickRootCDP, or CopickRootMLC: The initialized Copick project.
+        CopickRootFSSpec, CopickRootCDP, CopickRootMLC, or CopickRootEmbrella: The initialized Copick project.
     """
 
     with open(path, "r") as f:
@@ -111,6 +116,99 @@ def from_czcdp_datasets(
             f.write(json.dumps(config.model_dump(exclude_unset=True), indent=4))
 
     return CopickRootCDP(config)
+
+
+def from_embrella(
+    embrella_base_url: str,
+    sessions: List[Union[Dict[str, Any], "EmbrellaSessionSpec"]],
+    overlay_mode: str = "local",
+    overlay_fs_args: Optional[Dict[str, Any]] = None,
+    static_mode: str = "http",
+    static_fs_args: Optional[Dict[str, Any]] = None,
+    overlay_root: Optional[str] = None,
+    overlay_root_fs_args: Optional[Dict[str, Any]] = None,
+    clusters: Optional[Dict[str, Any]] = None,
+    default_data_cluster: Optional[str] = None,
+    scope: Optional[str] = None,
+    pickable_objects: Optional[List["PickableObject"]] = None,
+    objects_from_overlay: bool = True,
+    proj_name: str = "Embrella project",
+    proj_description: Optional[str] = None,
+    user_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    output_path: Optional[str] = None,
+) -> "CopickRootEmbrella":
+    """Create a Copick project combining tomograms from Embrella sessions.
+
+    Args:
+        embrella_base_url: Base URL of the Embrella server.
+        sessions: Session specs (dicts or EmbrellaSessionSpec): each names an Embrella
+            session, the tomogram versions (proc_run + recon_type) to expose and
+            optionally the overlay project to use.
+        overlay_mode: Overlay access mode: "local", "ssh" or "http" (read-only).
+        overlay_fs_args: Filesystem arguments for overlay access (e.g. sshfs host).
+        static_mode: Static tomogram access mode: "http" or "local".
+        static_fs_args: Filesystem arguments for static access.
+        overlay_root: Optional project-level overlay URL for object templates.
+        overlay_root_fs_args: Filesystem arguments for the project-level overlay.
+        clusters: Optional override of the cluster file server locations.
+        default_data_cluster: Cluster holding the tomogram zarrs (default "czii").
+        scope: The "{scope}.processing" path segment (default "krios1").
+        pickable_objects: Pickable objects for the project. When omitted and
+            objects_from_overlay is True, objects are collected from the sessions'
+            overlay project configs.
+        objects_from_overlay: Whether to seed pickable objects from the overlay
+            projects when none are given.
+        proj_name: Name of the project.
+        proj_description: Description of the project.
+        user_id: The user ID to use for the project.
+        session_id: The session ID to use for the project.
+        output_path: The path to write the project configuration to.
+
+    Returns:
+        CopickRootEmbrella: The initialized Copick project.
+    """
+    from copick.impl.embrella import CopickConfigEmbrella, CopickRootEmbrella
+
+    config_kwargs: Dict[str, Any] = {
+        "name": proj_name,
+        "description": proj_description
+        or f"This copick project combines tomograms from Embrella sessions "
+        f"{[s['name'] if isinstance(s, dict) else s.name for s in sessions]}.",
+        "config_type": "embrella",
+        "version": __version__,
+        "pickable_objects": pickable_objects or [],
+        "embrella_base_url": embrella_base_url,
+        "sessions": sessions,
+        "overlay_mode": overlay_mode,
+        "overlay_fs_args": overlay_fs_args or {},
+        "static_mode": static_mode,
+        "static_fs_args": static_fs_args or {},
+        "overlay_root": overlay_root,
+        "overlay_root_fs_args": overlay_root_fs_args or {},
+        "user_id": user_id,
+        "session_id": session_id,
+    }
+    if clusters is not None:
+        config_kwargs["clusters"] = clusters
+    if default_data_cluster is not None:
+        config_kwargs["default_data_cluster"] = default_data_cluster
+    if scope is not None:
+        config_kwargs["scope"] = scope
+
+    config = CopickConfigEmbrella(**config_kwargs)
+    root = CopickRootEmbrella(config)
+
+    if not config.pickable_objects and objects_from_overlay:
+        config.pickable_objects = root.overlay_pickable_objects()
+        root._objects = None
+
+    if output_path:
+        dump = config.model_dump(exclude_unset=False, exclude={"runs", "voxel_spacings", "tomograms"})
+        with open(output_path, "w") as f:
+            f.write(json.dumps(dump, indent=4))
+
+    return root
 
 
 def from_croissant(

--- a/tests/test_embrella.py
+++ b/tests/test_embrella.py
@@ -11,12 +11,10 @@ from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from threading import Thread
 
+import copick
 import numpy as np
 import pytest
 import zarr
-from zarr.storage import LocalStore
-
-import copick
 from copick.impl.embrella import (
     CopickConfigEmbrella,
     CopickRootEmbrella,
@@ -25,6 +23,7 @@ from copick.impl.embrella import (
     _positions_from_listing,
 )
 from copick.models import PickableObject
+from zarr.storage import LocalStore
 
 DCTF_VS = 5.0015426674967864  # rounds to 5.002
 SART_VS = 10.003085334993573  # rounds to 10.003
@@ -406,15 +405,7 @@ def test_unknown_cluster_raises(tree, server):
 
 
 def test_query_runs_union_with_overlay_only_runs(tree, root):
-    extra = (
-        tree
-        / "krios1.processing"
-        / "copick"
-        / "25aug25a"
-        / "run002"
-        / "ExperimentRuns"
-        / "25aug25a_Position_99"
-    )
+    extra = tree / "krios1.processing" / "copick" / "25aug25a" / "run002" / "ExperimentRuns" / "25aug25a_Position_99"
     extra.mkdir(parents=True)
 
     names = [r.name for r in root.runs]
@@ -581,15 +572,7 @@ def test_new_run_with_unconfigured_prefix_raises(root):
 def test_new_run_creates_overlay_directory(tree, root):
     run = root.new_run("25aug25a_Position_42")
     assert run is not None
-    run_dir = (
-        tree
-        / "krios1.processing"
-        / "copick"
-        / "25aug25a"
-        / "run002"
-        / "ExperimentRuns"
-        / "25aug25a_Position_42"
-    )
+    run_dir = tree / "krios1.processing" / "copick" / "25aug25a" / "run002" / "ExperimentRuns" / "25aug25a_Position_42"
     assert run_dir.is_dir()
 
 

--- a/tests/test_embrella.py
+++ b/tests/test_embrella.py
@@ -1,0 +1,722 @@
+"""Offline tests for the Embrella backend.
+
+A stdlib HTTP server plays both roles of the real deployment: the Embrella projects
+API (``/copick/v1/projects/``) and the cluster file server (Caddy), including Caddy's
+JSON directory listings (``Accept: application/json``) with an HTML fallback.
+"""
+
+import json
+import urllib.parse
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+
+import numpy as np
+import pytest
+import zarr
+from zarr.storage import LocalStore
+
+import copick
+from copick.impl.embrella import (
+    CopickConfigEmbrella,
+    CopickRootEmbrella,
+    EmbrellaTomoSelection,
+    _join_path,
+    _positions_from_listing,
+)
+from copick.models import PickableObject
+
+DCTF_VS = 5.0015426674967864  # rounds to 5.002
+SART_VS = 10.003085334993573  # rounds to 10.003
+
+
+def _write_tomo_zarr(path: Path, voxel_size: float, shape=(8, 8, 8), with_scale: bool = True) -> np.ndarray:
+    """Write a tiny Zarr v2 / NGFF 0.4 tomogram like zarrczar does."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    group = zarr.group(store=LocalStore(str(path)), zarr_format=2)
+    data = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+    array = group.create_array(
+        "0",
+        shape=shape,
+        chunks=shape,
+        dtype="float32",
+        chunk_key_encoding={"name": "v2", "separator": "/"},
+    )
+    array[:] = data
+
+    dataset = {"path": "0"}
+    if with_scale:
+        dataset["coordinateTransformations"] = [{"type": "scale", "scale": [voxel_size] * 3}]
+    group.attrs["multiscales"] = [
+        {
+            "version": "0.4",
+            "axes": [{"name": n, "type": "space", "unit": "angstrom"} for n in "zyx"],
+            "datasets": [dataset],
+        },
+    ]
+    return data
+
+
+def _write_overlay_project(root: Path, posix_root: str, pickable_objects=None) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "ExperimentRuns").mkdir(exist_ok=True)
+    config = {
+        "config_type": "filesystem",
+        "name": "embrella overlay",
+        "description": "",
+        "version": "1.23.3",
+        "pickable_objects": pickable_objects or [],
+        "overlay_root": f"local://{posix_root}",
+        "overlay_fs_args": {"auto_mkdir": True},
+    }
+    (root / "config.json").write_text(json.dumps(config))
+
+
+@pytest.fixture
+def tree(tmp_path):
+    """Build a processing tree with two sessions and their overlay projects."""
+    base = tmp_path / "tree"
+    proc = base / "krios1.processing"
+
+    # Session 25aug25a: AreTomo3 run003 (dctf + sart), DenoisET run001.
+    vol1 = proc / "aretomo3" / "25aug25a" / "run003" / "vol001"
+    vol3 = proc / "aretomo3" / "25aug25a" / "run003" / "vol003"
+    for pos in ("Position_1", "Position_2"):
+        _write_tomo_zarr(vol1 / f"{pos}_Vol.zarr", DCTF_VS)
+        _write_tomo_zarr(vol3 / f"{pos}_Vol.zarr", SART_VS)
+        (vol1 / f"{pos}_Vol.mrc").write_bytes(b"MRC")
+    # Even/odd half-reconstruction decoys (stem exclusion).
+    _write_tomo_zarr(vol1 / "Position_9_EVN_Vol.zarr", DCTF_VS)
+    _write_tomo_zarr(vol1 / "Position_9_ODD_Vol.zarr", DCTF_VS)
+    # Denoised run (no vol subdirectory).
+    _write_tomo_zarr(proc / "denoise" / "25aug25a" / "run001" / "Position_1_Vol.zarr", SART_VS)
+
+    # Session 25aug22b: AreTomo3 run001 (dctf only), messy stem, one zarr without scale.
+    vol1b = proc / "aretomo3" / "25aug22b" / "run001" / "vol001"
+    _write_tomo_zarr(vol1b / "L2_Series3A_Pos1.mrc_Vol.zarr", DCTF_VS)
+
+    # Overlay projects.
+    ovl_a = proc / "copick" / "25aug25a" / "run002"
+    _write_overlay_project(
+        ovl_a,
+        str(ovl_a),
+        pickable_objects=[
+            {"name": "ribosome", "is_particle": True, "label": 1, "color": [0, 117, 220, 255], "radius": 150.0},
+            {"name": "membrane", "is_particle": False, "label": 2, "color": [255, 0, 0, 255], "radius": 50.0},
+        ],
+    )
+    # Pre-existing duplicated import (plain tomo_type) and a pick, like Embrella creates.
+    run_dir = ovl_a / "ExperimentRuns" / "25aug25a_Position_1"
+    _write_tomo_zarr(run_dir / "VoxelSpacing10.003" / "sart.zarr", SART_VS)
+    (run_dir / "Picks").mkdir(parents=True)
+    (run_dir / "Picks" / "alice_1_ribosome.json").write_text(
+        json.dumps(
+            {
+                "pickable_object_name": "ribosome",
+                "user_id": "alice",
+                "session_id": "1",
+                "run_name": "25aug25a_Position_1",
+                "points": [],
+            },
+        ),
+    )
+
+    ovl_b = proc / "copick" / "25aug22b" / "run001"
+    _write_overlay_project(
+        ovl_b,
+        str(ovl_b),
+        pickable_objects=[
+            {"name": "ribosome", "is_particle": True, "label": 7, "color": [1, 2, 3, 255], "radius": 150.0},
+        ],
+    )
+
+    return base
+
+
+class _EmbrellaHandler(SimpleHTTPRequestHandler):
+    """Serves the Embrella projects API and Caddy-style file listings from a tree."""
+
+    projects: dict = {}
+
+    def log_message(self, format, *args):  # noqa: A002
+        pass
+
+    def _send_json(self, payload) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):  # noqa: N802
+        parsed = urllib.parse.urlparse(self.path)
+
+        if parsed.path.rstrip("/") == "/copick/v1/projects":
+            query = urllib.parse.parse_qs(parsed.query)
+            session = query.get("session_id", [None])[0]
+            self._send_json({"success": True, "projects": self.projects.get(session, [])})
+            return
+
+        if "application/json" in (self.headers.get("Accept") or ""):
+            local = Path(self.directory) / urllib.parse.unquote(parsed.path).lstrip("/")
+            if local.is_dir():
+                entries = [
+                    {"name": p.name + ("/" if p.is_dir() else ""), "is_dir": p.is_dir()}
+                    for p in sorted(local.iterdir())
+                ]
+                self._send_json(entries)
+                return
+
+        super().do_GET()
+
+
+@pytest.fixture
+def server(tree):
+    """Serve the tree; yields the base URL (Embrella API and file server in one)."""
+
+    class Handler(_EmbrellaHandler):
+        projects = {}
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=str(tree), **kwargs)
+
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://127.0.0.1:{httpd.server_port}"
+
+    Handler.projects = {
+        "25aug25a": [
+            {
+                "session_name": "25aug25a",
+                "run_name": "run001",
+                "cluster_id": "test",
+                "scope": "krios1",
+                "root_url": f"{base_url}/krios1.processing/copick/25aug25a/run001/",
+                "config_url": f"{base_url}/krios1.processing/copick/25aug25a/run001/config.json",
+                "data_url": f"{base_url}/krios1.processing/copick/25aug25a/run001/",
+                "status": "failed",
+                "created_at": "2026-08-01T00:00:00+00:00",
+                "proc_run_id": 1,
+            },
+            {
+                "session_name": "25aug25a",
+                "run_name": "run002",
+                "cluster_id": "test",
+                "scope": "krios1",
+                "root_url": f"{base_url}/krios1.processing/copick/25aug25a/run002/",
+                "config_url": f"{base_url}/krios1.processing/copick/25aug25a/run002/config.json",
+                "data_url": f"{base_url}/krios1.processing/copick/25aug25a/run002/",
+                "status": "completed",
+                "created_at": "2026-08-02T00:00:00+00:00",
+                "proc_run_id": 2,
+            },
+        ],
+        "25aug22b": [
+            {
+                "session_name": "25aug22b",
+                "run_name": "run001",
+                "cluster_id": "test",
+                "scope": "krios1",
+                "root_url": f"{base_url}/krios1.processing/copick/25aug22b/run001/",
+                "config_url": f"{base_url}/krios1.processing/copick/25aug22b/run001/config.json",
+                "data_url": f"{base_url}/krios1.processing/copick/25aug22b/run001/",
+                "status": "completed",
+                "created_at": "2026-08-03T00:00:00+00:00",
+                "proc_run_id": 3,
+            },
+        ],
+    }
+
+    yield base_url
+
+    httpd.shutdown()
+    httpd.server_close()
+    thread.join(timeout=5)
+
+
+def _config_dict(tree, base_url, **overrides):
+    config = {
+        "config_type": "embrella",
+        "name": "embrella test project",
+        "pickable_objects": [
+            {"name": "ribosome", "is_particle": True, "label": 1, "color": [0, 117, 220, 255], "radius": 150.0},
+        ],
+        "embrella_base_url": base_url,
+        "clusters": {"test": {"http_base": f"{base_url}/", "posix_base": str(tree)}},
+        "default_data_cluster": "test",
+        "scope": "krios1",
+        "sessions": [
+            {
+                "name": "25aug25a",
+                "tomograms": [
+                    {"proc_run": "run003", "recon_type": "dctf"},
+                    {"proc_run": "run003", "recon_type": "sart"},
+                    {"proc_run": "run001", "recon_type": "denoise"},
+                ],
+                "overlay_run": "run002",
+            },
+            {
+                "name": "25aug22b",
+                "tomograms": [{"proc_run": "run001", "recon_type": "dctf"}],
+            },
+        ],
+        "overlay_mode": "local",
+        "static_mode": "http",
+    }
+    config.update(overrides)
+    return config
+
+
+@pytest.fixture
+def root(tree, server) -> CopickRootEmbrella:
+    return copick.from_string(json.dumps(_config_dict(tree, server)))
+
+
+# --------------------------------------------------------------------------------------
+# Config validation
+# --------------------------------------------------------------------------------------
+
+
+def test_wbp_is_rejected():
+    with pytest.raises(ValueError, match="MRC only"):
+        EmbrellaTomoSelection(proc_run="run001", recon_type="wbp")
+
+
+def test_underscore_proc_run_is_rejected():
+    with pytest.raises(ValueError, match="underscore"):
+        EmbrellaTomoSelection(proc_run="run_001", recon_type="dctf")
+
+
+def test_tomo_type_derivation():
+    sel = EmbrellaTomoSelection(proc_run="run003", recon_type="DCTF")
+    assert sel.tomo_type == "run003-dctf"
+
+
+def test_positions_from_listing_excludes_half_reconstructions():
+    entries = [
+        {"name": "Position_1_Vol.zarr", "is_dir": True},
+        {"name": "Position_1_EVN_Vol.zarr", "is_dir": True},
+        {"name": "Position_1_ODD_Vol.zarr", "is_dir": True},
+        {"name": "Position_1_Vol.mrc", "is_dir": False},
+        {"name": "L2_Series3A_Pos1.mrc_Vol.zarr", "is_dir": True},
+    ]
+    assert _positions_from_listing(entries) == ["L2_Series3A_Pos1.mrc", "Position_1"]
+
+
+def test_join_path_collapses_empty_segments():
+    assert _join_path("http://x/", "a.processing", "denoise", "s", "r", None) == "http://x/a.processing/denoise/s/r"
+
+
+# --------------------------------------------------------------------------------------
+# Index building
+# --------------------------------------------------------------------------------------
+
+
+def test_index_build(root):
+    index = root.index
+    assert set(index.sessions) == {"25aug25a", "25aug22b"}
+
+    # Pinned overlay project wins over the newest one.
+    assert index.sessions["25aug25a"].overlay_run == "run002"
+    # Unpinned: newest completed project.
+    assert index.sessions["25aug22b"].overlay_run == "run001"
+
+    assert set(index.runs) == {
+        "25aug25a_Position_1",
+        "25aug25a_Position_2",
+        "25aug22b_L2_Series3A_Pos1.mrc",
+    }
+
+    # Position_1 has dctf, sart and denoise; Position_2 only dctf and sart.
+    types_p1 = {r.tomo_type for r in index.tomos_by_run["25aug25a_Position_1"]}
+    assert types_p1 == {"run003-dctf", "run003-sart", "run001-denoise"}
+    types_p2 = {r.tomo_type for r in index.tomos_by_run["25aug25a_Position_2"]}
+    assert types_p2 == {"run003-dctf", "run003-sart"}
+
+
+def test_voxel_size_sniffed_and_rounded(root):
+    records = root.index.tomos_by_run["25aug25a_Position_1"]
+    by_type = {r.tomo_type: r for r in records}
+    assert by_type["run003-dctf"].voxel_size == 5.002
+    assert by_type["run003-sart"].voxel_size == 10.003
+
+
+def test_denoise_url_has_no_vol_segment_and_no_double_slash(root):
+    record = next(r for r in root.index.tomos_by_run["25aug25a_Position_1"] if r.recon_type == "denoise")
+    assert record.static_url.endswith("/krios1.processing/denoise/25aug25a/run001/Position_1_Vol.zarr")
+    assert "//" not in record.static_url.split("://", 1)[1]
+
+
+def test_voxel_size_override(tree, server):
+    config = _config_dict(tree, server)
+    config["sessions"] = [
+        {
+            "name": "25aug25a",
+            "tomograms": [{"proc_run": "run003", "recon_type": "dctf", "voxel_size": 5.0}],
+            "overlay_run": "run002",
+        },
+    ]
+    root = copick.from_string(json.dumps(config))
+    assert all(r.voxel_size == 5.0 for r in root.index.tomos_by_run["25aug25a_Position_1"])
+
+
+def test_missing_scale_metadata_raises_actionable_error(tree, server):
+    _write_tomo_zarr(
+        tree / "krios1.processing" / "aretomo3" / "25aug25a" / "run005" / "vol001" / "Position_1_Vol.zarr",
+        DCTF_VS,
+        with_scale=False,
+    )
+    config = _config_dict(tree, server)
+    config["sessions"] = [
+        {
+            "name": "25aug25a",
+            "tomograms": [{"proc_run": "run005", "recon_type": "dctf"}],
+            "overlay_run": "run002",
+        },
+    ]
+    with pytest.raises(ValueError, match="voxel_size"):
+        copick.from_string(json.dumps(config))
+
+
+def test_pinned_positions_skip_listing(tree, server):
+    config = _config_dict(tree, server)
+    config["sessions"] = [
+        {
+            "name": "25aug25a",
+            "tomograms": [{"proc_run": "run003", "recon_type": "dctf", "positions": ["Position_1"]}],
+            "overlay_run": "run002",
+        },
+    ]
+    root = copick.from_string(json.dumps(config))
+    assert set(root.index.runs) == {"25aug25a_Position_1"}
+
+
+def test_unknown_cluster_raises(tree, server):
+    config = _config_dict(tree, server)
+    config["sessions"][0]["tomograms"] = [{"proc_run": "run003", "recon_type": "dctf", "cluster": "nope"}]
+    with pytest.raises(ValueError, match="Unknown cluster 'nope'"):
+        copick.from_string(json.dumps(config))
+
+
+# --------------------------------------------------------------------------------------
+# Runs, voxel spacings, tomograms
+# --------------------------------------------------------------------------------------
+
+
+def test_query_runs_union_with_overlay_only_runs(tree, root):
+    extra = (
+        tree
+        / "krios1.processing"
+        / "copick"
+        / "25aug25a"
+        / "run002"
+        / "ExperimentRuns"
+        / "25aug25a_Position_99"
+    )
+    extra.mkdir(parents=True)
+
+    names = [r.name for r in root.runs]
+    assert "25aug25a_Position_99" in names
+    assert "25aug25a_Position_1" in names
+    assert "25aug22b_L2_Series3A_Pos1.mrc" in names
+
+    overlay_only = root.get_run("25aug25a_Position_99")
+    assert overlay_only.embrella_session == "25aug25a"
+    assert overlay_only.voxel_spacings == []
+
+
+def test_get_run_random_access(root):
+    # _runs is None until the runs property is touched -> random access path.
+    assert root._runs is None
+    run = root.get_run("25aug25a_Position_1")
+    assert run is not None
+    assert run.embrella_session == "25aug25a"
+    assert run.embrella_position == "Position_1"
+    assert root.get_run("25aug25a_Position_nope") is None
+    assert root.get_run("unrelated_run") is None
+
+
+def test_voxel_spacings_deduped_between_static_and_overlay(root):
+    run = root.get_run("25aug25a_Position_1")
+    spacings = run.voxel_spacings
+    sizes = sorted(vs.voxel_size for vs in spacings)
+    # 5.002 (static dctf) and 10.003 (static sart/denoise + overlay dir, deduped).
+    assert sizes == [5.002, 10.003]
+
+
+def test_static_tomograms_read_only(root):
+    run = root.get_run("25aug25a_Position_1")
+    vs = run.get_voxel_spacing(5.002)
+    tomos = vs.get_tomograms("run003-dctf")
+    assert len(tomos) == 1
+    tomo = tomos[0]
+    assert tomo.read_only is True
+    assert tomo.meta.embrella_proc_run == "run003"
+    assert tomo.meta.embrella_recon_type == "dctf"
+    store = tomo.zarr()
+    assert store.read_only is True
+    with pytest.raises(PermissionError):
+        tomo.delete()
+
+
+def test_tomogram_numpy_over_http(root):
+    run = root.get_run("25aug25a_Position_1")
+    vs = run.get_voxel_spacing(5.002)
+    tomo = vs.get_tomograms("run003-dctf")[0]
+    data = tomo.numpy()
+    expected = np.arange(8 * 8 * 8, dtype=np.float32).reshape(8, 8, 8)
+    np.testing.assert_array_equal(data, expected)
+
+
+def test_overlay_tomogram_listed_alongside_static(root):
+    run = root.get_run("25aug25a_Position_1")
+    vs = run.get_voxel_spacing(10.003)
+    types = {t.tomo_type for t in vs.tomograms}
+    # Static sart/denoise plus the legacy duplicated plain "sart" import.
+    assert types == {"run003-sart", "run001-denoise", "sart"}
+
+
+def test_exclude_overlay_tomo_types(tree, server):
+    config = _config_dict(tree, server, exclude_overlay_tomo_types=["sart"])
+    root = copick.from_string(json.dumps(config))
+    run = root.get_run("25aug25a_Position_1")
+    vs = run.get_voxel_spacing(10.003)
+    types = {t.tomo_type for t in vs.tomograms}
+    assert types == {"run003-sart", "run001-denoise"}
+
+
+def test_overlay_features_glob(tree, root):
+    feat = (
+        tree
+        / "krios1.processing"
+        / "copick"
+        / "25aug25a"
+        / "run002"
+        / "ExperimentRuns"
+        / "25aug25a_Position_1"
+        / "VoxelSpacing5.002"
+        / "run003-dctf_sobel_features.zarr"
+    )
+    feat.mkdir(parents=True)
+
+    run = root.get_run("25aug25a_Position_1")
+    tomo = run.get_voxel_spacing(5.002).get_tomograms("run003-dctf")[0]
+    features = tomo.features
+    assert len(features) == 1
+    assert features[0].feature_type == "sobel"
+    assert features[0].read_only is False
+
+
+# --------------------------------------------------------------------------------------
+# Annotations: overlay routing and read-only modes
+# --------------------------------------------------------------------------------------
+
+
+def test_existing_overlay_picks_are_discovered(root):
+    run = root.get_run("25aug25a_Position_1")
+    picks = run.get_picks(object_name="ribosome")
+    assert len(picks) == 1
+    assert picks[0].user_id == "alice"
+    assert picks[0].read_only is False
+
+
+def test_picks_write_routed_to_owning_session_overlay(tree, root):
+    run_a = root.get_run("25aug25a_Position_2")
+    picks = run_a.new_picks("ribosome", session_id="7", user_id="tester")
+    picks.store()
+    expected_a = (
+        tree
+        / "krios1.processing"
+        / "copick"
+        / "25aug25a"
+        / "run002"
+        / "ExperimentRuns"
+        / "25aug25a_Position_2"
+        / "Picks"
+        / "tester_7_ribosome.json"
+    )
+    assert expected_a.exists()
+
+    run_b = root.get_run("25aug22b_L2_Series3A_Pos1.mrc")
+    picks_b = run_b.new_picks("ribosome", session_id="7", user_id="tester")
+    picks_b.store()
+    expected_b = (
+        tree
+        / "krios1.processing"
+        / "copick"
+        / "25aug22b"
+        / "run001"
+        / "ExperimentRuns"
+        / "25aug22b_L2_Series3A_Pos1.mrc"
+        / "Picks"
+        / "tester_7_ribosome.json"
+    )
+    assert expected_b.exists()
+
+
+def test_overlay_http_mode_is_read_only(tree, server):
+    config = _config_dict(tree, server, overlay_mode="http")
+    root = copick.from_string(json.dumps(config))
+
+    run = root.get_run("25aug25a_Position_1")
+    assert run.overlay_read_only is True
+
+    picks = run.get_picks(object_name="ribosome")
+    assert len(picks) == 1
+    assert picks[0].read_only is True
+    with pytest.raises(PermissionError):
+        picks[0].store()
+
+    with pytest.raises(PermissionError):
+        root.new_run("25aug25a_Position_50")
+
+
+def test_new_run_with_unconfigured_prefix_raises(root):
+    with pytest.raises(ValueError, match="does not belong to any configured"):
+        root.new_run("othersession_Position_1")
+
+
+def test_new_run_creates_overlay_directory(tree, root):
+    run = root.new_run("25aug25a_Position_42")
+    assert run is not None
+    run_dir = (
+        tree
+        / "krios1.processing"
+        / "copick"
+        / "25aug25a"
+        / "run002"
+        / "ExperimentRuns"
+        / "25aug25a_Position_42"
+    )
+    assert run_dir.is_dir()
+
+
+def test_session_without_overlay_project_is_static_only(tree, server):
+    config = _config_dict(tree, server)
+    config["sessions"] = [
+        {
+            "name": "25aug25a",
+            "tomograms": [{"proc_run": "run003", "recon_type": "dctf"}],
+            "overlay_run": "run042",  # does not exist
+        },
+    ]
+    root = copick.from_string(json.dumps(config))
+
+    run = root.get_run("25aug25a_Position_1")
+    assert run.fs_overlay is None
+    assert run.overlay_read_only is True
+
+    # Static tomograms are still served.
+    tomo = run.get_voxel_spacing(5.002).get_tomograms("run003-dctf")[0]
+    assert tomo.read_only is True
+
+    # new_picks stores immediately, so the write rejection surfaces there.
+    with pytest.raises(PermissionError):
+        run.new_picks("ribosome", session_id="7", user_id="tester")
+
+
+# --------------------------------------------------------------------------------------
+# Objects
+# --------------------------------------------------------------------------------------
+
+
+def test_objects_config_only_without_project_overlay(root):
+    obj = root.get_object("ribosome")
+    assert obj.read_only is True
+    assert obj.has_density_map() is False
+    assert obj.zarr() is None
+
+
+def test_objects_writable_with_project_overlay(tree, server, tmp_path):
+    objects_root = tmp_path / "project_overlay"
+    config = _config_dict(tree, server, overlay_root=f"local://{objects_root}")
+    root = copick.from_string(json.dumps(config))
+
+    obj = root.get_object("ribosome")
+    assert obj.read_only is False
+    assert obj.has_density_map() is False
+    store = obj.zarr()
+    assert store is not None
+    assert store.read_only is False
+
+
+def test_overlay_pickable_objects_deduplicated(root):
+    objects = root.overlay_pickable_objects()
+    by_name = {o.name: o for o in objects}
+    assert set(by_name) == {"ribosome", "membrane"}
+    # First session's definition wins over 25aug22b's conflicting one.
+    assert by_name["ribosome"].label == 1
+
+
+# --------------------------------------------------------------------------------------
+# Static local mode
+# --------------------------------------------------------------------------------------
+
+
+def test_static_mode_local(tree, server):
+    config = _config_dict(tree, server, static_mode="local")
+    root = copick.from_string(json.dumps(config))
+
+    run = root.get_run("25aug25a_Position_1")
+    tomo = run.get_voxel_spacing(5.002).get_tomograms("run003-dctf")[0]
+    data = tomo.numpy()
+    expected = np.arange(8 * 8 * 8, dtype=np.float32).reshape(8, 8, 8)
+    np.testing.assert_array_equal(data, expected)
+
+
+# --------------------------------------------------------------------------------------
+# Offline harness (no projects API)
+# --------------------------------------------------------------------------------------
+
+
+def test_offline_index_via_monkeypatched_fetch(tree, monkeypatch):
+    ovl = tree / "krios1.processing" / "copick" / "25aug25a" / "run002"
+    payload = {
+        "sessions": [
+            {
+                "session": "25aug25a",
+                "scope": "krios1",
+                "overlay_run": "run002",
+                "cluster_id": "test",
+                "overlay_url": None,
+                "overlay_posix": str(ovl),
+                "read_only": False,
+                "pickable_objects": [],
+                "selections": [
+                    {
+                        "proc_run": "run003",
+                        "recon_type": "dctf",
+                        "positions": ["Position_1", "Position_2"],
+                        "voxel_size": 5.002,
+                        "data_url": "http://unused/krios1.processing/aretomo3/25aug25a/run003/vol001",
+                        "data_posix": str(tree / "krios1.processing" / "aretomo3" / "25aug25a" / "run003" / "vol001"),
+                    },
+                ],
+            },
+        ],
+    }
+    monkeypatch.setattr(CopickRootEmbrella, "_fetch_index_data", lambda self: payload)
+
+    config = CopickConfigEmbrella(
+        name="offline",
+        pickable_objects=[PickableObject(name="ribosome", is_particle=True, label=1, radius=150.0)],
+        embrella_base_url="http://unused",
+        clusters={"test": {"http_base": "http://unused/", "posix_base": str(tree)}},
+        default_data_cluster="test",
+        sessions=[
+            {
+                "name": "25aug25a",
+                "tomograms": [{"proc_run": "run003", "recon_type": "dctf"}],
+                "overlay_run": "run002",
+            },
+        ],
+        overlay_mode="local",
+        static_mode="local",
+    )
+    root = CopickRootEmbrella(config)
+
+    assert set(root.index.runs) == {"25aug25a_Position_1", "25aug25a_Position_2"}
+    tomo = root.get_run("25aug25a_Position_1").get_voxel_spacing(5.002).get_tomograms("run003-dctf")[0]
+    np.testing.assert_array_equal(tomo.numpy(), np.arange(8 * 8 * 8, dtype=np.float32).reshape(8, 8, 8))

--- a/zensical.toml
+++ b/zensical.toml
@@ -193,6 +193,7 @@ nav = [
             {"File System" = "api_reference/implementations/Filesystem.md"},
             {"Data Portal" = "api_reference/implementations/Dataportal.md"},
             {"mlcroissant" = "api_reference/implementations/Croissant.md"},
+            {"Embrella" = "api_reference/implementations/Embrella.md"},
         ]},
         {"Functional API" = [
             {"Add" = "api_reference/functional/add.md"},


### PR DESCRIPTION
## Summary

Adds a new backend implementation (`config_type: "embrella"`) that serves tomograms **in place** from an [Embrella](https://github.com/czimaginginstitute/embrella) server — no duplication of volume data into the copick project — while routing annotations into the per-session copick overlay projects that Embrella already manages on the cluster.

This mirrors the structure of the CryoET Data Portal backend: a static, read-only remote source combined with writable overlays, backed by an eager in-memory index so per-run queries never hit the network.

## What it does

- **Combines multiple Embrella sessions** into one copick project. Per session, the config selects which AreTomo3/DenoisET processing runs ("tomogram versions") and reconstruction types to expose.
- **tomo_type encodes the version**: `{proc_run}-{recon_type}`, e.g. `run003-dctf`, `run003-sart`, `run001-denoise`. WBP is rejected by a config validator (AreTomo3 emits it as MRC only — no zarr exists).
- **Static side**: tomogram OME-Zarr stores are opened directly from the per-cluster static file servers over HTTP (`copick_store` on an fsspec HTTP filesystem), or from POSIX paths on-cluster (`static_mode: "local"`). Positions are enumerated via the file server's JSON directory listings (`Accept: application/json`), with an HTML-scrape fallback, matching by `*_Vol.zarr` suffix (excluding `_EVN`/`_ODD` half-reconstructions). Voxel sizes are read from the NGFF 0.4 multiscales metadata and **rounded to 3 decimals** so they dedupe against the overlay `VoxelSpacing{x:.3f}` directories.
- **Writable side**: annotations land in the existing per-session Embrella copick projects, discovered through the public unauthenticated `GET /copick/v1/projects/` API (pinned via `overlay_run` or newest completed). Run names follow the shared `{session}_{position}` convention, so picks/segmentations made through this backend are immediately visible to the per-session projects and vice versa. Overlay access modes: `local` (on-cluster POSIX), `ssh` (fsspec sshfs), `http` (read-only, e.g. for viewers).
- **Cluster map**: tomogram data location resolves independently of the overlay project location (`clusters` map + per-selection `cluster`) — in the current CZII deployment the zarrs live on the czii file server while overlay projects live on bruno.
- **Objects**: an optional project-level `overlay_root` stores pickable-object templates (`Objects/`); the per-session overlays are shared Embrella artifacts and are never polluted with project-global data. `copick.from_embrella(..., objects_from_overlay=True)` seeds `pickable_objects` from the sessions' overlay project configs (deduplicated by name).
- **No auth required at runtime**: the projects API is public and the file servers are open; TLS uses certifi's CA bundle (conda-style Pythons frequently ship broken default CA paths).

## Config example

```json
{
  "config_type": "embrella",
  "embrella_base_url": "https://umbrella.czbiohub.org",
  "sessions": [
    {
      "name": "26may21b",
      "tomograms": [
        {"proc_run": "run003", "recon_type": "dctf", "cluster": "czii"},
        {"proc_run": "run003", "recon_type": "sart", "cluster": "czii"}
      ],
      "overlay_run": "run003"
    }
  ],
  "overlay_mode": "ssh",
  "overlay_fs_args": {"host": "login-01...", "username": "..."},
  "static_mode": "http"
}
```

Also included: `copick.from_embrella(...)` convenience constructor, `_markdown` provenance rendering (session/proc_run/recon/position + source URL), docs stub + nav entry, and a config template.

## Testing

- `tests/test_embrella.py` (31 tests, fully offline): a stdlib HTTP server emulates both the Embrella projects API and Caddy-style JSON/HTML directory listings. Covers index build, voxel-size sniff/override/rounding + static↔overlay voxel-spacing dedup, run-name union with overlay-only runs, `get_run` random access, read-only guards (static tomos, overlay-http mode, sessions without an overlay project), multi-session pick-write routing, features/segmentation discovery, object store contracts (`has_density_map`), `exclude_overlay_tomo_types`, and the denoise no-subdirectory URL join. Includes the first end-to-end zarr array read through an HTTP-backed `FsspecStore` in the test suite.
- Repo guards pass (`test_zarr_structural_guards`, `test_zarr_imports`, `test_object_store_contracts`, `test_store`, `test_cli`); ruff clean.
- Verified read-only against real infrastructure (dev Embrella + both cluster file servers): index build over the public API, prod Caddy JSON listings, voxel-size sniff from real zarrczar `.zattrs`, and tomogram slab reads over HTTPS.

## Notes / follow-ups

- No disk cache yet: v2.0 predates the v1.27 `util/portal_cache.py`; the index builder keeps a clean fetch→build split so it can be wired in once that lands on v2.0.
- Phase 2 (separate PR): `copick config embrella` CLI subcommand with cluster auto-probe, `make_templates.py` integration.
- Caveat inherited from the zarr v3 migration: annotations written by copick 2.x are Zarr v3 / NGFF 0.5, which cluster tools pinned to copick 1.x cannot read (JSON picks and glb meshes are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
